### PR TITLE
Implementação do submenu para download de planilhas de indicadores bibliométricos

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -76,6 +76,7 @@ def main(global_config, **settings):
     config.add_route('bibliometrics_list_citing_forms_web', '/w/bibliometrics/list/citing_forms')
     config.add_route('bibliometrics_list_impact_factor_web', '/w/bibliometrics/list/impact_factor')
     config.add_route('bibliometrics_list_citing_half_life_web', '/w/bibliometrics/list/citing_half_life')
+    config.add_route('bibliometrics_list_general_indicators_web', '/w/bibliometrics/list/general_indicators')
     config.add_route('bibliometrics_journal_cited_and_citing_years_heat_web', '/w/bibliometrics/journal/cited_and_citing_years_heat')
     config.add_route('bibliometrics_journal_cited_and_citing_years_heat', '/ajx/bibliometrics/journal/cited_and_citing_years_heat')
     config.add_route('bibliometrics_journal_received_self_and_granted_citation_chart', '/ajx/bibliometrics/journal/received_self_and_granted_citation_chart')

--- a/analytics/locale/analytics.pot
+++ b/analytics/locale/analytics.pot
@@ -1,1149 +1,1256 @@
-# Translations template for analytics.
-# Copyright (C) 2017 ORGANIZATION
-# This file is distributed under the same license as the analytics project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+# Translations template for PROJECT.
+# Copyright (C) 2019 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: analytics 1.32.0\n"
+"Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-18 15:53-0300\n"
+"POT-Creation-Date: 2019-09-17 18:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.0\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: analytics/charts_config.py:25
+#: /app/analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr ""
 
-#: analytics/charts_config.py:58
+#: /app/analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:59
+#: /app/analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: analytics/charts_config.py:91
+#: /app/analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr ""
 
-#: analytics/charts_config.py:92
+#: /app/analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr ""
 
-#: analytics/charts_config.py:100
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: /app/analytics/charts_config.py:100
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: analytics/charts_config.py:103 analytics/charts_config.py:112
+#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: analytics/charts_config.py:113 analytics/charts_config.py:135
-#: analytics/charts_config.py:157 analytics/charts_config.py:179
-#: analytics/charts_config.py:202 analytics/charts_config.py:229
+#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
+#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
 msgid "Ano base"
 msgstr ""
 
-#: analytics/charts_config.py:122 analytics/charts_config.py:125
-#: analytics/charts_config.py:134
+#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
+#: /app/analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: analytics/charts_config.py:144 analytics/charts_config.py:147
-#: analytics/charts_config.py:156
+#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
+#: /app/analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: analytics/charts_config.py:166 analytics/charts_config.py:169
-#: analytics/charts_config.py:178
+#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
+#: /app/analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr ""
 
-#: analytics/charts_config.py:188
+#: /app/analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr ""
 
-#: analytics/charts_config.py:189 analytics/charts_config.py:192
-#: analytics/charts_config.py:201
+#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
+#: /app/analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr ""
 
-#: analytics/charts_config.py:211
+#: /app/analytics/charts_config.py:211
 msgid "imediatez"
 msgstr ""
 
-#: analytics/charts_config.py:212
-#: analytics/templates/website/access_datepicker.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: /app/analytics/charts_config.py:212
+#: /app/analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr ""
 
-#: analytics/charts_config.py:213
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/charts_config.py:213
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr ""
 
-#: analytics/charts_config.py:214
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/charts_config.py:214
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr ""
 
-#: analytics/charts_config.py:215
+#: /app/analytics/charts_config.py:215
 msgid "4 anos"
 msgstr ""
 
-#: analytics/charts_config.py:216
+#: /app/analytics/charts_config.py:216
 msgid "5 anos"
 msgstr ""
 
-#: analytics/charts_config.py:223
+#: /app/analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr ""
 
-#: analytics/charts_config.py:226 analytics/charts_config.py:228
-#: analytics/templates/website/bibliometrics_journal.mako:23
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
+#: /app/analytics/templates/website/bibliometrics_journal.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr ""
 
-#: analytics/charts_config.py:237
+#: /app/analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr ""
 
-#: analytics/charts_config.py:237
+#: /app/analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr ""
 
-#: analytics/charts_config.py:237
+#: /app/analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr ""
 
-#: analytics/charts_config.py:244
+#: /app/analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr ""
 
-#: analytics/charts_config.py:251
+#: /app/analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr ""
 
-#: analytics/charts_config.py:256 analytics/charts_config.py:273
-#: analytics/charts_config.py:287 analytics/charts_config.py:414
-#: analytics/charts_config.py:423 analytics/charts_config.py:438
-#: analytics/charts_config.py:446 analytics/charts_config.py:494
-#: analytics/charts_config.py:503 analytics/charts_config.py:582
-#: analytics/charts_config.py:592 analytics/charts_config.py:634
-#: analytics/charts_config.py:643 analytics/charts_config.py:684
-#: analytics/charts_config.py:692 analytics/charts_config.py:808
-#: analytics/templates/website/central_container_for_article_filters.mako:13
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
+#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
+#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
+#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
+#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
+#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:265
+#: /app/analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr ""
 
-#: analytics/charts_config.py:265
+#: /app/analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr ""
 
-#: analytics/charts_config.py:272
+#: /app/analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr ""
 
-#: analytics/charts_config.py:281 analytics/charts_config.py:305
-#: analytics/charts_config.py:324 analytics/charts_config.py:341
-#: analytics/charts_config.py:388 analytics/charts_config.py:412
-#: analytics/charts_config.py:441 analytics/charts_config.py:467
-#: analytics/charts_config.py:492 analytics/charts_config.py:560
-#: analytics/charts_config.py:580 analytics/charts_config.py:588
-#: analytics/charts_config.py:611 analytics/charts_config.py:632
-#: analytics/charts_config.py:682 analytics/charts_config.py:711
+#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
+#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
+#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
+#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
+#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
+#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
+#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
+#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr ""
 
-#: analytics/charts_config.py:298
+#: /app/analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:301
+#: /app/analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr ""
 
-#: analytics/charts_config.py:308
+#: /app/analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr ""
 
-#: analytics/charts_config.py:317
+#: /app/analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:320
-#: analytics/templates/website/publication_article.mako:133
+#: /app/analytics/charts_config.py:320
+#: /app/analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr ""
 
-#: analytics/charts_config.py:327
+#: /app/analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr ""
 
-#: analytics/charts_config.py:338 analytics/charts_config.py:380
+#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: analytics/charts_config.py:359 analytics/charts_config.py:391
-#: analytics/charts_config.py:446 analytics/charts_config.py:470
-#: analytics/charts_config.py:563 analytics/charts_config.py:614
-#: analytics/charts_config.py:714
+#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
+#: /app/analytics/charts_config.py:694
 msgid "Documentos"
 msgstr ""
 
-#: analytics/charts_config.py:368 analytics/charts_config.py:383
-#: analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
+#: /app/analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr ""
 
-#: analytics/charts_config.py:404
+#: /app/analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:437
+#: /app/analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:459
+#: /app/analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:462
+#: /app/analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr ""
 
-#: analytics/charts_config.py:484
+#: /app/analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:514 analytics/charts_config.py:654
-msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
-msgstr ""
-
-#: analytics/charts_config.py:517 analytics/charts_config.py:525
-#: analytics/charts_config.py:657 analytics/charts_config.py:665
-msgid "Situação da publicação"
-msgstr ""
-
-#: analytics/charts_config.py:522 analytics/charts_config.py:538
-#: analytics/charts_config.py:662 analytics/charts_config.py:731
-#: analytics/charts_config.py:751
-msgid "Número de periódicos"
-msgstr ""
-
-#: analytics/charts_config.py:525 analytics/charts_config.py:543
-#: analytics/charts_config.py:665 analytics/charts_config.py:734
-#: analytics/charts_config.py:754
-#: analytics/templates/website/navbar_collection.mako:10
-#: analytics/templates/website/navbar_journal.mako:10
-msgid "Periódicos"
-msgstr ""
-
-#: analytics/charts_config.py:534
+#: /app/analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr ""
 
-#: analytics/charts_config.py:535 analytics/charts_config.py:543
+#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr ""
 
-#: analytics/charts_config.py:552
+#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
+#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+msgid "Número de periódicos"
+msgstr ""
+
+#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
+#: /app/analytics/templates/website/navbar_collection.mako:10
+#: /app/analytics/templates/website/navbar_journal.mako:10
+msgid "Periódicos"
+msgstr ""
+
+#: /app/analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:555 analytics/charts_config.py:726
+#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr ""
 
-#: analytics/charts_config.py:563 analytics/charts_config.py:734
-#: analytics/templates/website/central_container_for_article_filters.mako:30
-#: analytics/templates/website/central_container_for_journal_filters.mako:13
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr ""
 
-#: analytics/charts_config.py:572
+#: /app/analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:603
+#: /app/analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr ""
 
-#: analytics/charts_config.py:606
-#: analytics/templates/website/publication_article.mako:43
-#: analytics/templates/website/publication_article_by_publication_year.mako:43
+#: /app/analytics/charts_config.py:586
+#: /app/analytics/templates/website/publication_article.mako:43
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr ""
 
-#: analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr ""
 
-#: analytics/charts_config.py:624
+#: /app/analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:674
+#: /app/analytics/charts_config.py:634
+msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
+msgstr ""
+
+#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+msgid "Situação da publicação"
+msgstr ""
+
+#: /app/analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:703
+#: /app/analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:706 analytics/charts_config.py:746
-#: analytics/templates/website/publication_article.mako:5
-#: analytics/templates/website/publication_article_by_publication_year.mako:5
+#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
+#: /app/analytics/templates/website/publication_article.mako:5
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr ""
 
-#: analytics/charts_config.py:714 analytics/charts_config.py:754
+#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
 msgid "Licença"
 msgstr ""
 
-#: analytics/charts_config.py:723
+#: /app/analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr ""
 
-#: analytics/charts_config.py:743
+#: /app/analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr ""
 
-#: analytics/charts_config.py:762
+#: /app/analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr ""
 
-#: analytics/charts_config.py:770 analytics/charts_config.py:805
-#: analytics/templates/website/navbar_collection.mako:7
-#: analytics/templates/website/navbar_document.mako:7
-#: analytics/templates/website/navbar_journal.mako:7
+#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
+#: /app/analytics/templates/website/navbar_collection.mako:7
+#: /app/analytics/templates/website/navbar_document.mako:7
+#: /app/analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr ""
 
-#: analytics/charts_config.py:776
+#: /app/analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr ""
 
-#: analytics/charts_config.py:787
+#: /app/analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr ""
 
-#: analytics/charts_config.py:791
+#: /app/analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr ""
 
-#: analytics/charts_config.py:803
+#: /app/analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr ""
 
-#: analytics/charts_config.py:812
+#: /app/analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr ""
 
-#: analytics/charts_config.py:812
+#: /app/analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr ""
 
-#: analytics/templates/website/access_by_document_type.mako:6
-#: analytics/templates/website/access_by_month_and_year.mako:5
-#: analytics/templates/website/access_lifetime.mako:6
-#: analytics/templates/website/accesses_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: analytics/templates/website/publication_article_affiliations.mako:5
-#: analytics/templates/website/publication_article_affiliations_map.mako:5
-#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: analytics/templates/website/publication_article_authors.mako:5
-#: analytics/templates/website/publication_article_citable_documents.mako:5
-#: analytics/templates/website/publication_article_document_type.mako:5
-#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: analytics/templates/website/publication_article_languages.mako:5
-#: analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: analytics/templates/website/publication_article_licenses.mako:5
-#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: analytics/templates/website/publication_article_references.mako:5
-#: analytics/templates/website/publication_article_subject_areas.mako:6
-#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: analytics/templates/website/publication_article_year.mako:5
-#: analytics/templates/website/publication_journal_licenses.mako:7
-#: analytics/templates/website/publication_journal_status.mako:7
-#: analytics/templates/website/publication_journal_subject_areas.mako:7
-#: analytics/templates/website/publication_journal_year.mako:7
-#: analytics/templates/website/publication_size_citations.mako:6
-#: analytics/templates/website/publication_size_documents.mako:6
-#: analytics/templates/website/publication_size_issues.mako:6
-#: analytics/templates/website/publication_size_journals.mako:8
+#: /app/analytics/templates/website/access_by_document_type.mako:6
+#: /app/analytics/templates/website/access_by_month_and_year.mako:5
+#: /app/analytics/templates/website/access_lifetime.mako:6
+#: /app/analytics/templates/website/accesses_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_authors.mako:5
+#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
+#: /app/analytics/templates/website/publication_article_document_type.mako:5
+#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_languages.mako:5
+#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_licenses.mako:5
+#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_references.mako:5
+#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
+#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: /app/analytics/templates/website/publication_article_year.mako:5
+#: /app/analytics/templates/website/publication_journal_licenses.mako:7
+#: /app/analytics/templates/website/publication_journal_status.mako:7
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
+#: /app/analytics/templates/website/publication_journal_year.mako:7
+#: /app/analytics/templates/website/publication_size_citations.mako:6
+#: /app/analytics/templates/website/publication_size_documents.mako:6
+#: /app/analytics/templates/website/publication_size_issues.mako:6
+#: /app/analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:5
+#: /app/analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr ""
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
-"recuperação dos dados de acesso. Você pode também selecionar o período de 1, "
-"2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis "
-"selecionando tudo."
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
 msgstr ""
 
-#: analytics/templates/website/access_list_articles.mako:6
+#: /app/analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr ""
 
-#: analytics/templates/website/access_list_articles.mako:9
+#: /app/analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr ""
 
-#: analytics/templates/website/access_list_articles.mako:13
-#: analytics/templates/website/access_list_issues.mako:13
-#: analytics/templates/website/access_list_journals.mako:13
+#: /app/analytics/templates/website/access_list_articles.mako:13
+#: /app/analytics/templates/website/access_list_issues.mako:13
+#: /app/analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr ""
 
-#: analytics/templates/website/access_list_articles.mako:14
-#: analytics/templates/website/access_list_issues.mako:14
-#: analytics/templates/website/access_list_journals.mako:14
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: analytics/templates/website/bibliometrics_list_granted.mako:19
-#: analytics/templates/website/bibliometrics_list_granted.mako:30
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: analytics/templates/website/bibliometrics_list_received.mako:26
-#: analytics/templates/website/bibliometrics_list_received.mako:37
+#: /app/analytics/templates/website/access_list_articles.mako:14
+#: /app/analytics/templates/website/access_list_issues.mako:14
+#: /app/analytics/templates/website/access_list_journals.mako:14
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr ""
 
-#: analytics/templates/website/access_list_issues.mako:6
+#: /app/analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr ""
 
-#: analytics/templates/website/access_list_issues.mako:9
-#: analytics/templates/website/access_list_journals.mako:9
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: /app/analytics/templates/website/access_list_issues.mako:9
+#: /app/analytics/templates/website/access_list_journals.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr ""
 
-#: analytics/templates/website/access_list_journals.mako:6
+#: /app/analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:6
+#: /app/analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:12
+#: /app/analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:18
+#: /app/analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:15
+#: /app/analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: analytics/templates/website/base.mako:6
+#: /app/analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr ""
 
-#: analytics/templates/website/base.mako:30
+#: /app/analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr ""
 
-#: analytics/templates/website/base.mako:38
-#: analytics/templates/website/journal_selector_modal.mako:7
+#: /app/analytics/templates/website/base.mako:38
+#: /app/analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr ""
 
-#: analytics/templates/website/base.mako:91
+#: /app/analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr ""
 
-#: analytics/templates/website/base.mako:93
+#: /app/analytics/templates/website/base.mako:93
 msgid ""
-"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de "
-"realizar testes de uso e performance. Todos os indicadores carregados são "
-"reais e estão sendo atualizados e inseridos gradativamente. Problemas de "
-"lentidão e indisponibilidade do serviços são esperados nesta fase."
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
 msgstr ""
 
-#: analytics/templates/website/base.mako:114
+#: /app/analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr ""
 
-#: analytics/templates/website/base.mako:116
+#: /app/analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr ""
 
-#: analytics/templates/website/base.mako:117
+#: /app/analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr ""
 
-#: analytics/templates/website/base.mako:121
+#: /app/analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr ""
 
-#: analytics/templates/website/base.mako:124
+#: /app/analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr ""
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:8
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: analytics/templates/website/bibliometrics_list_granted.mako:8
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: analytics/templates/website/bibliometrics_list_received.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:11
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: analytics/templates/website/bibliometrics_list_granted.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: analytics/templates/website/bibliometrics_list_received.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:20
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: analytics/templates/website/bibliometrics_list_received.mako:19
-#: analytics/templates/website/central_container_for_article_filters.mako:16
-#: analytics/templates/website/central_container_for_article_filters.mako:33
-#: analytics/templates/website/central_container_for_article_filters.mako:52
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: analytics/templates/website/central_container_for_journal_filters.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal.mako:20
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:32
-#: analytics/templates/website/bibliometrics_journal.mako:51
-#: analytics/templates/website/bibliometrics_journal.mako:69
-#: analytics/templates/website/bibliometrics_journal.mako:87
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: analytics/templates/website/publication_article.mako:14
-#: analytics/templates/website/publication_article.mako:33
-#: analytics/templates/website/publication_article.mako:52
-#: analytics/templates/website/publication_article.mako:70
-#: analytics/templates/website/publication_article.mako:88
-#: analytics/templates/website/publication_article.mako:106
-#: analytics/templates/website/publication_article.mako:124
-#: analytics/templates/website/publication_article.mako:142
-#: analytics/templates/website/publication_article.mako:160
-#: analytics/templates/website/publication_article_by_publication_year.mako:14
-#: analytics/templates/website/publication_article_by_publication_year.mako:33
-#: analytics/templates/website/publication_article_by_publication_year.mako:52
-#: analytics/templates/website/publication_article_by_publication_year.mako:70
-#: analytics/templates/website/publication_article_by_publication_year.mako:88
-#: analytics/templates/website/publication_article_by_publication_year.mako:106
-#: analytics/templates/website/publication_journal_licenses.mako:14
-#: analytics/templates/website/publication_journal_status.mako:14
-#: analytics/templates/website/publication_journal_subject_areas.mako:14
-#: analytics/templates/website/publication_journal_year.mako:14
+#: /app/analytics/templates/website/bibliometrics_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal.mako:51
+#: /app/analytics/templates/website/bibliometrics_journal.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal.mako:87
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: /app/analytics/templates/website/publication_article.mako:14
+#: /app/analytics/templates/website/publication_article.mako:33
+#: /app/analytics/templates/website/publication_article.mako:52
+#: /app/analytics/templates/website/publication_article.mako:70
+#: /app/analytics/templates/website/publication_article.mako:88
+#: /app/analytics/templates/website/publication_article.mako:106
+#: /app/analytics/templates/website/publication_article.mako:124
+#: /app/analytics/templates/website/publication_article.mako:142
+#: /app/analytics/templates/website/publication_article.mako:160
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
+#: /app/analytics/templates/website/publication_journal_licenses.mako:14
+#: /app/analytics/templates/website/publication_journal_status.mako:14
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
+#: /app/analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
-"linha de 2 anos equivale ao fator de impacto de periódicos da Thomson Reuters"
+"linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
+"Reuters"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:54
-#: analytics/templates/website/publication_article_by_publication_year.mako:109
+#: /app/analytics/templates/website/bibliometrics_journal.mako:54
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
-"Este gráfico apresenta a distribuição de documentos citáveis e não citáveis "
-"relacionados ao periódico selecionado. De acordo com as regras de contagem do"
-" SciELO, documentos citáveis devem ser do tipo \"Research Article\", \"Review"
-" Article\", \"Case Report\", \"Brief Report\", \"Rapid Communication\" e "
-"\"Article Commentary\". Os demais tipos de documentos são considerados não "
-"citáveis."
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:60
+#: /app/analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:72
+#: /app/analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
-"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores "
-"são fornecidos anualmente pelo Google Scholar. A ausência de indicadores para"
-" um periódico ou para um período de um periódico pode ocorrer caso esses "
-"dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, "
-"você será direcionado para o site do Google Scholar."
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:78
+#: /app/analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:90
+#: /app/analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
-"citações do periódico selecionado, os dados estão distribuidos por ano de "
-"publicação."
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: analytics/templates/website/navbar_journal.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: analytics/templates/website/navbar_journal.mako:28
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: analytics/templates/website/navbar_journal.mako:29
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: analytics/templates/website/bibliometrics_list_granted.mako:18
-#: analytics/templates/website/bibliometrics_list_received.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: analytics/templates/website/bibliometrics_list_granted.mako:35
-#: analytics/templates/website/bibliometrics_list_received.mako:42
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: analytics/templates/website/navbar_collection.mako:30
-#: analytics/templates/website/navbar_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:30
+#: /app/analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_granted.mako:15
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+msgid "Indicadores Bibliométricos da Rede SciELO"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid "Periodicidade de atualização:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid " anual"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+msgid "Indicadores de Publicação"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+msgid "Numeros da Rede SciELO por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+msgid "Ano de publicação: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+msgid "Periódico: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+msgid "Assunto: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+msgid "País de afiliação do autor: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+msgid "País de Afiliação do Autor por: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+msgid "País de publicação da revista: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+msgid "Número de Co-autores por: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+msgid "Indicadores de Coleção"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+msgid "Periódico por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+msgid "Indicadores gerais: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+msgid "Indicadores de Citação"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+msgid "Ano de Citação por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+msgid "Idade do documento citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+msgid "Tipo de documento citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+msgid "Periódico Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+msgid "Assunto do Periódico Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+msgid "Periódico SciELO citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+msgid "País de Afiliação do Autor Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: analytics/templates/website/navbar_collection.mako:29
-#: analytics/templates/website/navbar_journal.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:29
+#: /app/analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
-"Aqui são considerados apenas os documentos citáveis. De acordo com as regras "
-"de contagem do SciELO, documentos citáveis devem ser do tipo Research "
-"Article, Review Article, Case Report, Brief Report, Rapid Communication e "
-"Article Commentary. Os demais tipos de documentos são considerados não "
-"citáveis."
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_list_received.mako:22
-#: analytics/templates/website/navbar_collection.mako:33
-#: analytics/templates/website/navbar_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:33
+#: /app/analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr ""
 
-#: analytics/templates/website/central_container_for_article_filters.mako:8
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr ""
 
-#: analytics/templates/website/central_container_for_article_filters.mako:22
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr ""
 
-#: analytics/templates/website/central_container_for_article_filters.mako:49
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr ""
 
-#: analytics/templates/website/central_container_for_journal_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:5
+#: /app/analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:7
+#: /app/analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:8
+#: /app/analytics/templates/website/faq.mako:8
 msgid ""
-"Para que os dados de acessos sejam computados é necessário que os logs de "
-"acessos sejam enviados para processamento. A ausência de estatísticas de "
-"acessos deve ser verificada com a coordenação de cada coleção SciELO."
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:11
+#: /app/analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:12
+#: /app/analytics/templates/website/faq.mako:12
 msgid ""
-"O período disponível de cada uma das coleções depende do período disponível "
-"dos logs de acessos de cada uma das coleções. Este projeto se compromete a "
-"computar os dados de acessos à partir de 2012, desde que os logs sejam "
-"devidamente fornecidos pelas coleções."
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:15 analytics/templates/website/faq.mako:36
+#: /app/analytics/templates/website/faq.mako:15
+#: /app/analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:16
+#: /app/analytics/templates/website/faq.mako:16
 msgid ""
-"Estão sendo contabilizados e classificados os acessos ao texto completo em "
-"HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:19
+#: /app/analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:21
+#: /app/analytics/templates/website/faq.mako:21
 msgid ""
-"Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos de"
-" estatísticas de acessos."
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:22
+#: /app/analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:23
+#: /app/analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:27 analytics/templates/website/faq.mako:40
+#: /app/analytics/templates/website/faq.mako:27
+#: /app/analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:28
+#: /app/analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:30
+#: /app/analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:32
+#: /app/analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr ""
 
-#: analytics/templates/website/faq.mako:33
+#: /app/analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1151,138 +1258,143 @@ msgid ""
 "coleções."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:37
+#: /app/analytics/templates/website/faq.mako:37
 msgid ""
-"Estão sendo contabilizados indicadores de publicação das coleções com base "
-"nos metadados fornecidos durante todo o processo de publicação de um "
-"documento no SciELO. A qualidade desses indicadores esta diretamente ligada a"
-" qualidade dos processos implementados por cada uma das coleções."
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
 msgstr ""
 
-#: analytics/templates/website/faq.mako:41
+#: /app/analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr ""
 
-#: analytics/templates/website/home_collection.mako:7
-#: analytics/templates/website/home_journal.mako:7
-#: analytics/templates/website/home_network.mako:7
-#: analytics/templates/website/navbar_collection.mako:18
-#: analytics/templates/website/navbar_journal.mako:18
-#: analytics/templates/website/publication_size.mako:5
+#: /app/analytics/templates/website/home_collection.mako:7
+#: /app/analytics/templates/website/home_journal.mako:7
+#: /app/analytics/templates/website/home_network.mako:7
+#: /app/analytics/templates/website/navbar_collection.mako:18
+#: /app/analytics/templates/website/navbar_journal.mako:18
+#: /app/analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr ""
 
-#: analytics/templates/website/home_collection.mako:24
-#: analytics/templates/website/home_document.mako:21
-#: analytics/templates/website/home_journal.mako:21
-#: analytics/templates/website/home_network.mako:24
-#: analytics/templates/website/navbar_collection.mako:9
-#: analytics/templates/website/navbar_collection.mako:27
-#: analytics/templates/website/navbar_document.mako:9
-#: analytics/templates/website/navbar_journal.mako:9
-#: analytics/templates/website/navbar_journal.mako:26
+#: /app/analytics/templates/website/home_collection.mako:24
+#: /app/analytics/templates/website/home_document.mako:21
+#: /app/analytics/templates/website/home_journal.mako:21
+#: /app/analytics/templates/website/home_network.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:9
+#: /app/analytics/templates/website/navbar_collection.mako:27
+#: /app/analytics/templates/website/navbar_document.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr ""
 
-#: analytics/templates/website/home_document.mako:7
+#: /app/analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr ""
 
-#: analytics/templates/website/journal_selector_modal.mako:6
+#: /app/analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr ""
 
-#: analytics/templates/website/journal_selector_modal.mako:11
+#: /app/analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr ""
 
-#: analytics/templates/website/journal_selector_modal.mako:20
+#: /app/analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:11
-#: analytics/templates/website/navbar_journal.mako:11
+#: /app/analytics/templates/website/navbar_collection.mako:11
+#: /app/analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:12
-#: analytics/templates/website/navbar_journal.mako:12
+#: /app/analytics/templates/website/navbar_collection.mako:12
+#: /app/analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:16
-#: analytics/templates/website/navbar_journal.mako:16
+#: /app/analytics/templates/website/navbar_collection.mako:16
+#: /app/analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:19
-#: analytics/templates/website/navbar_journal.mako:19
+#: /app/analytics/templates/website/navbar_collection.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:20
-#: analytics/templates/website/navbar_journal.mako:20
+#: /app/analytics/templates/website/navbar_collection.mako:20
+#: /app/analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:21
+#: /app/analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:25
-#: analytics/templates/website/navbar_document.mako:13
-#: analytics/templates/website/navbar_journal.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:25
+#: /app/analytics/templates/website/navbar_document.mako:13
+#: /app/analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:32
-#: analytics/templates/website/navbar_journal.mako:34
+#: /app/analytics/templates/website/navbar_collection.mako:32
+#: /app/analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:34
-#: analytics/templates/website/navbar_journal.mako:36
+#: /app/analytics/templates/website/navbar_collection.mako:34
+#: /app/analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr ""
 
-#: analytics/templates/website/navbar_collection.mako:38
-#: analytics/templates/website/navbar_document.mako:19
-#: analytics/templates/website/navbar_journal.mako:40
+#: /app/analytics/templates/website/navbar_collection.mako:35
+#: /app/analytics/templates/website/navbar_journal.mako:37
+msgid "Indicadores Gerais"
+msgstr ""
+
+#: /app/analytics/templates/website/navbar_collection.mako:39
+#: /app/analytics/templates/website/navbar_document.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr ""
 
-#: analytics/templates/website/navbar_document.mako:15
+#: /app/analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:17
+#: /app/analytics/templates/website/publication_article.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. A disponibilidade de indicadores de licença de uso dependem da "
-"adoção da coleção ou periódico selecionado de licenças de uso creative "
-"commons."
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:24
-#: analytics/templates/website/publication_article_by_publication_year.mako:24
+#: /app/analytics/templates/website/publication_article.mako:24
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:36
+#: /app/analytics/templates/website/publication_article.mako:36
 msgid ""
-"Este gráfico apresenta o total de documentos publicados por área de atuação. "
-"Os números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas "
-"são determinadas para cada um dos periódicos SciELO, podendo um periódico "
-"estar relacionado a mais de uma área de atuação. Os valores totais de "
-"documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode fazer parte de mais de "
-"uma área de atuação. Este gráfico é recomendado para extração de indicadores "
-"de Coleção."
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:55
+#: /app/analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1290,283 +1402,287 @@ msgid ""
 "Citation Index e documentados no SciELO Publishing Schema."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:61
-#: analytics/templates/website/publication_article_by_publication_year.mako:61
+#: /app/analytics/templates/website/publication_article.mako:61
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:73
+#: /app/analytics/templates/website/publication_article.mako:73
 msgid ""
-"Este gráfico apresenta o total de documentos por idioma de publicação. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ser publicado em mais de um idioma."
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:79
+#: /app/analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:91
+#: /app/analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
-"publicação. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado."
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:97
-#: analytics/templates/website/publication_article_by_publication_year.mako:79
+#: /app/analytics/templates/website/publication_article.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:109
+#: /app/analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ter mais um país de afiliação."
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:115
+#: /app/analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:127
+#: /app/analytics/templates/website/publication_article.mako:127
 msgid ""
-"Este mapa apresenta o total de documentos por país de afiliação dos autores. "
-"Os valores totais de documentos deste mapa não podem ser considerados como "
-"totais de publicações da coleção uma vez que um documento pode ter mais um "
-"país de afiliação."
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:145
+#: /app/analytics/templates/website/publication_article.mako:145
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de autores. Os"
-" números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:151
+#: /app/analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:163
+#: /app/analytics/templates/website/publication_article.mako:163
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de referências"
-" bibliográficas. Os números são relacionados a coleção ou ao periódico quando"
-" um periódico é selecionado."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"referências bibliográficas. Os números são relacionados a coleção ou ao "
+"periódico quando um periódico é selecionado."
 msgstr ""
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso e ano "
-"de publicação. Os números são relacionados a coleção ou ao periódico quando "
-"um periódico é selecionado. A disponibilidade de indicadores de licença de "
-"uso dependem da adoção da coleção ou periódico selecionado de licenças de uso"
-" creative commons."
-msgstr ""
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:36
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por área de atuação e ano"
-" de publicação. Os números são relacionados a coleção ou ao periódico quando "
-"um periódico é selecionado. Os valores totais de documentos deste gráfico não"
-" podem ser considerados como totais de publicações da coleção uma vez que um "
-"documento pode fazer parte de mais de uma área de atuação. Este gráfico é "
-"recomendado para extração de indicadores de Coleção."
-msgstr ""
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:55
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por tipo de publicação e "
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado."
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
 msgstr ""
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:73
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por idioma de publicação "
-"e ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma "
-"vez que um documento pode ser publicado em mais de um idioma."
-msgstr ""
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:91
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por país de afiliação dos"
-" autores e ano de publicação. Os números são relacionados a coleção ou ao "
-"periódico quando um periódico é selecionado. Os valores totais de documentos "
-"deste gráfico não podem ser considerados como totais de publicações da "
-"coleção uma vez que um documento pode ser publicado por mais de um país de "
-"afiliação."
-msgstr ""
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:97
-msgid "Citações recebidas, concedidas e auto citações"
-msgstr ""
-
-#: analytics/templates/website/publication_journal_licenses.mako:17
-msgid ""
-"Este gráfico apresenta o número de periódicos por licença de uso adotada. Os "
-"valores totais de periódicos deste gráfico não podem ser considerados como "
-"totais da coleção uma vez que um documento pode fazer parte de mais de uma "
-"área de atuação. Este gráfico é recomendado para extração de indicadores de "
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
 "Coleção."
 msgstr ""
 
-#: analytics/templates/website/publication_journal_status.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
-"Este gráfico apresenta o número de periódicos por status da publicação no "
-"SciELO. O status considerado neste grafíco é o status vigente do periódico, "
-"não são consideradas as mudanças de status a longo da existência do periódico"
-" nas bases SciELO. Este gráfico é recomendado para extração de indicadores de"
-" Coleção."
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
 msgstr ""
 
-#: analytics/templates/website/publication_journal_subject_areas.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
+msgstr ""
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+msgstr ""
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+msgid "Citações recebidas, concedidas e auto citações"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:5
+msgid "Licenças de uso dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:10
+msgid "Áreas temáticas dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:15
+msgid "Ano de inclusão de periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:19
+msgid "Situação de publicação dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
+"indicadores de Coleção."
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_status.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção. As áreas de "
-"atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada "
-"um dos periódicos SciELO, podendo um periódico estar relacionado a mais de "
-"uma área de atuação. Os valores totais de periódicos deste gráfico não podem "
-"ser considerados como totais da coleção uma vez que um documento pode fazer "
-"parte de mais de uma área de atuação. Este gráfico é recomendado para "
-"extração de indicadores de Coleção."
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
 msgstr ""
 
-#: analytics/templates/website/publication_journal_year.mako:17
+#: /app/analytics/templates/website/publication_journal_year.mako:17
 msgid ""
-"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. "
-"Este gráfico é recomendado para extração de indicadores de Coleção."
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
 msgstr ""
 
-#: analytics/templates/website/publication_size.mako:11
-#: analytics/templates/website/publication_size.mako:22
-#: analytics/templates/website/publication_size.mako:33
-#: analytics/templates/website/publication_size.mako:44
+#: /app/analytics/templates/website/publication_size.mako:11
+#: /app/analytics/templates/website/publication_size.mako:22
+#: /app/analytics/templates/website/publication_size.mako:33
+#: /app/analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr ""
 
-#: analytics/templates/website/publication_size.mako:14
+#: /app/analytics/templates/website/publication_size.mako:14
 msgid ""
-"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e "
-"artigo publicados. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado na barra superior do site."
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
 msgstr ""
 
-#: analytics/templates/website/publication_size.mako:25
+#: /app/analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
-"publicado. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado na barra superior do site."
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
 msgstr ""
 
-#: analytics/templates/website/publication_size.mako:36
+#: /app/analytics/templates/website/publication_size.mako:36
 msgid ""
-"Os números a cima correspondem ao número de documentos publicados. Os números"
-" são relacionados a coleção ou ao periódico quando um periódico é selecionado"
-" na barra superior do site."
+"Os números a cima correspondem ao número de documentos publicados. Os "
+"números são relacionados a coleção ou ao periódico quando um periódico é "
+"selecionado na barra superior do site."
 msgstr ""
 
-#: analytics/templates/website/publication_size.mako:47
+#: /app/analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
-"citadas nos documentos publicados. Os números são relacionados a coleção ou "
-"ao periódico quando um periódico é selecionado na barra superior do site."
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
 msgstr ""
 
-#: analytics/templates/website/publication_size_citations.mako:9
+#: /app/analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr ""
 
-#: analytics/templates/website/publication_size_documents.mako:9
+#: /app/analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr ""
 
-#: analytics/templates/website/publication_size_issues.mako:9
+#: /app/analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr ""
 
-#: analytics/templates/website/publication_size_journals.mako:11
+#: /app/analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr ""
 
-#: analytics/templates/website/publication_size_journals.mako:15
-msgid "ativo"
-msgstr ""
-
-#: analytics/templates/website/publication_size_journals.mako:16
-msgid "em progresso"
-msgstr ""
-
-#: analytics/templates/website/publication_size_journals.mako:17
-msgid "suspenso"
-msgstr ""
-
-#: analytics/templates/website/publication_size_journals.mako:18
-msgid "descontinuado"
-msgstr ""
-
-#: analytics/templates/website/reports.mako:5
+#: /app/analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:7
+#: /app/analytics/templates/website/reports.mako:7
 msgid ""
-"O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados "
-"utilizados para produção dos indicadores presentes nesta ferramenta. Qualquer"
-" interessado pode fazer o download e produzir análises bibliométricas de "
-"acordo com suas necessidade."
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
 msgstr ""
 
-#: analytics/templates/website/reports.mako:10
+#: /app/analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:16
+#: /app/analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:18
+#: /app/analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:19
+#: /app/analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:20
+#: /app/analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr ""
 
-#: analytics/templates/website/reports.mako:23
+#: /app/analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr ""
 
-#: analytics/templates/website/share.mako:8
+#: /app/analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr ""
 
-#: analytics/templates/website/share.mako:10
+#: /app/analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr ""
 
-#: analytics/templates/website/share.mako:13
+#: /app/analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr ""
 
-#: analytics/templates/website/share.mako:16
+#: /app/analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr ""
 

--- a/analytics/locale/analytics.pot
+++ b/analytics/locale/analytics.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-09-17 18:21+0000\n"
+"POT-Creation-Date: 2019-09-18 12:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,421 +17,421 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.1\n"
 
-#: /app/analytics/charts_config.py:25
+#: analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr ""
 
-#: /app/analytics/charts_config.py:58
+#: analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:59
+#: analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:91
+#: analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:92
+#: analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:100
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: analytics/charts_config.py:100
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+#: analytics/charts_config.py:103 analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
-#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
-#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
+#: analytics/charts_config.py:113 analytics/charts_config.py:135
+#: analytics/charts_config.py:157 analytics/charts_config.py:179
+#: analytics/charts_config.py:202 analytics/charts_config.py:229
 msgid "Ano base"
 msgstr ""
 
-#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
-#: /app/analytics/charts_config.py:134
+#: analytics/charts_config.py:122 analytics/charts_config.py:125
+#: analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
-#: /app/analytics/charts_config.py:156
+#: analytics/charts_config.py:144 analytics/charts_config.py:147
+#: analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
-#: /app/analytics/charts_config.py:178
+#: analytics/charts_config.py:166 analytics/charts_config.py:169
+#: analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:188
+#: analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr ""
 
-#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
-#: /app/analytics/charts_config.py:201
+#: analytics/charts_config.py:189 analytics/charts_config.py:192
+#: analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr ""
 
-#: /app/analytics/charts_config.py:211
+#: analytics/charts_config.py:211
 msgid "imediatez"
 msgstr ""
 
-#: /app/analytics/charts_config.py:212
-#: /app/analytics/templates/website/access_datepicker.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: analytics/charts_config.py:212
+#: analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr ""
 
-#: /app/analytics/charts_config.py:213
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/charts_config.py:213
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:214
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/charts_config.py:214
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:215
+#: analytics/charts_config.py:215
 msgid "4 anos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:216
+#: analytics/charts_config.py:216
 msgid "5 anos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:223
+#: analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr ""
 
-#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
-#: /app/analytics/templates/website/bibliometrics_journal.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: analytics/charts_config.py:226 analytics/charts_config.py:228
+#: analytics/templates/website/bibliometrics_journal.mako:23
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr ""
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr ""
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr ""
 
-#: /app/analytics/charts_config.py:244
+#: analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr ""
 
-#: /app/analytics/charts_config.py:251
+#: analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr ""
 
-#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
-#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
-#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
-#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
-#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
-#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
-#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: analytics/charts_config.py:256 analytics/charts_config.py:273
+#: analytics/charts_config.py:287 analytics/charts_config.py:414
+#: analytics/charts_config.py:423 analytics/charts_config.py:438
+#: analytics/charts_config.py:446 analytics/charts_config.py:494
+#: analytics/charts_config.py:503 analytics/charts_config.py:562
+#: analytics/charts_config.py:572 analytics/charts_config.py:614
+#: analytics/charts_config.py:623 analytics/charts_config.py:664
+#: analytics/charts_config.py:672 analytics/charts_config.py:788
+#: analytics/templates/website/central_container_for_article_filters.mako:13
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr ""
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr ""
 
-#: /app/analytics/charts_config.py:272
+#: analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr ""
 
-#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
-#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
-#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
-#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
-#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
-#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
-#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
-#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
+#: analytics/charts_config.py:281 analytics/charts_config.py:305
+#: analytics/charts_config.py:324 analytics/charts_config.py:341
+#: analytics/charts_config.py:388 analytics/charts_config.py:412
+#: analytics/charts_config.py:441 analytics/charts_config.py:467
+#: analytics/charts_config.py:492 analytics/charts_config.py:540
+#: analytics/charts_config.py:560 analytics/charts_config.py:568
+#: analytics/charts_config.py:591 analytics/charts_config.py:612
+#: analytics/charts_config.py:662 analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:298
+#: analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:301
+#: analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr ""
 
-#: /app/analytics/charts_config.py:308
+#: analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr ""
 
-#: /app/analytics/charts_config.py:317
+#: analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:320
-#: /app/analytics/templates/website/publication_article.mako:133
+#: analytics/charts_config.py:320
+#: analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr ""
 
-#: /app/analytics/charts_config.py:327
+#: analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr ""
 
-#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
+#: analytics/charts_config.py:338 analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
-#: /app/analytics/charts_config.py:694
+#: analytics/charts_config.py:359 analytics/charts_config.py:391
+#: analytics/charts_config.py:446 analytics/charts_config.py:470
+#: analytics/charts_config.py:543 analytics/charts_config.py:594
+#: analytics/charts_config.py:694
 msgid "Documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
-#: /app/analytics/charts_config.py:391
+#: analytics/charts_config.py:368 analytics/charts_config.py:383
+#: analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:404
+#: analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:437
+#: analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:459
+#: analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:462
+#: analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:470
+#: analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr ""
 
-#: /app/analytics/charts_config.py:484
+#: analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:514
+#: analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr ""
 
-#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
+#: analytics/charts_config.py:515 analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr ""
 
-#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
-#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+#: analytics/charts_config.py:518 analytics/charts_config.py:642
+#: analytics/charts_config.py:711 analytics/charts_config.py:731
 msgid "Número de periódicos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
-#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
-#: /app/analytics/templates/website/navbar_collection.mako:10
-#: /app/analytics/templates/website/navbar_journal.mako:10
+#: analytics/charts_config.py:523 analytics/charts_config.py:645
+#: analytics/charts_config.py:714 analytics/charts_config.py:734
+#: analytics/templates/website/navbar_collection.mako:10
+#: analytics/templates/website/navbar_journal.mako:10
 msgid "Periódicos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:532
+#: analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
+#: analytics/charts_config.py:535 analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr ""
 
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
+#: analytics/charts_config.py:543 analytics/charts_config.py:714
+#: analytics/templates/website/central_container_for_article_filters.mako:30
+#: analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr ""
 
-#: /app/analytics/charts_config.py:552
+#: analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:583
+#: analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr ""
 
-#: /app/analytics/charts_config.py:586
-#: /app/analytics/templates/website/publication_article.mako:43
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
+#: analytics/charts_config.py:586
+#: analytics/templates/website/publication_article.mako:43
+#: analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:594
+#: analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr ""
 
-#: /app/analytics/charts_config.py:604
+#: analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:634
+#: analytics/charts_config.py:634
 msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
 msgstr ""
 
-#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+#: analytics/charts_config.py:637 analytics/charts_config.py:645
 msgid "Situação da publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:654
+#: analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:683
+#: analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
-#: /app/analytics/templates/website/publication_article.mako:5
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
+#: analytics/charts_config.py:686 analytics/charts_config.py:726
+#: analytics/templates/website/publication_article.mako:5
+#: analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr ""
 
-#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
+#: analytics/charts_config.py:694 analytics/charts_config.py:734
 msgid "Licença"
 msgstr ""
 
-#: /app/analytics/charts_config.py:703
+#: analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:723
+#: analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:742
+#: analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr ""
 
-#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
-#: /app/analytics/templates/website/navbar_collection.mako:7
-#: /app/analytics/templates/website/navbar_document.mako:7
-#: /app/analytics/templates/website/navbar_journal.mako:7
+#: analytics/charts_config.py:750 analytics/charts_config.py:785
+#: analytics/templates/website/navbar_collection.mako:7
+#: analytics/templates/website/navbar_document.mako:7
+#: analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:756
+#: analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr ""
 
-#: /app/analytics/charts_config.py:767
+#: analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr ""
 
-#: /app/analytics/charts_config.py:771
+#: analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr ""
 
-#: /app/analytics/charts_config.py:783
+#: analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr ""
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr ""
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr ""
 
-#: /app/analytics/templates/website/access_by_document_type.mako:6
-#: /app/analytics/templates/website/access_by_month_and_year.mako:5
-#: /app/analytics/templates/website/access_lifetime.mako:6
-#: /app/analytics/templates/website/accesses_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_authors.mako:5
-#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
-#: /app/analytics/templates/website/publication_article_document_type.mako:5
-#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_languages.mako:5
-#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_licenses.mako:5
-#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_references.mako:5
-#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
-#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: /app/analytics/templates/website/publication_article_year.mako:5
-#: /app/analytics/templates/website/publication_journal_licenses.mako:7
-#: /app/analytics/templates/website/publication_journal_status.mako:7
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
-#: /app/analytics/templates/website/publication_journal_year.mako:7
-#: /app/analytics/templates/website/publication_size_citations.mako:6
-#: /app/analytics/templates/website/publication_size_documents.mako:6
-#: /app/analytics/templates/website/publication_size_issues.mako:6
-#: /app/analytics/templates/website/publication_size_journals.mako:6
+#: analytics/templates/website/access_by_document_type.mako:6
+#: analytics/templates/website/access_by_month_and_year.mako:5
+#: analytics/templates/website/access_lifetime.mako:6
+#: analytics/templates/website/accesses_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: analytics/templates/website/publication_article_affiliations.mako:5
+#: analytics/templates/website/publication_article_affiliations_map.mako:5
+#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: analytics/templates/website/publication_article_authors.mako:5
+#: analytics/templates/website/publication_article_citable_documents.mako:5
+#: analytics/templates/website/publication_article_document_type.mako:5
+#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: analytics/templates/website/publication_article_languages.mako:5
+#: analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: analytics/templates/website/publication_article_licenses.mako:5
+#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: analytics/templates/website/publication_article_references.mako:5
+#: analytics/templates/website/publication_article_subject_areas.mako:6
+#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: analytics/templates/website/publication_article_year.mako:5
+#: analytics/templates/website/publication_journal_licenses.mako:7
+#: analytics/templates/website/publication_journal_status.mako:7
+#: analytics/templates/website/publication_journal_subject_areas.mako:7
+#: analytics/templates/website/publication_journal_year.mako:7
+#: analytics/templates/website/publication_size_citations.mako:6
+#: analytics/templates/website/publication_size_documents.mako:6
+#: analytics/templates/website/publication_size_issues.mako:6
+#: analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:5
+#: analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
 "recuperação dos dados de acesso. Você pode também selecionar o período de"
@@ -439,96 +439,96 @@ msgid ""
 " selecionando tudo."
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_articles.mako:6
+#: analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_articles.mako:9
+#: analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_articles.mako:13
-#: /app/analytics/templates/website/access_list_issues.mako:13
-#: /app/analytics/templates/website/access_list_journals.mako:13
+#: analytics/templates/website/access_list_articles.mako:13
+#: analytics/templates/website/access_list_issues.mako:13
+#: analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_articles.mako:14
-#: /app/analytics/templates/website/access_list_issues.mako:14
-#: /app/analytics/templates/website/access_list_journals.mako:14
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
+#: analytics/templates/website/access_list_articles.mako:14
+#: analytics/templates/website/access_list_issues.mako:14
+#: analytics/templates/website/access_list_journals.mako:14
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: analytics/templates/website/bibliometrics_list_granted.mako:19
+#: analytics/templates/website/bibliometrics_list_granted.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: analytics/templates/website/bibliometrics_list_received.mako:26
+#: analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_issues.mako:6
+#: analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_issues.mako:9
-#: /app/analytics/templates/website/access_list_journals.mako:9
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: analytics/templates/website/access_list_issues.mako:9
+#: analytics/templates/website/access_list_journals.mako:9
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/access_list_journals.mako:6
+#: analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:6
+#: analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:12
+#: analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:18
+#: analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:15
+#: analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:6
+#: analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:30
+#: analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:38
-#: /app/analytics/templates/website/journal_selector_modal.mako:7
+#: analytics/templates/website/base.mako:38
+#: analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:91
+#: analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:93
+#: analytics/templates/website/base.mako:93
 msgid ""
 "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
 " realizar testes de uso e performance. Todos os indicadores carregados "
@@ -536,214 +536,214 @@ msgid ""
 " de lentidão e indisponibilidade do serviços são esperados nesta fase."
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:114
+#: analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:116
+#: analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:117
+#: analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:121
+#: analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:124
+#: analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
+#: analytics/templates/website/bibliometrics_journal.mako:8
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: analytics/templates/website/bibliometrics_list_granted.mako:8
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
+#: analytics/templates/website/bibliometrics_journal.mako:11
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: analytics/templates/website/bibliometrics_list_granted.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:20
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
+#: analytics/templates/website/bibliometrics_journal.mako:20
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: analytics/templates/website/bibliometrics_list_received.mako:19
+#: analytics/templates/website/central_container_for_article_filters.mako:16
+#: analytics/templates/website/central_container_for_article_filters.mako:33
+#: analytics/templates/website/central_container_for_article_filters.mako:52
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:32
-#: /app/analytics/templates/website/bibliometrics_journal.mako:51
-#: /app/analytics/templates/website/bibliometrics_journal.mako:69
-#: /app/analytics/templates/website/bibliometrics_journal.mako:87
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: /app/analytics/templates/website/publication_article.mako:14
-#: /app/analytics/templates/website/publication_article.mako:33
-#: /app/analytics/templates/website/publication_article.mako:52
-#: /app/analytics/templates/website/publication_article.mako:70
-#: /app/analytics/templates/website/publication_article.mako:88
-#: /app/analytics/templates/website/publication_article.mako:106
-#: /app/analytics/templates/website/publication_article.mako:124
-#: /app/analytics/templates/website/publication_article.mako:142
-#: /app/analytics/templates/website/publication_article.mako:160
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
-#: /app/analytics/templates/website/publication_journal_licenses.mako:14
-#: /app/analytics/templates/website/publication_journal_status.mako:14
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
-#: /app/analytics/templates/website/publication_journal_year.mako:14
+#: analytics/templates/website/bibliometrics_journal.mako:32
+#: analytics/templates/website/bibliometrics_journal.mako:51
+#: analytics/templates/website/bibliometrics_journal.mako:69
+#: analytics/templates/website/bibliometrics_journal.mako:87
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: analytics/templates/website/publication_article.mako:14
+#: analytics/templates/website/publication_article.mako:33
+#: analytics/templates/website/publication_article.mako:52
+#: analytics/templates/website/publication_article.mako:70
+#: analytics/templates/website/publication_article.mako:88
+#: analytics/templates/website/publication_article.mako:106
+#: analytics/templates/website/publication_article.mako:124
+#: analytics/templates/website/publication_article.mako:142
+#: analytics/templates/website/publication_article.mako:160
+#: analytics/templates/website/publication_article_by_publication_year.mako:14
+#: analytics/templates/website/publication_article_by_publication_year.mako:33
+#: analytics/templates/website/publication_article_by_publication_year.mako:52
+#: analytics/templates/website/publication_article_by_publication_year.mako:70
+#: analytics/templates/website/publication_article_by_publication_year.mako:88
+#: analytics/templates/website/publication_article_by_publication_year.mako:106
+#: analytics/templates/website/publication_journal_licenses.mako:14
+#: analytics/templates/website/publication_journal_status.mako:14
+#: analytics/templates/website/publication_journal_subject_areas.mako:14
+#: analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:35
+#: analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
@@ -751,12 +751,12 @@ msgid ""
 "Reuters"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:42
+#: analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:54
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
+#: analytics/templates/website/bibliometrics_journal.mako:54
+#: analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
 "Este gráfico apresenta a distribuição de documentos citáveis e não "
 "citáveis relacionados ao periódico selecionado. De acordo com as regras "
@@ -766,11 +766,11 @@ msgid ""
 "são considerados não citáveis."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+#: analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:72
+#: analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
 "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
 "indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
@@ -779,349 +779,349 @@ msgid ""
 "Ao clicar na série, você será direcionado para o site do Google Scholar."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:78
+#: analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:90
+#: analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
 " publicação."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:27
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:28
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:29
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: analytics/templates/website/bibliometrics_list_granted.mako:18
+#: analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: analytics/templates/website/bibliometrics_list_granted.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:30
-#: /app/analytics/templates/website/navbar_journal.mako:32
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: analytics/templates/website/navbar_collection.mako:30
+#: analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:5
 msgid "Indicadores Bibliométricos da Rede SciELO"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid "Periodicidade de atualização:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid " anual"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:13
 msgid "Indicadores de Publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:19
 msgid "Numeros da Rede SciELO por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:54
 msgid "Ano de publicação: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:35
 msgid "Periódico: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:55
 msgid "Assunto: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:24
 msgid "País de afiliação do autor: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:26
 msgid "País de Afiliação do Autor por: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:30
 msgid "País de publicação da revista: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:33
 msgid "Número de Co-autores por: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:46
 msgid "Indicadores de Coleção"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:52
 msgid "Periódico por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:56
 msgid "Indicadores gerais: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:66
 msgid "Indicadores de Citação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:72
 msgid "Ano de Citação por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:90
 msgid "Idade do documento citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:91
 msgid "Tipo de documento citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:77
 msgid "Periódico Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:82
 msgid "Assunto do Periódico Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:92
 msgid "Periódico SciELO citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:88
 msgid "País de Afiliação do Autor Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
+#: analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:29
-#: /app/analytics/templates/website/navbar_journal.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: analytics/templates/website/navbar_collection.mako:29
+#: analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
 "Aqui são considerados apenas os documentos citáveis. De acordo com as "
 "regras de contagem do SciELO, documentos citáveis devem ser do tipo "
@@ -1130,66 +1130,66 @@ msgid ""
 "considerados não citáveis."
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:33
-#: /app/analytics/templates/website/navbar_journal.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:22
+#: analytics/templates/website/navbar_collection.mako:33
+#: analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: analytics/templates/website/central_container_for_article_filters.mako:8
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: analytics/templates/website/central_container_for_article_filters.mako:22
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr ""
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
+#: analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr ""
 
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
+#: analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:5
+#: analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:7
+#: analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:8
+#: analytics/templates/website/faq.mako:8
 msgid ""
 "Para que os dados de acessos sejam computados é necessário que os logs de"
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
 " acessos deve ser verificada com a coordenação de cada coleção SciELO."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:11
+#: analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:12
+#: analytics/templates/website/faq.mako:12
 msgid ""
 "O período disponível de cada uma das coleções depende do período "
 "disponível dos logs de acessos de cada uma das coleções. Este projeto se "
@@ -1197,60 +1197,60 @@ msgid ""
 "logs sejam devidamente fornecidos pelas coleções."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:15
-#: /app/analytics/templates/website/faq.mako:36
+#: analytics/templates/website/faq.mako:15
+#: analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:16
+#: analytics/templates/website/faq.mako:16
 msgid ""
 "Estão sendo contabilizados e classificados os acessos ao texto completo "
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
 "artigo."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:19
+#: analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:21
+#: analytics/templates/website/faq.mako:21
 msgid ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:22
+#: analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:23
+#: analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:27
-#: /app/analytics/templates/website/faq.mako:40
+#: analytics/templates/website/faq.mako:27
+#: analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:28
+#: analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:30
+#: analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:32
+#: analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:33
+#: analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1258,7 +1258,7 @@ msgid ""
 "coleções."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:37
+#: analytics/templates/website/faq.mako:37
 msgid ""
 "Estão sendo contabilizados indicadores de publicação das coleções com "
 "base nos metadados fornecidos durante todo o processo de publicação de um"
@@ -1266,108 +1266,108 @@ msgid ""
 "ligada a qualidade dos processos implementados por cada uma das coleções."
 msgstr ""
 
-#: /app/analytics/templates/website/faq.mako:41
+#: analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr ""
 
-#: /app/analytics/templates/website/home_collection.mako:7
-#: /app/analytics/templates/website/home_journal.mako:7
-#: /app/analytics/templates/website/home_network.mako:7
-#: /app/analytics/templates/website/navbar_collection.mako:18
-#: /app/analytics/templates/website/navbar_journal.mako:18
-#: /app/analytics/templates/website/publication_size.mako:5
+#: analytics/templates/website/home_collection.mako:7
+#: analytics/templates/website/home_journal.mako:7
+#: analytics/templates/website/home_network.mako:7
+#: analytics/templates/website/navbar_collection.mako:18
+#: analytics/templates/website/navbar_journal.mako:18
+#: analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr ""
 
-#: /app/analytics/templates/website/home_collection.mako:24
-#: /app/analytics/templates/website/home_document.mako:21
-#: /app/analytics/templates/website/home_journal.mako:21
-#: /app/analytics/templates/website/home_network.mako:24
-#: /app/analytics/templates/website/navbar_collection.mako:9
-#: /app/analytics/templates/website/navbar_collection.mako:27
-#: /app/analytics/templates/website/navbar_document.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:26
+#: analytics/templates/website/home_collection.mako:24
+#: analytics/templates/website/home_document.mako:21
+#: analytics/templates/website/home_journal.mako:21
+#: analytics/templates/website/home_network.mako:24
+#: analytics/templates/website/navbar_collection.mako:9
+#: analytics/templates/website/navbar_collection.mako:27
+#: analytics/templates/website/navbar_document.mako:9
+#: analytics/templates/website/navbar_journal.mako:9
+#: analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr ""
 
-#: /app/analytics/templates/website/home_document.mako:7
+#: analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr ""
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:6
+#: analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr ""
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:11
+#: analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:20
+#: analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:11
-#: /app/analytics/templates/website/navbar_journal.mako:11
+#: analytics/templates/website/navbar_collection.mako:11
+#: analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:12
-#: /app/analytics/templates/website/navbar_journal.mako:12
+#: analytics/templates/website/navbar_collection.mako:12
+#: analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:16
-#: /app/analytics/templates/website/navbar_journal.mako:16
+#: analytics/templates/website/navbar_collection.mako:16
+#: analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:19
+#: analytics/templates/website/navbar_collection.mako:19
+#: analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:20
-#: /app/analytics/templates/website/navbar_journal.mako:20
+#: analytics/templates/website/navbar_collection.mako:20
+#: analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:21
+#: analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:25
-#: /app/analytics/templates/website/navbar_document.mako:13
-#: /app/analytics/templates/website/navbar_journal.mako:24
+#: analytics/templates/website/navbar_collection.mako:25
+#: analytics/templates/website/navbar_document.mako:13
+#: analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:32
-#: /app/analytics/templates/website/navbar_journal.mako:34
+#: analytics/templates/website/navbar_collection.mako:32
+#: analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:34
-#: /app/analytics/templates/website/navbar_journal.mako:36
+#: analytics/templates/website/navbar_collection.mako:34
+#: analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:35
-#: /app/analytics/templates/website/navbar_journal.mako:37
+#: analytics/templates/website/navbar_collection.mako:35
+#: analytics/templates/website/navbar_journal.mako:37
 msgid "Indicadores Gerais"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_collection.mako:39
-#: /app/analytics/templates/website/navbar_document.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:41
+#: analytics/templates/website/navbar_collection.mako:39
+#: analytics/templates/website/navbar_document.mako:19
+#: analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr ""
 
-#: /app/analytics/templates/website/navbar_document.mako:15
+#: analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:17
+#: analytics/templates/website/publication_article.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso. "
 "Os números são relacionados a coleção ou ao periódico quando um periódico"
@@ -1376,12 +1376,12 @@ msgid ""
 " creative commons."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:24
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
+#: analytics/templates/website/publication_article.mako:24
+#: analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:36
+#: analytics/templates/website/publication_article.mako:36
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por área de "
 "atuação. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1394,7 +1394,7 @@ msgid ""
 "extração de indicadores de Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:55
+#: analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1402,12 +1402,12 @@ msgid ""
 "Citation Index e documentados no SciELO Publishing Schema."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:61
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
+#: analytics/templates/website/publication_article.mako:61
+#: analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:73
+#: analytics/templates/website/publication_article.mako:73
 msgid ""
 "Este gráfico apresenta o total de documentos por idioma de publicação. Os"
 " números são relacionados a coleção ou ao periódico quando um periódico é"
@@ -1416,23 +1416,23 @@ msgid ""
 "documento pode ser publicado em mais de um idioma."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:79
+#: analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:91
+#: analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
 "um periódico é selecionado."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:97
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
+#: analytics/templates/website/publication_article.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:109
+#: analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
@@ -1440,11 +1440,11 @@ msgid ""
 "documento pode ter mais um país de afiliação."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:115
+#: analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:127
+#: analytics/templates/website/publication_article.mako:127
 msgid ""
 "Este mapa apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste mapa não podem ser "
@@ -1452,25 +1452,25 @@ msgid ""
 "documento pode ter mais um país de afiliação."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:145
+#: analytics/templates/website/publication_article.mako:145
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
 "periódico é selecionado."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:151
+#: analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:163
+#: analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
+#: analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
@@ -1479,7 +1479,7 @@ msgid ""
 "licenças de uso creative commons."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
+#: analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por área de atuação e"
 " ano de publicação. Os números são relacionados a coleção ou ao periódico"
@@ -1490,14 +1490,14 @@ msgid ""
 "Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
+#: analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por tipo de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
 "ao periódico quando um periódico é selecionado."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+#: analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por idioma de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1507,7 +1507,7 @@ msgid ""
 "mais de um idioma."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+#: analytics/templates/website/publication_article_by_publication_year.mako:91
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por país de afiliação"
 " dos autores e ano de publicação. Os números são relacionados a coleção "
@@ -1517,27 +1517,27 @@ msgid ""
 "mais de um país de afiliação."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:5
+#: analytics/templates/website/publication_journal.mako:5
 msgid "Licenças de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:10
+#: analytics/templates/website/publication_journal.mako:10
 msgid "Áreas temáticas dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:15
+#: analytics/templates/website/publication_journal.mako:15
 msgid "Ano de inclusão de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:19
+#: analytics/templates/website/publication_journal.mako:19
 msgid "Situação de publicação dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+#: analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por licença de uso adotada."
 " Os valores totais de periódicos deste gráfico não podem ser considerados"
@@ -1546,7 +1546,7 @@ msgid ""
 "indicadores de Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_status.mako:17
+#: analytics/templates/website/publication_journal_status.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por status da publicação no"
 " SciELO. O status considerado neste grafíco é o status vigente do "
@@ -1555,7 +1555,7 @@ msgid ""
 " extração de indicadores de Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
+#: analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
 "gráfico é recomendado para extração de indicadores de Coleção. As áreas "
@@ -1568,41 +1568,41 @@ msgid ""
 "Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_year.mako:17
+#: analytics/templates/website/publication_journal_year.mako:17
 msgid ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size.mako:11
-#: /app/analytics/templates/website/publication_size.mako:22
-#: /app/analytics/templates/website/publication_size.mako:33
-#: /app/analytics/templates/website/publication_size.mako:44
+#: analytics/templates/website/publication_size.mako:11
+#: analytics/templates/website/publication_size.mako:22
+#: analytics/templates/website/publication_size.mako:33
+#: analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size.mako:14
+#: analytics/templates/website/publication_size.mako:14
 msgid ""
 "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
 " quando um periódico é selecionado na barra superior do site."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size.mako:25
+#: analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
 "um periódico é selecionado na barra superior do site."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size.mako:36
+#: analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size.mako:47
+#: analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
 "citadas nos documentos publicados. Os números são relacionados a coleção "
@@ -1610,27 +1610,27 @@ msgid ""
 "site."
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size_citations.mako:9
+#: analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size_documents.mako:9
+#: analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size_issues.mako:9
+#: analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_size_journals.mako:10
+#: analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:5
+#: analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:7
+#: analytics/templates/website/reports.mako:7
 msgid ""
 "O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
 "metadados utilizados para produção dos indicadores presentes nesta "
@@ -1638,51 +1638,51 @@ msgid ""
 "análises bibliométricas de acordo com suas necessidade."
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:10
+#: analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:16
+#: analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:18
+#: analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:19
+#: analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:20
+#: analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr ""
 
-#: /app/analytics/templates/website/reports.mako:23
+#: analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr ""
 
-#: /app/analytics/templates/website/share.mako:8
+#: analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr ""
 
-#: /app/analytics/templates/website/share.mako:10
+#: analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr ""
 
-#: /app/analytics/templates/website/share.mako:13
+#: analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr ""
 
-#: /app/analytics/templates/website/share.mako:16
+#: analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr ""
 

--- a/analytics/locale/en/LC_MESSAGES/analytics.po
+++ b/analytics/locale/en/LC_MESSAGES/analytics.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-09-17 18:21+0000\n"
+"POT-Creation-Date: 2019-09-18 12:50+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
 "Language: en\n"
@@ -23,421 +23,421 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.1\n"
 
-#: /app/analytics/charts_config.py:25
+#: analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Source: SciELO.org"
 
-#: /app/analytics/charts_config.py:58
+#: analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr "Documents access year"
 
-#: /app/analytics/charts_config.py:59
+#: analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr "Documents publication year"
 
-#: /app/analytics/charts_config.py:91
+#: analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Publishing year of the journal documents. (cited)"
 
-#: /app/analytics/charts_config.py:92
+#: analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Publishing year of the SciELO Network documents. (citing)"
 
-#: /app/analytics/charts_config.py:100
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: analytics/charts_config.py:100
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+#: analytics/charts_config.py:103 analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
-#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
-#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
+#: analytics/charts_config.py:113 analytics/charts_config.py:135
+#: analytics/charts_config.py:157 analytics/charts_config.py:179
+#: analytics/charts_config.py:202 analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Base year"
 
-#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
-#: /app/analytics/charts_config.py:134
+#: analytics/charts_config.py:122 analytics/charts_config.py:125
+#: analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
-#: /app/analytics/charts_config.py:156
+#: analytics/charts_config.py:144 analytics/charts_config.py:147
+#: analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
-#: /app/analytics/charts_config.py:178
+#: analytics/charts_config.py:166 analytics/charts_config.py:169
+#: analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr "Impact factor JCR"
 
-#: /app/analytics/charts_config.py:188
+#: analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Source: Google Scholar"
 
-#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
-#: /app/analytics/charts_config.py:201
+#: analytics/charts_config.py:189 analytics/charts_config.py:192
+#: analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "H5M5 Metrics"
 
-#: /app/analytics/charts_config.py:211
+#: analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "immediacy"
 
-#: /app/analytics/charts_config.py:212
-#: /app/analytics/templates/website/access_datepicker.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: analytics/charts_config.py:212
+#: analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "1 year"
 
-#: /app/analytics/charts_config.py:213
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/charts_config.py:213
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 years"
 
-#: /app/analytics/charts_config.py:214
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/charts_config.py:214
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 years"
 
-#: /app/analytics/charts_config.py:215
+#: analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 years"
 
-#: /app/analytics/charts_config.py:216
+#: analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 years"
 
-#: /app/analytics/charts_config.py:223
+#: analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "SciELO Impact in 1, 2, 3, 4, 5 years and Immediacity index"
 
-#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
-#: /app/analytics/templates/website/bibliometrics_journal.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: analytics/charts_config.py:226 analytics/charts_config.py:228
+#: analytics/templates/website/bibliometrics_journal.mako:23
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "SciELO Impact"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citation"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Granted citations"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Received citations"
 
-#: /app/analytics/charts_config.py:244
+#: analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribution of granted, received and auto citations"
 
-#: /app/analytics/charts_config.py:251
+#: analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Number of citations"
 
-#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
-#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
-#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
-#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
-#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
-#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
-#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: analytics/charts_config.py:256 analytics/charts_config.py:273
+#: analytics/charts_config.py:287 analytics/charts_config.py:414
+#: analytics/charts_config.py:423 analytics/charts_config.py:438
+#: analytics/charts_config.py:446 analytics/charts_config.py:494
+#: analytics/charts_config.py:503 analytics/charts_config.py:562
+#: analytics/charts_config.py:572 analytics/charts_config.py:614
+#: analytics/charts_config.py:623 analytics/charts_config.py:664
+#: analytics/charts_config.py:672 analytics/charts_config.py:788
+#: analytics/templates/website/central_container_for_article_filters.mako:13
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Publishing year"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Citable documents"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Non citable documents"
 
-#: /app/analytics/charts_config.py:272
+#: analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribution of citable and non citable documents"
 
-#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
-#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
-#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
-#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
-#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
-#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
-#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
-#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
+#: analytics/charts_config.py:281 analytics/charts_config.py:305
+#: analytics/charts_config.py:324 analytics/charts_config.py:341
+#: analytics/charts_config.py:388 analytics/charts_config.py:412
+#: analytics/charts_config.py:441 analytics/charts_config.py:467
+#: analytics/charts_config.py:492 analytics/charts_config.py:540
+#: analytics/charts_config.py:560 analytics/charts_config.py:568
+#: analytics/charts_config.py:591 analytics/charts_config.py:612
+#: analytics/charts_config.py:662 analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Number of documents"
 
-#: /app/analytics/charts_config.py:298
+#: analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Documents distribution by number of bibliographic references"
 
-#: /app/analytics/charts_config.py:301
+#: analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Bibliographic references"
 
-#: /app/analytics/charts_config.py:308
+#: analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documents with %s bibliographic references"
 
-#: /app/analytics/charts_config.py:317
+#: analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Documents distribution by number of author"
 
-#: /app/analytics/charts_config.py:320
-#: /app/analytics/templates/website/publication_article.mako:133
+#: analytics/charts_config.py:320
+#: analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Number of authors"
 
-#: /app/analytics/charts_config.py:327
+#: analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documents with %s authors"
 
-#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
+#: analytics/charts_config.py:338 analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr "Distribution by authors affiliation countries"
 
-#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
-#: /app/analytics/charts_config.py:694
+#: analytics/charts_config.py:359 analytics/charts_config.py:391
+#: analytics/charts_config.py:446 analytics/charts_config.py:470
+#: analytics/charts_config.py:543 analytics/charts_config.py:594
+#: analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documents"
 
-#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
-#: /app/analytics/charts_config.py:391
+#: analytics/charts_config.py:368 analytics/charts_config.py:383
+#: analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "Affiliation countries"
 
-#: /app/analytics/charts_config.py:404
+#: analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr "Distribution by authors affiliation countries and publication year"
 
-#: /app/analytics/charts_config.py:437
+#: analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Documents distribution by publishing years"
 
-#: /app/analytics/charts_config.py:459
+#: analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribution by languages"
 
-#: /app/analytics/charts_config.py:462
+#: analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Publishing languages"
 
-#: /app/analytics/charts_config.py:470
+#: analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Document Language"
 
-#: /app/analytics/charts_config.py:484
+#: analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribution by language and publication year"
 
-#: /app/analytics/charts_config.py:514
+#: analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Journals distribution by the inclusion year at SciELO"
 
-#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
+#: analytics/charts_config.py:515 analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Inclusion year"
 
-#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
-#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+#: analytics/charts_config.py:518 analytics/charts_config.py:642
+#: analytics/charts_config.py:711 analytics/charts_config.py:731
 msgid "Número de periódicos"
 msgstr "Number of journals"
 
-#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
-#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
-#: /app/analytics/templates/website/navbar_collection.mako:10
-#: /app/analytics/templates/website/navbar_journal.mako:10
+#: analytics/charts_config.py:523 analytics/charts_config.py:645
+#: analytics/charts_config.py:714 analytics/charts_config.py:734
+#: analytics/templates/website/navbar_collection.mako:10
+#: analytics/templates/website/navbar_journal.mako:10
 msgid "Periódicos"
 msgstr "Journals"
 
-#: /app/analytics/charts_config.py:532
+#: analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Documents distribution by suject areas"
 
-#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
+#: analytics/charts_config.py:535 analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Subject areas"
 
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
+#: analytics/charts_config.py:543 analytics/charts_config.py:714
+#: analytics/templates/website/central_container_for_article_filters.mako:30
+#: analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Subject area"
 
-#: /app/analytics/charts_config.py:552
+#: analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribution by subject area and publication year"
 
-#: /app/analytics/charts_config.py:583
+#: analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Documents distribution by document type"
 
-#: /app/analytics/charts_config.py:586
-#: /app/analytics/templates/website/publication_article.mako:43
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
+#: analytics/charts_config.py:586
+#: analytics/templates/website/publication_article.mako:43
+#: analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Document types"
 
-#: /app/analytics/charts_config.py:594
+#: analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Document type"
 
-#: /app/analytics/charts_config.py:604
+#: analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Documents distribution by publishing year"
 
-#: /app/analytics/charts_config.py:634
+#: analytics/charts_config.py:634
 msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
 msgstr "Journals distribution by current status at SciELO"
 
-#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+#: analytics/charts_config.py:637 analytics/charts_config.py:645
 msgid "Situação da publicação"
 msgstr "Publishing status"
 
-#: /app/analytics/charts_config.py:654
+#: analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Documents distribution by use license and publication year"
 
-#: /app/analytics/charts_config.py:683
+#: analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Documents distribution by use licenses"
 
-#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
-#: /app/analytics/templates/website/publication_article.mako:5
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
+#: analytics/charts_config.py:686 analytics/charts_config.py:726
+#: analytics/templates/website/publication_article.mako:5
+#: analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Use licenses"
 
-#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
+#: analytics/charts_config.py:694 analytics/charts_config.py:734
 msgid "Licença"
 msgstr "license"
 
-#: /app/analytics/charts_config.py:703
+#: analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribution by subject areas"
 
-#: /app/analytics/charts_config.py:723
+#: analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Journals distribution by use licenses"
 
-#: /app/analytics/charts_config.py:742
+#: analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total accesses by year and month"
 
-#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
-#: /app/analytics/templates/website/navbar_collection.mako:7
-#: /app/analytics/templates/website/navbar_document.mako:7
-#: /app/analytics/templates/website/navbar_journal.mako:7
+#: analytics/charts_config.py:750 analytics/charts_config.py:785
+#: analytics/templates/website/navbar_collection.mako:7
+#: analytics/templates/website/navbar_document.mako:7
+#: analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesses"
 
-#: /app/analytics/charts_config.py:756
+#: analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesses at"
 
-#: /app/analytics/charts_config.py:767
+#: analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total accesses by document type"
 
-#: /app/analytics/charts_config.py:771
+#: analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesses for documents of the type %s"
 
-#: /app/analytics/charts_config.py:783
+#: analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Articles lifetime by number of accesses at"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Reference year"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesses to documents from %s"
 
-#: /app/analytics/templates/website/access_by_document_type.mako:6
-#: /app/analytics/templates/website/access_by_month_and_year.mako:5
-#: /app/analytics/templates/website/access_lifetime.mako:6
-#: /app/analytics/templates/website/accesses_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_authors.mako:5
-#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
-#: /app/analytics/templates/website/publication_article_document_type.mako:5
-#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_languages.mako:5
-#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_licenses.mako:5
-#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_references.mako:5
-#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
-#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: /app/analytics/templates/website/publication_article_year.mako:5
-#: /app/analytics/templates/website/publication_journal_licenses.mako:7
-#: /app/analytics/templates/website/publication_journal_status.mako:7
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
-#: /app/analytics/templates/website/publication_journal_year.mako:7
-#: /app/analytics/templates/website/publication_size_citations.mako:6
-#: /app/analytics/templates/website/publication_size_documents.mako:6
-#: /app/analytics/templates/website/publication_size_issues.mako:6
-#: /app/analytics/templates/website/publication_size_journals.mako:6
+#: analytics/templates/website/access_by_document_type.mako:6
+#: analytics/templates/website/access_by_month_and_year.mako:5
+#: analytics/templates/website/access_lifetime.mako:6
+#: analytics/templates/website/accesses_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: analytics/templates/website/publication_article_affiliations.mako:5
+#: analytics/templates/website/publication_article_affiliations_map.mako:5
+#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: analytics/templates/website/publication_article_authors.mako:5
+#: analytics/templates/website/publication_article_citable_documents.mako:5
+#: analytics/templates/website/publication_article_document_type.mako:5
+#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: analytics/templates/website/publication_article_languages.mako:5
+#: analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: analytics/templates/website/publication_article_licenses.mako:5
+#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: analytics/templates/website/publication_article_references.mako:5
+#: analytics/templates/website/publication_article_subject_areas.mako:6
+#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: analytics/templates/website/publication_article_year.mako:5
+#: analytics/templates/website/publication_journal_licenses.mako:7
+#: analytics/templates/website/publication_journal_status.mako:7
+#: analytics/templates/website/publication_journal_subject_areas.mako:7
+#: analytics/templates/website/publication_journal_year.mako:7
+#: analytics/templates/website/publication_size_citations.mako:6
+#: analytics/templates/website/publication_size_documents.mako:6
+#: analytics/templates/website/publication_size_issues.mako:6
+#: analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "loading"
 
-#: /app/analytics/templates/website/access_datepicker.mako:5
+#: analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Period"
 
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "Accesses in the last 36 months"
 
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "Accesses in the last 24 months"
 
-#: /app/analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "Accesses in the las 12 months"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "all availalble data"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "all"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Select the access period"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
 "recuperação dos dados de acesso. Você pode também selecionar o período de"
@@ -448,96 +448,96 @@ msgstr ""
 "data. You can choose the period of 1, 2 and 3 years through the fast "
 "links or all the available accesses choosing all."
 
-#: /app/analytics/templates/website/access_list_articles.mako:6
+#: analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 articles by number of accesses"
 
-#: /app/analytics/templates/website/access_list_articles.mako:9
+#: analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "article"
 
-#: /app/analytics/templates/website/access_list_articles.mako:13
-#: /app/analytics/templates/website/access_list_issues.mako:13
-#: /app/analytics/templates/website/access_list_journals.mako:13
+#: analytics/templates/website/access_list_articles.mako:13
+#: analytics/templates/website/access_list_issues.mako:13
+#: analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "abstract"
 
-#: /app/analytics/templates/website/access_list_articles.mako:14
-#: /app/analytics/templates/website/access_list_issues.mako:14
-#: /app/analytics/templates/website/access_list_journals.mako:14
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
+#: analytics/templates/website/access_list_articles.mako:14
+#: analytics/templates/website/access_list_issues.mako:14
+#: analytics/templates/website/access_list_journals.mako:14
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: analytics/templates/website/bibliometrics_list_granted.mako:19
+#: analytics/templates/website/bibliometrics_list_granted.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: analytics/templates/website/bibliometrics_list_received.mako:26
+#: analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: /app/analytics/templates/website/access_list_issues.mako:6
+#: analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 issues by accesses"
 
-#: /app/analytics/templates/website/access_list_issues.mako:9
-#: /app/analytics/templates/website/access_list_journals.mako:9
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: analytics/templates/website/access_list_issues.mako:9
+#: analytics/templates/website/access_list_journals.mako:9
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "previous"
 
-#: /app/analytics/templates/website/access_list_journals.mako:6
+#: analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesses to the journals documents"
 
-#: /app/analytics/templates/website/accesses.mako:6
+#: analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr "Site usage chart"
 
-#: /app/analytics/templates/website/accesses.mako:12
+#: analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr "Usage heat chart"
 
-#: /app/analytics/templates/website/accesses.mako:18
+#: analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:15
+#: analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr "Accesses to documents"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr "Documents published at"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr "have had"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr "accesses at"
 
-#: /app/analytics/templates/website/base.mako:6
+#: analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Analytics"
 
-#: /app/analytics/templates/website/base.mako:30
+#: analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Collections"
 
-#: /app/analytics/templates/website/base.mako:38
-#: /app/analytics/templates/website/journal_selector_modal.mako:7
+#: analytics/templates/website/base.mako:38
+#: analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "select a journal"
 
-#: /app/analytics/templates/website/base.mako:91
+#: analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "This tool is under development and it is available in Beta Test version"
 
-#: /app/analytics/templates/website/base.mako:93
+#: analytics/templates/website/base.mako:93
 msgid ""
 "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
 " realizar testes de uso e performance. Todos os indicadores carregados "
@@ -549,214 +549,214 @@ msgstr ""
 " gradually being loaded. Slowness and out of service problems may occur "
 "in this version."
 
-#: /app/analytics/templates/website/base.mako:114
+#: analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Help"
 
-#: /app/analytics/templates/website/base.mako:116
+#: analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Report Errors"
 
-#: /app/analytics/templates/website/base.mako:117
+#: analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Discuss mailing list"
 
-#: /app/analytics/templates/website/base.mako:121
+#: analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Developments"
 
-#: /app/analytics/templates/website/base.mako:124
+#: analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Developments mailing list"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "January"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "February"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "March"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "April"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "May"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "June"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "July"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "August"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "September"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "October"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "November"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Dicember"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Jan"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Apr"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Aug"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Received Citations"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "publishing year"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "first author"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "document title"
 
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "received citations"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
+#: analytics/templates/website/bibliometrics_journal.mako:8
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: analytics/templates/website/bibliometrics_list_granted.mako:8
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Warning"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
+#: analytics/templates/website/bibliometrics_journal.mako:11
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: analytics/templates/website/bibliometrics_list_granted.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "It is necessary to choose one journal for bibliometrics indicators"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:20
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
+#: analytics/templates/website/bibliometrics_journal.mako:20
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: analytics/templates/website/bibliometrics_list_received.mako:19
+#: analytics/templates/website/central_container_for_article_filters.mako:16
+#: analytics/templates/website/central_container_for_article_filters.mako:33
+#: analytics/templates/website/central_container_for_article_filters.mako:52
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "apply"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:32
-#: /app/analytics/templates/website/bibliometrics_journal.mako:51
-#: /app/analytics/templates/website/bibliometrics_journal.mako:69
-#: /app/analytics/templates/website/bibliometrics_journal.mako:87
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: /app/analytics/templates/website/publication_article.mako:14
-#: /app/analytics/templates/website/publication_article.mako:33
-#: /app/analytics/templates/website/publication_article.mako:52
-#: /app/analytics/templates/website/publication_article.mako:70
-#: /app/analytics/templates/website/publication_article.mako:88
-#: /app/analytics/templates/website/publication_article.mako:106
-#: /app/analytics/templates/website/publication_article.mako:124
-#: /app/analytics/templates/website/publication_article.mako:142
-#: /app/analytics/templates/website/publication_article.mako:160
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
-#: /app/analytics/templates/website/publication_journal_licenses.mako:14
-#: /app/analytics/templates/website/publication_journal_status.mako:14
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
-#: /app/analytics/templates/website/publication_journal_year.mako:14
+#: analytics/templates/website/bibliometrics_journal.mako:32
+#: analytics/templates/website/bibliometrics_journal.mako:51
+#: analytics/templates/website/bibliometrics_journal.mako:69
+#: analytics/templates/website/bibliometrics_journal.mako:87
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: analytics/templates/website/publication_article.mako:14
+#: analytics/templates/website/publication_article.mako:33
+#: analytics/templates/website/publication_article.mako:52
+#: analytics/templates/website/publication_article.mako:70
+#: analytics/templates/website/publication_article.mako:88
+#: analytics/templates/website/publication_article.mako:106
+#: analytics/templates/website/publication_article.mako:124
+#: analytics/templates/website/publication_article.mako:142
+#: analytics/templates/website/publication_article.mako:160
+#: analytics/templates/website/publication_article_by_publication_year.mako:14
+#: analytics/templates/website/publication_article_by_publication_year.mako:33
+#: analytics/templates/website/publication_article_by_publication_year.mako:52
+#: analytics/templates/website/publication_article_by_publication_year.mako:70
+#: analytics/templates/website/publication_article_by_publication_year.mako:88
+#: analytics/templates/website/publication_article_by_publication_year.mako:106
+#: analytics/templates/website/publication_journal_licenses.mako:14
+#: analytics/templates/website/publication_journal_status.mako:14
+#: analytics/templates/website/publication_journal_subject_areas.mako:14
+#: analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "About the chart"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:35
+#: analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
@@ -767,12 +767,12 @@ msgstr ""
 "immediacy period, including the impact factor for 1 to 5 years. The 2 "
 "years line refers to the Thomson Reuters impact factor."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:42
+#: analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr "Citable and non citable documents"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:54
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
+#: analytics/templates/website/bibliometrics_journal.mako:54
+#: analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
 "Este gráfico apresenta a distribuição de documentos citáveis e não "
 "citáveis relacionados ao periódico selecionado. De acordo com as regras "
@@ -788,11 +788,11 @@ msgstr ""
 " \"Article Commentary\". Other types of documents are considered not "
 "citable."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+#: analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:72
+#: analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
 "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
 "indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
@@ -802,15 +802,15 @@ msgid ""
 msgstr ""
 "This chart shows the Google Scholar H5 and M5 indicators. These "
 "indicators are yearly supplied by the Google Scholar. The absent of "
-"indicators for specific journals or in a period of a specific journal may "
-"occurs. Once clicking in a series, the user will be redirected to the Google "
-"Scholar website."
+"indicators for specific journals or in a period of a specific journal may"
+" occurs. Once clicking in a series, the user will be redirected to the "
+"Google Scholar website."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:78
+#: analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr "Granted, received and auto citing"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:90
+#: analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
@@ -819,106 +819,106 @@ msgstr ""
 "This chart show the number of granted, received and auto citations of the"
 " selected journal, the data is distributed by publication year."
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:27
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr "Altmetric indicators"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr "There are no Altimetric indicators for this journal"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr "There are no Altmetric indicators for this journal in this time frame"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr "Posts"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr "Score sum"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr "Score median"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr "Score sum at this timeframe"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr "Score median at this timeframe"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:28
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr "JCR Indicators"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr "There are no JCR indicators for this journal"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr "Impact factor"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr "All years data"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr "Total of citations"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr "FI 2 years"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr "FI 2 years without self citing"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr "FI 5 years"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr "Immediacity index"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr "Citing half life"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr "Normalized Eigen Factor"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:29
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Heat chart for received citations"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
@@ -928,232 +928,232 @@ msgstr ""
 " The corpus of citations is compounded of all the SciELO Network "
 "collections, the Thematic collections and Indenpendent collections."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Citing list for the selected period"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citing"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Cited"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "document"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Choose the axis x/y to gather the list of citations for the journal."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Journal received citations"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "SciELO Network documents published at"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "cited"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "times the documents of the journal"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "published at"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Click the axis to see the articles citing list."
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Matching citing forms for the selected journal"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: analytics/templates/website/bibliometrics_list_granted.mako:18
+#: analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "title"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acctions"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "report error"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: analytics/templates/website/bibliometrics_list_granted.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "without results"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:30
-#: /app/analytics/templates/website/navbar_journal.mako:32
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: analytics/templates/website/navbar_collection.mako:30
+#: analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Half life Citations"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citations at"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "for publications from"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Total citations"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Half life"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citations"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "percentage"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "acummulated percentage"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:5
 msgid "Indicadores Bibliométricos da Rede SciELO"
 msgstr "SciELO Network Bibliometric Indicators"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid "Periodicidade de atualização:"
 msgstr "Updating periodicity:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid " anual"
 msgstr " yearly"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:13
 msgid "Indicadores de Publicação"
 msgstr "Publication Indicators"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:19
 msgid "Numeros da Rede SciELO por:"
 msgstr "Numbers of SciELO Network by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:54
 msgid "Ano de publicação: "
 msgstr "Publication year: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:35
 msgid "Periódico: "
 msgstr "Journal: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:55
 msgid "Assunto: "
 msgstr "Subject: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:24
 msgid "País de afiliação do autor: "
 msgstr "Author’s affiliation country: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:26
 msgid "País de Afiliação do Autor por: "
 msgstr "Author’s Affiliation Country by: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:30
 msgid "País de publicação da revista: "
 msgstr "Journal's country of publication: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:33
 msgid "Número de Co-autores por: "
 msgstr "Number of Co-authors by: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:46
 msgid "Indicadores de Coleção"
 msgstr "Collection Indicators"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:52
 msgid "Periódico por:"
 msgstr "Journal by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:56
 msgid "Indicadores gerais: "
 msgstr "General indicators: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:66
 msgid "Indicadores de Citação"
 msgstr "Citation Indicators"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:72
 msgid "Ano de Citação por:"
 msgstr "Citing Year by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:90
 msgid "Idade do documento citado: "
 msgstr "Cited document age: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:91
 msgid "Tipo de documento citado: "
 msgstr "Cited document type: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:77
 msgid "Periódico Citante por:"
 msgstr "Citing Journal by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:82
 msgid "Assunto do Periódico Citante por:"
 msgstr "Citing Journal's Subject by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:92
 msgid "Periódico SciELO citado: "
 msgstr "Cited SciELO journal: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:88
 msgid "País de Afiliação do Autor Citante por:"
 msgstr "Citing Author's Affiliation Country by:"
 
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
+#: analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Granted citations by journal"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:29
-#: /app/analytics/templates/website/navbar_journal.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: analytics/templates/website/navbar_collection.mako:29
+#: analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "SciELO Impact in 1, 2, 3, 4, and 5 years"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documents published at"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
 "Aqui são considerados apenas os documentos citáveis. De acordo com as "
 "regras de contagem do SciELO, documentos citáveis devem ser do tipo "
@@ -1167,55 +1167,55 @@ msgstr ""
 "and Article Commentary. Other types of documents are considered not "
 "citable."
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 years"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 years"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 years"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 years"
 
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:33
-#: /app/analytics/templates/website/navbar_journal.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:22
+#: analytics/templates/website/navbar_collection.mako:33
+#: analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Received citations by journals"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: analytics/templates/website/central_container_for_article_filters.mako:8
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Documents filters"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: analytics/templates/website/central_container_for_article_filters.mako:22
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "period"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
+#: analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Language"
 
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
+#: analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Journals filters"
 
-#: /app/analytics/templates/website/faq.mako:5
+#: analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Frequent Questions (Accesses)"
 
-#: /app/analytics/templates/website/faq.mako:7
+#: analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "Why some collections do not have site usage indicators?"
 
-#: /app/analytics/templates/website/faq.mako:8
+#: analytics/templates/website/faq.mako:8
 msgid ""
 "Para que os dados de acessos sejam computados é necessário que os logs de"
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
@@ -1225,13 +1225,13 @@ msgstr ""
 " send for processing. The absense of usage indicators must be notified "
 "for the coordinators of the specific SciELO collection."
 
-#: /app/analytics/templates/website/faq.mako:11
+#: analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr ""
 "Why the available periods of the usage indicators differs from one "
 "collection to another?"
 
-#: /app/analytics/templates/website/faq.mako:12
+#: analytics/templates/website/faq.mako:12
 msgid ""
 "O período disponível de cada uma das coleções depende do período "
 "disponível dos logs de acessos de cada uma das coleções. Este projeto se "
@@ -1243,12 +1243,12 @@ msgstr ""
 "undertakes to compute the site usage data from 2012, once the logs are "
 "properly provided by the collections."
 
-#: /app/analytics/templates/website/faq.mako:15
-#: /app/analytics/templates/website/faq.mako:36
+#: analytics/templates/website/faq.mako:15
+#: analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "What is being computed?"
 
-#: /app/analytics/templates/website/faq.mako:16
+#: analytics/templates/website/faq.mako:16
 msgid ""
 "Estão sendo contabilizados e classificados os acessos ao texto completo "
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
@@ -1258,7 +1258,7 @@ msgstr ""
 "PDF, EPDF (ReadCube), besides the accesses to the abstract pages in the "
 "website."
 
-#: /app/analytics/templates/website/faq.mako:19
+#: analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
@@ -1266,13 +1266,13 @@ msgstr ""
 "Why the indicators of this tool differs from the indicators delivered by "
 "other SciELO sites?"
 
-#: /app/analytics/templates/website/faq.mako:21
+#: analytics/templates/website/faq.mako:21
 msgid ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
 msgstr "Some SciELO tools may still be using the old statistics service access."
 
-#: /app/analytics/templates/website/faq.mako:22
+#: analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
@@ -1280,30 +1280,30 @@ msgstr ""
 "The site usage accounting differs in a lot of aspects from the previous "
 "tool."
 
-#: /app/analytics/templates/website/faq.mako:23
+#: analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
 msgstr "Some tools have a delta of different updating access indicators."
 
-#: /app/analytics/templates/website/faq.mako:27
-#: /app/analytics/templates/website/faq.mako:40
+#: analytics/templates/website/faq.mako:27
+#: analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "What is the updating frequency of the indicators?"
 
-#: /app/analytics/templates/website/faq.mako:28
+#: analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Monthly"
 
-#: /app/analytics/templates/website/faq.mako:30
+#: analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "FAQ (Publishing)"
 
-#: /app/analytics/templates/website/faq.mako:32
+#: analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "Why some collections have out of date indicators?"
 
-#: /app/analytics/templates/website/faq.mako:33
+#: analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1314,7 +1314,7 @@ msgstr ""
 "SciELO collections. The update of these indicators is directly linked to "
 "the proper conduct of these processes by each of the collections."
 
-#: /app/analytics/templates/website/faq.mako:37
+#: analytics/templates/website/faq.mako:37
 msgid ""
 "Estão sendo contabilizados indicadores de publicação das coleções com "
 "base nos metadados fornecidos durante todo o processo de publicação de um"
@@ -1326,108 +1326,108 @@ msgstr ""
 "the total of publications of the collection once the documents may have "
 "more than one affiliation country."
 
-#: /app/analytics/templates/website/faq.mako:41
+#: analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Weekly"
 
-#: /app/analytics/templates/website/home_collection.mako:7
-#: /app/analytics/templates/website/home_journal.mako:7
-#: /app/analytics/templates/website/home_network.mako:7
-#: /app/analytics/templates/website/navbar_collection.mako:18
-#: /app/analytics/templates/website/navbar_journal.mako:18
-#: /app/analytics/templates/website/publication_size.mako:5
+#: analytics/templates/website/home_collection.mako:7
+#: analytics/templates/website/home_journal.mako:7
+#: analytics/templates/website/home_network.mako:7
+#: analytics/templates/website/navbar_collection.mako:18
+#: analytics/templates/website/navbar_journal.mako:18
+#: analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Collection composition"
 
-#: /app/analytics/templates/website/home_collection.mako:24
-#: /app/analytics/templates/website/home_document.mako:21
-#: /app/analytics/templates/website/home_journal.mako:21
-#: /app/analytics/templates/website/home_network.mako:24
-#: /app/analytics/templates/website/navbar_collection.mako:9
-#: /app/analytics/templates/website/navbar_collection.mako:27
-#: /app/analytics/templates/website/navbar_document.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:26
+#: analytics/templates/website/home_collection.mako:24
+#: analytics/templates/website/home_document.mako:21
+#: analytics/templates/website/home_journal.mako:21
+#: analytics/templates/website/home_network.mako:24
+#: analytics/templates/website/navbar_collection.mako:9
+#: analytics/templates/website/navbar_collection.mako:27
+#: analytics/templates/website/navbar_document.mako:9
+#: analytics/templates/website/navbar_journal.mako:9
+#: analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Charts"
 
-#: /app/analytics/templates/website/home_document.mako:7
+#: analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Document indicators"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:6
+#: analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "close"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:11
+#: analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "choose a journal"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:20
+#: analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "select"
 
-#: /app/analytics/templates/website/navbar_collection.mako:11
-#: /app/analytics/templates/website/navbar_journal.mako:11
+#: analytics/templates/website/navbar_collection.mako:11
+#: analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 issues"
 
-#: /app/analytics/templates/website/navbar_collection.mako:12
-#: /app/analytics/templates/website/navbar_journal.mako:12
+#: analytics/templates/website/navbar_collection.mako:12
+#: analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 articles"
 
-#: /app/analytics/templates/website/navbar_collection.mako:16
-#: /app/analytics/templates/website/navbar_journal.mako:16
+#: analytics/templates/website/navbar_collection.mako:16
+#: analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publishing"
 
-#: /app/analytics/templates/website/navbar_collection.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:19
+#: analytics/templates/website/navbar_collection.mako:19
+#: analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Documents charts"
 
-#: /app/analytics/templates/website/navbar_collection.mako:20
-#: /app/analytics/templates/website/navbar_journal.mako:20
+#: analytics/templates/website/navbar_collection.mako:20
+#: analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Documents charts by publishing year"
 
-#: /app/analytics/templates/website/navbar_collection.mako:21
+#: analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Journals charts"
 
-#: /app/analytics/templates/website/navbar_collection.mako:25
-#: /app/analytics/templates/website/navbar_document.mako:13
-#: /app/analytics/templates/website/navbar_journal.mako:24
+#: analytics/templates/website/navbar_collection.mako:25
+#: analytics/templates/website/navbar_document.mako:13
+#: analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometrics"
 
-#: /app/analytics/templates/website/navbar_collection.mako:32
-#: /app/analytics/templates/website/navbar_journal.mako:34
+#: analytics/templates/website/navbar_collection.mako:32
+#: analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Granted citations by journals"
 
-#: /app/analytics/templates/website/navbar_collection.mako:34
-#: /app/analytics/templates/website/navbar_journal.mako:36
+#: analytics/templates/website/navbar_collection.mako:34
+#: analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Journal citing forms"
 
-#: /app/analytics/templates/website/navbar_collection.mako:35
-#: /app/analytics/templates/website/navbar_journal.mako:37
+#: analytics/templates/website/navbar_collection.mako:35
+#: analytics/templates/website/navbar_journal.mako:37
 msgid "Indicadores Gerais"
 msgstr "General Indicators"
 
-#: /app/analytics/templates/website/navbar_collection.mako:39
-#: /app/analytics/templates/website/navbar_document.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:41
+#: analytics/templates/website/navbar_collection.mako:39
+#: analytics/templates/website/navbar_document.mako:19
+#: analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Reports"
 
-#: /app/analytics/templates/website/navbar_document.mako:15
+#: analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Received citations"
 
-#: /app/analytics/templates/website/publication_article.mako:17
+#: analytics/templates/website/publication_article.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso. "
 "Os números são relacionados a coleção ou ao periódico quando um periódico"
@@ -1440,12 +1440,12 @@ msgstr ""
 "The availability of use license of indicators depends on the adoption of "
 "creative commons licences by the collection or the selected journal."
 
-#: /app/analytics/templates/website/publication_article.mako:24
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
+#: analytics/templates/website/publication_article.mako:24
+#: analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr "Subject areas"
 
-#: /app/analytics/templates/website/publication_article.mako:36
+#: analytics/templates/website/publication_article.mako:36
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por área de "
 "atuação. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1467,7 +1467,7 @@ msgstr ""
 "expertise. This graphical is recommended for collecting indicators "
 "extraction."
 
-#: /app/analytics/templates/website/publication_article.mako:55
+#: analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1479,12 +1479,12 @@ msgstr ""
 "Document types are the types used on the SciELO Citation Index and "
 "documented in SciELO Publishing Schema."
 
-#: /app/analytics/templates/website/publication_article.mako:61
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
+#: analytics/templates/website/publication_article.mako:61
+#: analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr "Documents languages"
 
-#: /app/analytics/templates/website/publication_article.mako:73
+#: analytics/templates/website/publication_article.mako:73
 msgid ""
 "Este gráfico apresenta o total de documentos por idioma de publicação. Os"
 " números são relacionados a coleção ou ao periódico quando um periódico é"
@@ -1498,11 +1498,11 @@ msgstr ""
 "considered as the total of publications of the collection once a document"
 " could be published in more than one language."
 
-#: /app/analytics/templates/website/publication_article.mako:79
+#: analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr "Publishing Years"
 
-#: /app/analytics/templates/website/publication_article.mako:91
+#: analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
@@ -1512,12 +1512,12 @@ msgstr ""
 " numbers are related to one collection or to one journal when it is "
 "selected."
 
-#: /app/analytics/templates/website/publication_article.mako:97
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
+#: analytics/templates/website/publication_article.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr "Affiliation countries"
 
-#: /app/analytics/templates/website/publication_article.mako:109
+#: analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
@@ -1529,11 +1529,11 @@ msgstr ""
 "the total of publications of the collection once the documents may have "
 "more than one affiliation country."
 
-#: /app/analytics/templates/website/publication_article.mako:115
+#: analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr "Map of affiliation countries"
 
-#: /app/analytics/templates/website/publication_article.mako:127
+#: analytics/templates/website/publication_article.mako:127
 msgid ""
 "Este mapa apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste mapa não podem ser "
@@ -1545,7 +1545,7 @@ msgstr ""
 "publications of the collection as a document can have more than one "
 "affiliation country."
 
-#: /app/analytics/templates/website/publication_article.mako:145
+#: analytics/templates/website/publication_article.mako:145
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1555,11 +1555,11 @@ msgstr ""
 "numbers are related to one collection or to one journal when it is "
 "selected."
 
-#: /app/analytics/templates/website/publication_article.mako:151
+#: analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr "Number of bibliographic references"
 
-#: /app/analytics/templates/website/publication_article.mako:163
+#: analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
@@ -1569,7 +1569,7 @@ msgstr ""
 " references. The numbers are related to one collection or to one journal "
 "when it is selected."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
+#: analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
@@ -1583,7 +1583,7 @@ msgstr ""
 "depends on the adoption of the journal collection or selected in creative"
 " commons licenses."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
+#: analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por área de atuação e"
 " ano de publicação. Os números são relacionados a coleção ou ao periódico"
@@ -1601,7 +1601,7 @@ msgstr ""
 "expertise. This graphical is recommended for collecting indicators "
 "extraction."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
+#: analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por tipo de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1611,7 +1611,7 @@ msgstr ""
 " document type. The numbers are related to one collection or to one "
 "journal when it is selected."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+#: analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por idioma de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1626,7 +1626,7 @@ msgstr ""
 " chart can not be considered as the total publications of the collection "
 "once a document is published in more than one language."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+#: analytics/templates/website/publication_article_by_publication_year.mako:91
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por país de afiliação"
 " dos autores e ano de publicação. Os números são relacionados a coleção "
@@ -1641,27 +1641,27 @@ msgstr ""
 "this chart can not be considered as the total of publications of the "
 "collection once the documents may have more than one affiliation country."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr "Received, granted and self citing"
 
-#: /app/analytics/templates/website/publication_journal.mako:5
+#: analytics/templates/website/publication_journal.mako:5
 msgid "Licenças de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:10
+#: analytics/templates/website/publication_journal.mako:10
 msgid "Áreas temáticas dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:15
+#: analytics/templates/website/publication_journal.mako:15
 msgid "Ano de inclusão de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:19
+#: analytics/templates/website/publication_journal.mako:19
 msgid "Situação de publicação dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+#: analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por licença de uso adotada."
 " Os valores totais de periódicos deste gráfico não podem ser considerados"
@@ -1674,7 +1674,7 @@ msgstr ""
 "because a document can be part of more than one area of expertise. This "
 "graphical is recommended for collecting indicators extraction."
 
-#: /app/analytics/templates/website/publication_journal_status.mako:17
+#: analytics/templates/website/publication_journal_status.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por status da publicação no"
 " SciELO. O status considerado neste grafíco é o status vigente do "
@@ -1688,7 +1688,7 @@ msgstr ""
 "changes across the existence of the journal in SciELO. This graphical is "
 "recommended for collecting indicators."
 
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
+#: analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
 "gráfico é recomendado para extração de indicadores de Coleção. As áreas "
@@ -1708,7 +1708,7 @@ msgstr ""
 "due to a document may be part of more than one area of expertise. This "
 "graphical is recommended for extracting indicators collection."
 
-#: /app/analytics/templates/website/publication_journal_year.mako:17
+#: analytics/templates/website/publication_journal_year.mako:17
 msgid ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
@@ -1716,14 +1716,14 @@ msgstr ""
 "This chart show the number of journals by the inclusion year at SciELO. "
 "This chart is recommended for collection indicators."
 
-#: /app/analytics/templates/website/publication_size.mako:11
-#: /app/analytics/templates/website/publication_size.mako:22
-#: /app/analytics/templates/website/publication_size.mako:33
-#: /app/analytics/templates/website/publication_size.mako:44
+#: analytics/templates/website/publication_size.mako:11
+#: analytics/templates/website/publication_size.mako:22
+#: analytics/templates/website/publication_size.mako:33
+#: analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "About the numbers"
 
-#: /app/analytics/templates/website/publication_size.mako:14
+#: analytics/templates/website/publication_size.mako:14
 msgid ""
 "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
@@ -1733,7 +1733,7 @@ msgstr ""
 " and published documents. The numbers are related to the collection or "
 "journal selected in the top bar of this website."
 
-#: /app/analytics/templates/website/publication_size.mako:25
+#: analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
@@ -1743,7 +1743,7 @@ msgstr ""
 "published document. The numbers are related to the collection or journal "
 "selected in the top bar of this website."
 
-#: /app/analytics/templates/website/publication_size.mako:36
+#: analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1753,7 +1753,7 @@ msgstr ""
 "numbers are related to the collection or journal selected in the top bar "
 "of this website."
 
-#: /app/analytics/templates/website/publication_size.mako:47
+#: analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
 "citadas nos documentos publicados. Os números são relacionados a coleção "
@@ -1764,27 +1764,27 @@ msgstr ""
 " in the published documents. The numbers are related to the collection or"
 " journal selected in the top bar of this website."
 
-#: /app/analytics/templates/website/publication_size_citations.mako:9
+#: analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "references"
 
-#: /app/analytics/templates/website/publication_size_documents.mako:9
+#: analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documents"
 
-#: /app/analytics/templates/website/publication_size_issues.mako:9
+#: analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "issues"
 
-#: /app/analytics/templates/website/publication_size_journals.mako:10
+#: analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "journals"
 
-#: /app/analytics/templates/website/reports.mako:5
+#: analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Spreadsheets"
 
-#: /app/analytics/templates/website/reports.mako:7
+#: analytics/templates/website/reports.mako:7
 msgid ""
 "O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
 "metadados utilizados para produção dos indicadores presentes nesta "
@@ -1795,50 +1795,51 @@ msgstr ""
 " the indicators available in this tool. Any interested people can "
 "download it to produce their own analysis."
 
-#: /app/analytics/templates/website/reports.mako:10
+#: analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "For more information about the caracteristics of each spreadsheet, access"
 
-#: /app/analytics/templates/website/reports.mako:16
+#: analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "file name"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "updating periodicity"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "monthly"
 
-#: /app/analytics/templates/website/reports.mako:18
+#: analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "file size"
 
-#: /app/analytics/templates/website/reports.mako:19
+#: analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "charset"
 
-#: /app/analytics/templates/website/reports.mako:20
+#: analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "last update"
 
-#: /app/analytics/templates/website/reports.mako:23
+#: analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "file not available for this collection"
 
-#: /app/analytics/templates/website/share.mako:8
+#: analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "share by email"
 
-#: /app/analytics/templates/website/share.mako:10
+#: analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "share at Facebook"
 
-#: /app/analytics/templates/website/share.mako:13
+#: analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "share at Twitter"
 
-#: /app/analytics/templates/website/share.mako:16
+#: analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "share at LinkedIn"
+

--- a/analytics/locale/en/LC_MESSAGES/analytics.po
+++ b/analytics/locale/en/LC_MESSAGES/analytics.po
@@ -1,7 +1,7 @@
-# Translations template for analytics.
+# English translations for analytics.
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the analytics project.
-# 
+#
 # Translators:
 # Abel Laerte Packer <abel.packer@scielo.org>, 2016
 # fabiobatalha <fabiobatalha@gmail.com>, 2015-2017
@@ -9,1537 +9,1836 @@
 # scielo <tecnologia@scielo.org>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Analytics\n"
+"Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-07-28 11:18-0300\n"
+"POT-Creation-Date: 2019-09-17 18:21+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
-"Language-Team: English (http://www.transifex.com/scielo/analytics/language/en/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.0\n"
 "Language: en\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: English "
+"(http://www.transifex.com/scielo/analytics/language/en/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: analytics/charts_config.py:25
+#: /app/analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Source: SciELO.org"
 
-#: analytics/charts_config.py:58
+#: /app/analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr "Documents access year"
 
-#: analytics/charts_config.py:59
+#: /app/analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr "Documents publication year"
 
-#: analytics/charts_config.py:91
+#: /app/analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Publishing year of the journal documents. (cited)"
 
-#: analytics/charts_config.py:92
+#: /app/analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Publishing year of the SciELO Network documents. (citing)"
 
-#: analytics/charts_config.py:100 analytics/charts_config.py:103
-#: analytics/charts_config.py:112
-msgid "Fator de impacto JCR"
-msgstr "Impact factor JCR"
+#: /app/analytics/charts_config.py:100
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+msgid "Fator de impacto (Média de percentil)"
+msgstr ""
 
-#: analytics/charts_config.py:113 analytics/charts_config.py:136
-#: analytics/charts_config.py:163
+#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+msgid "Média de percentil"
+msgstr ""
+
+#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
+#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Base year"
 
-#: analytics/charts_config.py:122
+#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
+#: /app/analytics/charts_config.py:134
+msgid "Eigen Factor JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
+#: /app/analytics/charts_config.py:156
+msgid "Received Citations JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
+#: /app/analytics/charts_config.py:178
+msgid "Fator de impacto JCR"
+msgstr "Impact factor JCR"
+
+#: /app/analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Source: Google Scholar"
 
-#: analytics/charts_config.py:123 analytics/charts_config.py:126
-#: analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
+#: /app/analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "H5M5 Metrics"
 
-#: analytics/charts_config.py:145
+#: /app/analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "immediacy"
 
-#: analytics/charts_config.py:146
-#: analytics/templates/website/access_datepicker.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: /app/analytics/charts_config.py:212
+#: /app/analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "1 year"
 
-#: analytics/charts_config.py:147
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/charts_config.py:213
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 years"
 
-#: analytics/charts_config.py:148
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/charts_config.py:214
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 years"
 
-#: analytics/charts_config.py:149
+#: /app/analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 years"
 
-#: analytics/charts_config.py:150
+#: /app/analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 years"
 
-#: analytics/charts_config.py:157
+#: /app/analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "SciELO Impact in 1, 2, 3, 4, 5 years and Immediacity index"
 
-#: analytics/charts_config.py:160 analytics/charts_config.py:162
-#: analytics/templates/website/bibliometrics_journal.mako:23
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
+#: /app/analytics/templates/website/bibliometrics_journal.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "SciELO Impact"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citation"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Granted citations"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Received citations"
 
-#: analytics/charts_config.py:178
+#: /app/analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribution of granted, received and auto citations"
 
-#: analytics/charts_config.py:185
+#: /app/analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Number of citations"
 
-#: analytics/charts_config.py:190 analytics/charts_config.py:207
-#: analytics/charts_config.py:221 analytics/charts_config.py:348
-#: analytics/charts_config.py:357 analytics/charts_config.py:372
-#: analytics/charts_config.py:380 analytics/charts_config.py:428
-#: analytics/charts_config.py:437 analytics/charts_config.py:516
-#: analytics/charts_config.py:526 analytics/charts_config.py:568
-#: analytics/charts_config.py:577 analytics/charts_config.py:618
-#: analytics/charts_config.py:626 analytics/charts_config.py:742
-#: analytics/templates/website/central_container_for_article_filters.mako:13
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
+#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
+#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
+#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
+#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
+#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Publishing year"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Citable documents"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Non citable documents"
 
-#: analytics/charts_config.py:206
+#: /app/analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribution of citable and non citable documents"
 
-#: analytics/charts_config.py:215 analytics/charts_config.py:239
-#: analytics/charts_config.py:258 analytics/charts_config.py:275
-#: analytics/charts_config.py:322 analytics/charts_config.py:346
-#: analytics/charts_config.py:375 analytics/charts_config.py:401
-#: analytics/charts_config.py:426 analytics/charts_config.py:494
-#: analytics/charts_config.py:514 analytics/charts_config.py:522
-#: analytics/charts_config.py:545 analytics/charts_config.py:566
-#: analytics/charts_config.py:616 analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
+#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
+#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
+#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
+#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
+#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
+#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
+#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Number of documents"
 
-#: analytics/charts_config.py:232
+#: /app/analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Documents distribution by number of bibliographic references"
 
-#: analytics/charts_config.py:235
+#: /app/analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Bibliographic references"
 
-#: analytics/charts_config.py:242
+#: /app/analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documents with %s bibliographic references"
 
-#: analytics/charts_config.py:251
+#: /app/analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Documents distribution by number of author"
 
-#: analytics/charts_config.py:254
-#: analytics/templates/website/publication_article.mako:133
+#: /app/analytics/charts_config.py:320
+#: /app/analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Number of authors"
 
-#: analytics/charts_config.py:261
+#: /app/analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documents with %s authors"
 
-#: analytics/charts_config.py:272 analytics/charts_config.py:314
+#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr "Distribution by authors affiliation countries"
 
-#: analytics/charts_config.py:293 analytics/charts_config.py:325
-#: analytics/charts_config.py:380 analytics/charts_config.py:404
-#: analytics/charts_config.py:497 analytics/charts_config.py:548
-#: analytics/charts_config.py:648
+#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
+#: /app/analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documents"
 
-#: analytics/charts_config.py:302 analytics/charts_config.py:317
-#: analytics/charts_config.py:325
+#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
+#: /app/analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "Affiliation countries"
 
-#: analytics/charts_config.py:338
+#: /app/analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr "Distribution by authors affiliation countries and publication year"
 
-#: analytics/charts_config.py:371
+#: /app/analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Documents distribution by publishing years"
 
-#: analytics/charts_config.py:393
+#: /app/analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribution by languages"
 
-#: analytics/charts_config.py:396
+#: /app/analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Publishing languages"
 
-#: analytics/charts_config.py:404
+#: /app/analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Document Language"
 
-#: analytics/charts_config.py:418
+#: /app/analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribution by language and publication year"
 
-#: analytics/charts_config.py:448 analytics/charts_config.py:588
-msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
-msgstr "Journals distribution by current status at SciELO"
-
-#: analytics/charts_config.py:451 analytics/charts_config.py:459
-#: analytics/charts_config.py:591 analytics/charts_config.py:599
-msgid "Situação da publicação"
-msgstr "Publishing status"
-
-#: analytics/charts_config.py:456 analytics/charts_config.py:472
-#: analytics/charts_config.py:596 analytics/charts_config.py:665
-#: analytics/charts_config.py:685
-msgid "Número de periódicos"
-msgstr "Number of journals"
-
-#: analytics/charts_config.py:459 analytics/charts_config.py:477
-#: analytics/charts_config.py:599 analytics/charts_config.py:668
-#: analytics/charts_config.py:688
-#: analytics/templates/website/navbar_collection.mako:10
-#: analytics/templates/website/navbar_journal.mako:10
-msgid "Periódicos"
-msgstr "Journals"
-
-#: analytics/charts_config.py:468
+#: /app/analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Journals distribution by the inclusion year at SciELO"
 
-#: analytics/charts_config.py:469 analytics/charts_config.py:477
+#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Inclusion year"
 
-#: analytics/charts_config.py:486
+#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
+#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+msgid "Número de periódicos"
+msgstr "Number of journals"
+
+#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
+#: /app/analytics/templates/website/navbar_collection.mako:10
+#: /app/analytics/templates/website/navbar_journal.mako:10
+msgid "Periódicos"
+msgstr "Journals"
+
+#: /app/analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Documents distribution by suject areas"
 
-#: analytics/charts_config.py:489 analytics/charts_config.py:660
+#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Subject areas"
 
-#: analytics/charts_config.py:497 analytics/charts_config.py:668
-#: analytics/templates/website/central_container_for_article_filters.mako:30
-#: analytics/templates/website/central_container_for_journal_filters.mako:13
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Subject area"
 
-#: analytics/charts_config.py:506
+#: /app/analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribution by subject area and publication year"
 
-#: analytics/charts_config.py:537
+#: /app/analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Documents distribution by document type"
 
-#: analytics/charts_config.py:540
-#: analytics/templates/website/publication_article.mako:43
-#: analytics/templates/website/publication_article_by_publication_year.mako:43
+#: /app/analytics/charts_config.py:586
+#: /app/analytics/templates/website/publication_article.mako:43
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Document types"
 
-#: analytics/charts_config.py:548
+#: /app/analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Document type"
 
-#: analytics/charts_config.py:558
+#: /app/analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Documents distribution by publishing year"
 
-#: analytics/charts_config.py:608
+#: /app/analytics/charts_config.py:634
+msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
+msgstr "Journals distribution by current status at SciELO"
+
+#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+msgid "Situação da publicação"
+msgstr "Publishing status"
+
+#: /app/analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Documents distribution by use license and publication year"
 
-#: analytics/charts_config.py:637
+#: /app/analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Documents distribution by use licenses"
 
-#: analytics/charts_config.py:640 analytics/charts_config.py:680
-#: analytics/templates/website/publication_article.mako:5
-#: analytics/templates/website/publication_article_by_publication_year.mako:5
+#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
+#: /app/analytics/templates/website/publication_article.mako:5
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Use licenses"
 
-#: analytics/charts_config.py:648 analytics/charts_config.py:688
+#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
 msgid "Licença"
 msgstr "license"
 
-#: analytics/charts_config.py:657
+#: /app/analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribution by subject areas"
 
-#: analytics/charts_config.py:677
+#: /app/analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Journals distribution by use licenses"
 
-#: analytics/charts_config.py:696
+#: /app/analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total accesses by year and month"
 
-#: analytics/charts_config.py:704 analytics/charts_config.py:739
-#: analytics/templates/website/navbar_collection.mako:7
-#: analytics/templates/website/navbar_document.mako:7
-#: analytics/templates/website/navbar_journal.mako:7
+#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
+#: /app/analytics/templates/website/navbar_collection.mako:7
+#: /app/analytics/templates/website/navbar_document.mako:7
+#: /app/analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesses"
 
-#: analytics/charts_config.py:710
+#: /app/analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesses at"
 
-#: analytics/charts_config.py:721
+#: /app/analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total accesses by document type"
 
-#: analytics/charts_config.py:725
+#: /app/analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesses for documents of the type %s"
 
-#: analytics/charts_config.py:737
+#: /app/analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Articles lifetime by number of accesses at"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Reference year"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesses to documents from %s"
 
-#: analytics/controller.py:354
-msgid "Fator de impacto 5 anos"
-msgstr "Impact factor (5 years)"
-
-#: analytics/controller.py:359
-msgid "Fator de impacto 2 anos"
-msgstr "Impact factor (2 year)"
-
-#: analytics/controller.py:364
-msgid "Fator de impacto 2 anos, sem auto citação"
-msgstr "Impact factor (2 years), without auto citing"
-
-#: analytics/templates/website/access_by_document_type.mako:6
-#: analytics/templates/website/access_by_month_and_year.mako:5
-#: analytics/templates/website/access_lifetime.mako:6
-#: analytics/templates/website/accesses_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: analytics/templates/website/publication_article_affiliations.mako:5
-#: analytics/templates/website/publication_article_affiliations_map.mako:5
-#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: analytics/templates/website/publication_article_authors.mako:5
-#: analytics/templates/website/publication_article_citable_documents.mako:5
-#: analytics/templates/website/publication_article_document_type.mako:5
-#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: analytics/templates/website/publication_article_languages.mako:5
-#: analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: analytics/templates/website/publication_article_licenses.mako:5
-#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: analytics/templates/website/publication_article_references.mako:5
-#: analytics/templates/website/publication_article_subject_areas.mako:6
-#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: analytics/templates/website/publication_article_year.mako:5
-#: analytics/templates/website/publication_journal_licenses.mako:7
-#: analytics/templates/website/publication_journal_status.mako:7
-#: analytics/templates/website/publication_journal_subject_areas.mako:7
-#: analytics/templates/website/publication_journal_year.mako:7
-#: analytics/templates/website/publication_size_citations.mako:6
-#: analytics/templates/website/publication_size_documents.mako:6
-#: analytics/templates/website/publication_size_issues.mako:6
-#: analytics/templates/website/publication_size_journals.mako:6
+#: /app/analytics/templates/website/access_by_document_type.mako:6
+#: /app/analytics/templates/website/access_by_month_and_year.mako:5
+#: /app/analytics/templates/website/access_lifetime.mako:6
+#: /app/analytics/templates/website/accesses_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_authors.mako:5
+#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
+#: /app/analytics/templates/website/publication_article_document_type.mako:5
+#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_languages.mako:5
+#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_licenses.mako:5
+#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_references.mako:5
+#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
+#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: /app/analytics/templates/website/publication_article_year.mako:5
+#: /app/analytics/templates/website/publication_journal_licenses.mako:7
+#: /app/analytics/templates/website/publication_journal_status.mako:7
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
+#: /app/analytics/templates/website/publication_journal_year.mako:7
+#: /app/analytics/templates/website/publication_size_citations.mako:6
+#: /app/analytics/templates/website/publication_size_documents.mako:6
+#: /app/analytics/templates/website/publication_size_issues.mako:6
+#: /app/analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "loading"
 
-#: analytics/templates/website/access_datepicker.mako:5
+#: /app/analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Period"
 
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "Accesses in the last 36 months"
 
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "Accesses in the last 24 months"
 
-#: analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "Accesses in the las 12 months"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "all availalble data"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "all"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Select the access period"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
-"recuperação dos dados de acesso. Você pode também selecionar o período de 1,"
-" 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis "
-"selecionando tudo."
-msgstr "Use the field with dates to choose a custom date range to retrieve usage data. You can choose the period of 1, 2 and 3 years through the fast links or all the available accesses choosing all."
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
+msgstr ""
+"Use the field with dates to choose a custom date range to retrieve usage "
+"data. You can choose the period of 1, 2 and 3 years through the fast "
+"links or all the available accesses choosing all."
 
-#: analytics/templates/website/access_list_articles.mako:6
+#: /app/analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 articles by number of accesses"
 
-#: analytics/templates/website/access_list_articles.mako:9
+#: /app/analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "article"
 
-#: analytics/templates/website/access_list_articles.mako:13
-#: analytics/templates/website/access_list_issues.mako:13
-#: analytics/templates/website/access_list_journals.mako:13
+#: /app/analytics/templates/website/access_list_articles.mako:13
+#: /app/analytics/templates/website/access_list_issues.mako:13
+#: /app/analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "abstract"
 
-#: analytics/templates/website/access_list_articles.mako:14
-#: analytics/templates/website/access_list_issues.mako:14
-#: analytics/templates/website/access_list_journals.mako:14
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: analytics/templates/website/bibliometrics_list_granted.mako:19
-#: analytics/templates/website/bibliometrics_list_granted.mako:30
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: analytics/templates/website/bibliometrics_list_received.mako:26
-#: analytics/templates/website/bibliometrics_list_received.mako:37
+#: /app/analytics/templates/website/access_list_articles.mako:14
+#: /app/analytics/templates/website/access_list_issues.mako:14
+#: /app/analytics/templates/website/access_list_journals.mako:14
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: analytics/templates/website/access_list_issues.mako:6
+#: /app/analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 issues by accesses"
 
-#: analytics/templates/website/access_list_issues.mako:9
-#: analytics/templates/website/access_list_journals.mako:9
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: /app/analytics/templates/website/access_list_issues.mako:9
+#: /app/analytics/templates/website/access_list_journals.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "previous"
 
-#: analytics/templates/website/access_list_journals.mako:6
+#: /app/analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesses to the journals documents"
 
-#: analytics/templates/website/accesses.mako:6
+#: /app/analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr "Site usage chart"
 
-#: analytics/templates/website/accesses.mako:12
+#: /app/analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr "Usage heat chart"
 
-#: analytics/templates/website/accesses.mako:18
+#: /app/analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:15
+#: /app/analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr "Accesses to documents"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr "Documents published at"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr "have had"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr "accesses at"
 
-#: analytics/templates/website/base.mako:6
+#: /app/analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Analytics"
 
-#: analytics/templates/website/base.mako:30
+#: /app/analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Collections"
 
-#: analytics/templates/website/base.mako:38
-#: analytics/templates/website/journal_selector_modal.mako:7
+#: /app/analytics/templates/website/base.mako:38
+#: /app/analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "select a journal"
 
-#: analytics/templates/website/base.mako:91
+#: /app/analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "This tool is under development and it is available in Beta Test version"
 
-#: analytics/templates/website/base.mako:93
+#: /app/analytics/templates/website/base.mako:93
 msgid ""
-"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de "
-"realizar testes de uso e performance. Todos os indicadores carregados são "
-"reais e estão sendo atualizados e inseridos gradativamente. Problemas de "
-"lentidão e indisponibilidade do serviços são esperados nesta fase."
-msgstr "This tool is under development and it was published with the objective to test the usage and performance. All the indicators are real and they are gradually being loaded. Slowness and out of service problems may occur in this version."
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
+msgstr ""
+"This tool is under development and it was published with the objective to"
+" test the usage and performance. All the indicators are real and they are"
+" gradually being loaded. Slowness and out of service problems may occur "
+"in this version."
 
-#: analytics/templates/website/base.mako:114
+#: /app/analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Help"
 
-#: analytics/templates/website/base.mako:116
+#: /app/analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Report Errors"
 
-#: analytics/templates/website/base.mako:117
+#: /app/analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Discuss mailing list"
 
-#: analytics/templates/website/base.mako:121
+#: /app/analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Developments"
 
-#: analytics/templates/website/base.mako:124
+#: /app/analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Developments mailing list"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "January"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "February"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "March"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "April"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "May"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "June"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "July"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "August"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "September"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "October"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "November"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Dicember"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Jan"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Apr"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Aug"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Received Citations"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "publishing year"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "first author"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "document title"
 
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "received citations"
 
-#: analytics/templates/website/bibliometrics_journal.mako:8
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: analytics/templates/website/bibliometrics_list_granted.mako:8
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: analytics/templates/website/bibliometrics_list_received.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Warning"
 
-#: analytics/templates/website/bibliometrics_journal.mako:11
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: analytics/templates/website/bibliometrics_list_granted.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: analytics/templates/website/bibliometrics_list_received.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "It is necessary to choose one journal for bibliometrics indicators"
 
-#: analytics/templates/website/bibliometrics_journal.mako:20
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: analytics/templates/website/bibliometrics_list_received.mako:19
-#: analytics/templates/website/central_container_for_article_filters.mako:16
-#: analytics/templates/website/central_container_for_article_filters.mako:33
-#: analytics/templates/website/central_container_for_article_filters.mako:52
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: analytics/templates/website/central_container_for_journal_filters.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal.mako:20
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "apply"
 
-#: analytics/templates/website/bibliometrics_journal.mako:32
-#: analytics/templates/website/bibliometrics_journal.mako:51
-#: analytics/templates/website/bibliometrics_journal.mako:69
-#: analytics/templates/website/bibliometrics_journal.mako:87
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: analytics/templates/website/publication_article.mako:14
-#: analytics/templates/website/publication_article.mako:33
-#: analytics/templates/website/publication_article.mako:52
-#: analytics/templates/website/publication_article.mako:70
-#: analytics/templates/website/publication_article.mako:88
-#: analytics/templates/website/publication_article.mako:106
-#: analytics/templates/website/publication_article.mako:124
-#: analytics/templates/website/publication_article.mako:142
-#: analytics/templates/website/publication_article.mako:160
-#: analytics/templates/website/publication_article_by_publication_year.mako:14
-#: analytics/templates/website/publication_article_by_publication_year.mako:33
-#: analytics/templates/website/publication_article_by_publication_year.mako:52
-#: analytics/templates/website/publication_article_by_publication_year.mako:70
-#: analytics/templates/website/publication_article_by_publication_year.mako:88
-#: analytics/templates/website/publication_article_by_publication_year.mako:106
-#: analytics/templates/website/publication_journal_licenses.mako:14
-#: analytics/templates/website/publication_journal_status.mako:14
-#: analytics/templates/website/publication_journal_subject_areas.mako:14
-#: analytics/templates/website/publication_journal_year.mako:14
+#: /app/analytics/templates/website/bibliometrics_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal.mako:51
+#: /app/analytics/templates/website/bibliometrics_journal.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal.mako:87
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: /app/analytics/templates/website/publication_article.mako:14
+#: /app/analytics/templates/website/publication_article.mako:33
+#: /app/analytics/templates/website/publication_article.mako:52
+#: /app/analytics/templates/website/publication_article.mako:70
+#: /app/analytics/templates/website/publication_article.mako:88
+#: /app/analytics/templates/website/publication_article.mako:106
+#: /app/analytics/templates/website/publication_article.mako:124
+#: /app/analytics/templates/website/publication_article.mako:142
+#: /app/analytics/templates/website/publication_article.mako:160
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
+#: /app/analytics/templates/website/publication_journal_licenses.mako:14
+#: /app/analytics/templates/website/publication_journal_status.mako:14
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
+#: /app/analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "About the chart"
 
-#: analytics/templates/website/bibliometrics_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
 "linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
 "Reuters"
-msgstr "This chart show the impact fator of the selected journal considering the immediacy period, including the impact factor for 1 to 5 years. The 2 years line refers to the Thomson Reuters impact factor."
+msgstr ""
+"This chart show the impact fator of the selected journal considering the "
+"immediacy period, including the impact factor for 1 to 5 years. The 2 "
+"years line refers to the Thomson Reuters impact factor."
 
-#: analytics/templates/website/bibliometrics_journal.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr "Citable and non citable documents"
 
-#: analytics/templates/website/bibliometrics_journal.mako:54
-#: analytics/templates/website/publication_article_by_publication_year.mako:109
+#: /app/analytics/templates/website/bibliometrics_journal.mako:54
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
-"Este gráfico apresenta a distribuição de documentos citáveis e não citáveis "
-"relacionados ao periódico selecionado. De acordo com as regras de contagem "
-"do SciELO, documentos citáveis devem ser do tipo \"Research Article\", "
-"\"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid "
-"Communication\" e \"Article Commentary\". Os demais tipos de documentos são "
-"considerados não citáveis."
-msgstr "This chart shows the distribution of citable and non citable documents related to the selected journal. According to the SciELO counting rules, citable documents must be of the types: \"Research Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid Communication\" and \"Article Commentary\". Other types of documents are considered not citable."
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
+msgstr ""
+"This chart shows the distribution of citable and non citable documents "
+"related to the selected journal. According to the SciELO counting rules, "
+"citable documents must be of the types: \"Research Article\", \"Review "
+"Article\", \"Case Report\", \"Brief Report\", \"Rapid Communication\" and"
+" \"Article Commentary\". Other types of documents are considered not "
+"citable."
 
-#: analytics/templates/website/bibliometrics_journal.mako:60
+#: /app/analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: analytics/templates/website/bibliometrics_journal.mako:72
+#: /app/analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
-"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores "
-"são fornecidos anualmente pelo Google Scholar. A ausência de indicadores "
-"para um periódico ou para um período de um periódico pode ocorrer caso esses"
-" dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, "
-"você será direcionado para o site do Google Scholar."
-msgstr "This chart shows the Google Scholar H5 and M5 indicators. These indicators are yearly supplied by the Google Scholar. The absent of indicators for specific journals or in a period of a specific journal may occurs. Once clicking in a series, the user will be redirected to the Google Scholar website."
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
+msgstr ""
+"This chart shows the Google Scholar H5 and M5 indicators. These "
+"indicators are yearly supplied by the Google Scholar. The absent of "
+"indicators for specific journals or in a period of a specific journal may "
+"occurs. Once clicking in a series, the user will be redirected to the Google "
+"Scholar website."
 
-#: analytics/templates/website/bibliometrics_journal.mako:78
+#: /app/analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr "Granted, received and auto citing"
 
-#: analytics/templates/website/bibliometrics_journal.mako:90
+#: /app/analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
-"citações do periódico selecionado, os dados estão distribuidos por ano de "
-"publicação."
-msgstr "This chart show the number of granted, received and auto citations of the selected journal, the data is distributed by publication year."
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
+msgstr ""
+"This chart show the number of granted, received and auto citations of the"
+" selected journal, the data is distributed by publication year."
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: analytics/templates/website/navbar_journal.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr "Altmetric indicators"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr "There are no Altimetric indicators for this journal"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr "There are no Altmetric indicators for this journal in this time frame"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr "Posts"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr "Score sum"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr "Score median"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr "Score sum at this timeframe"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr "Score median at this timeframe"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: analytics/templates/website/navbar_journal.mako:28
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr "JCR Indicators"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+msgid "Dados extraídos em: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr "There are no JCR indicators for this journal"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:25
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr "Impact factor"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+msgid "Eigen Factor"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr "All years data"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr "Total of citations"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr "FI 2 years"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr "FI 2 years without self citing"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr "FI 5 years"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr "Immediacity index"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr "Citing half life"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr "Normalized Eigen Factor"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: analytics/templates/website/navbar_journal.mako:29
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Heat chart for received citations"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
-msgstr "This chart shows the number of received citations for a specific journal. The corpus of citations is compounded of all the SciELO Network collections, the Thematic collections and Indenpendent collections."
+msgstr ""
+"This chart shows the number of received citations for a specific journal."
+" The corpus of citations is compounded of all the SciELO Network "
+"collections, the Thematic collections and Indenpendent collections."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Citing list for the selected period"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citing"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Cited"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "document"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Choose the axis x/y to gather the list of citations for the journal."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Journal received citations"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "SciELO Network documents published at"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "cited"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "times the documents of the journal"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "published at"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Click the axis to see the articles citing list."
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Matching citing forms for the selected journal"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: analytics/templates/website/bibliometrics_list_granted.mako:18
-#: analytics/templates/website/bibliometrics_list_received.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "title"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acctions"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "report error"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: analytics/templates/website/bibliometrics_list_granted.mako:35
-#: analytics/templates/website/bibliometrics_list_received.mako:42
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "without results"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: analytics/templates/website/navbar_collection.mako:30
-#: analytics/templates/website/navbar_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:30
+#: /app/analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Half life Citations"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citations at"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "for publications from"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Total citations"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Half life"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citations"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "percentage"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "acummulated percentage"
 
-#: analytics/templates/website/bibliometrics_list_granted.mako:15
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+msgid "Indicadores Bibliométricos da Rede SciELO"
+msgstr "SciELO Network Bibliometric Indicators"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid "Periodicidade de atualização:"
+msgstr "Updating periodicity:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid " anual"
+msgstr " yearly"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+msgid "Indicadores de Publicação"
+msgstr "Publication Indicators"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+msgid "Numeros da Rede SciELO por:"
+msgstr "Numbers of SciELO Network by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+msgid "Ano de publicação: "
+msgstr "Publication year: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+msgid "Periódico: "
+msgstr "Journal: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+msgid "Assunto: "
+msgstr "Subject: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+msgid "País de afiliação do autor: "
+msgstr "Author’s affiliation country: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+msgid "País de Afiliação do Autor por: "
+msgstr "Author’s Affiliation Country by: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+msgid "País de publicação da revista: "
+msgstr "Journal's country of publication: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+msgid "Número de Co-autores por: "
+msgstr "Number of Co-authors by: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+msgid "Indicadores de Coleção"
+msgstr "Collection Indicators"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+msgid "Periódico por:"
+msgstr "Journal by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+msgid "Indicadores gerais: "
+msgstr "General indicators: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+msgid "Indicadores de Citação"
+msgstr "Citation Indicators"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+msgid "Ano de Citação por:"
+msgstr "Citing Year by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+msgid "Idade do documento citado: "
+msgstr "Cited document age: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+msgid "Tipo de documento citado: "
+msgstr "Cited document type: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+msgid "Periódico Citante por:"
+msgstr "Citing Journal by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+msgid "Assunto do Periódico Citante por:"
+msgstr "Citing Journal's Subject by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+msgid "Periódico SciELO citado: "
+msgstr "Cited SciELO journal: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+msgid "País de Afiliação do Autor Citante por:"
+msgstr "Citing Author's Affiliation Country by:"
+
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Granted citations by journal"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: analytics/templates/website/navbar_collection.mako:29
-#: analytics/templates/website/navbar_journal.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:29
+#: /app/analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "SciELO Impact in 1, 2, 3, 4, and 5 years"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documents published at"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
-"Aqui são considerados apenas os documentos citáveis. De acordo com as regras"
-" de contagem do SciELO, documentos citáveis devem ser do tipo Research "
-"Article, Review Article, Case Report, Brief Report, Rapid Communication e "
-"Article Commentary. Os demais tipos de documentos são considerados não "
-"citáveis."
-msgstr "Here are considered only citable documents. According to the SciELO counting rules, quotable documents must be of the types: Research Article, Review Article, Case Report, Brief Report, Rapid Communication and Article Commentary. Other types of documents are considered not citable."
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
+msgstr ""
+"Here are considered only citable documents. According to the SciELO "
+"counting rules, quotable documents must be of the types: Research "
+"Article, Review Article, Case Report, Brief Report, Rapid Communication "
+"and Article Commentary. Other types of documents are considered not "
+"citable."
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 years"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 years"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 years"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 years"
 
-#: analytics/templates/website/bibliometrics_list_received.mako:22
-#: analytics/templates/website/navbar_collection.mako:33
-#: analytics/templates/website/navbar_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:33
+#: /app/analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Received citations by journals"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:8
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Documents filters"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:22
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "period"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:49
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Language"
 
-#: analytics/templates/website/central_container_for_journal_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Journals filters"
 
-#: analytics/templates/website/faq.mako:5
+#: /app/analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Frequent Questions (Accesses)"
 
-#: analytics/templates/website/faq.mako:7
+#: /app/analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "Why some collections do not have site usage indicators?"
 
-#: analytics/templates/website/faq.mako:8
+#: /app/analytics/templates/website/faq.mako:8
 msgid ""
-"Para que os dados de acessos sejam computados é necessário que os logs de "
-"acessos sejam enviados para processamento. A ausência de estatísticas de "
-"acessos deve ser verificada com a coordenação de cada coleção SciELO."
-msgstr "To compute the site usage data it is necessary that the log files must be send for processing. The absense of usage indicators must be notified for the coordinators of the specific SciELO collection."
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
+msgstr ""
+"To compute the site usage data it is necessary that the log files must be"
+" send for processing. The absense of usage indicators must be notified "
+"for the coordinators of the specific SciELO collection."
 
-#: analytics/templates/website/faq.mako:11
+#: /app/analytics/templates/website/faq.mako:11
+msgid "Por que algumas coleções possuem acessos computados para um período maior?"
+msgstr ""
+"Why the available periods of the usage indicators differs from one "
+"collection to another?"
+
+#: /app/analytics/templates/website/faq.mako:12
 msgid ""
-"Por que algumas coleções possuem acessos computados para um período maior?"
-msgstr "Why the available periods of the usage indicators differs from one collection to another?"
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
+msgstr ""
+"The available period of each of the collections depends on the available "
+"period of the access logs of each of the collections. This project "
+"undertakes to compute the site usage data from 2012, once the logs are "
+"properly provided by the collections."
 
-#: analytics/templates/website/faq.mako:12
-msgid ""
-"O período disponível de cada uma das coleções depende do período disponível "
-"dos logs de acessos de cada uma das coleções. Este projeto se compromete a "
-"computar os dados de acessos à partir de 2012, desde que os logs sejam "
-"devidamente fornecidos pelas coleções."
-msgstr "The available period of each of the collections depends on the available period of the access logs of each of the collections. This project undertakes to compute the site usage data from 2012, once the logs are properly provided by the collections."
-
-#: analytics/templates/website/faq.mako:15
-#: analytics/templates/website/faq.mako:36
+#: /app/analytics/templates/website/faq.mako:15
+#: /app/analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "What is being computed?"
 
-#: analytics/templates/website/faq.mako:16
+#: /app/analytics/templates/website/faq.mako:16
 msgid ""
-"Estão sendo contabilizados e classificados os acessos ao texto completo em "
-"HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
-msgstr "Are being computed and classified the accesses to the full text in HTML, PDF, EPDF (ReadCube), besides the accesses to the abstract pages in the website."
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
+msgstr ""
+"Are being computed and classified the accesses to the full text in HTML, "
+"PDF, EPDF (ReadCube), besides the accesses to the abstract pages in the "
+"website."
 
-#: analytics/templates/website/faq.mako:19
+#: /app/analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
-msgstr "Why the indicators of this tool differs from the indicators delivered by other SciELO sites?"
+msgstr ""
+"Why the indicators of this tool differs from the indicators delivered by "
+"other SciELO sites?"
 
-#: analytics/templates/website/faq.mako:21
+#: /app/analytics/templates/website/faq.mako:21
 msgid ""
-"Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos "
-"de estatísticas de acessos."
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
 msgstr "Some SciELO tools may still be using the old statistics service access."
 
-#: analytics/templates/website/faq.mako:22
+#: /app/analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
-msgstr "The site usage accounting differs in a lot of aspects from the previous tool."
+msgstr ""
+"The site usage accounting differs in a lot of aspects from the previous "
+"tool."
 
-#: analytics/templates/website/faq.mako:23
+#: /app/analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
 msgstr "Some tools have a delta of different updating access indicators."
 
-#: analytics/templates/website/faq.mako:27
-#: analytics/templates/website/faq.mako:40
+#: /app/analytics/templates/website/faq.mako:27
+#: /app/analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "What is the updating frequency of the indicators?"
 
-#: analytics/templates/website/faq.mako:28
+#: /app/analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Monthly"
 
-#: analytics/templates/website/faq.mako:30
+#: /app/analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "FAQ (Publishing)"
 
-#: analytics/templates/website/faq.mako:32
+#: /app/analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "Why some collections have out of date indicators?"
 
-#: analytics/templates/website/faq.mako:33
+#: /app/analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
 "diretamente ligada a condução adequada desses processos por cada uma das "
 "coleções."
-msgstr "The data refresh depends on processes that involve each of the certified SciELO collections. The update of these indicators is directly linked to the proper conduct of these processes by each of the collections."
+msgstr ""
+"The data refresh depends on processes that involve each of the certified "
+"SciELO collections. The update of these indicators is directly linked to "
+"the proper conduct of these processes by each of the collections."
 
-#: analytics/templates/website/faq.mako:37
+#: /app/analytics/templates/website/faq.mako:37
 msgid ""
-"Estão sendo contabilizados indicadores de publicação das coleções com base "
-"nos metadados fornecidos durante todo o processo de publicação de um "
-"documento no SciELO. A qualidade desses indicadores esta diretamente ligada "
-"a qualidade dos processos implementados por cada uma das coleções."
-msgstr "This chart show the total of documents by the affiliation country of the authors. The total of documents of this chart can not be considered as the total of publications of the collection once the documents may have more than one affiliation country."
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
+msgstr ""
+"This chart show the total of documents by the affiliation country of the "
+"authors. The total of documents of this chart can not be considered as "
+"the total of publications of the collection once the documents may have "
+"more than one affiliation country."
 
-#: analytics/templates/website/faq.mako:41
+#: /app/analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Weekly"
 
-#: analytics/templates/website/home_collection.mako:7
-#: analytics/templates/website/home_journal.mako:7
-#: analytics/templates/website/home_network.mako:7
-#: analytics/templates/website/navbar_collection.mako:18
-#: analytics/templates/website/navbar_journal.mako:18
-#: analytics/templates/website/publication_size.mako:5
+#: /app/analytics/templates/website/home_collection.mako:7
+#: /app/analytics/templates/website/home_journal.mako:7
+#: /app/analytics/templates/website/home_network.mako:7
+#: /app/analytics/templates/website/navbar_collection.mako:18
+#: /app/analytics/templates/website/navbar_journal.mako:18
+#: /app/analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Collection composition"
 
-#: analytics/templates/website/home_collection.mako:24
-#: analytics/templates/website/home_document.mako:21
-#: analytics/templates/website/home_journal.mako:21
-#: analytics/templates/website/home_network.mako:24
-#: analytics/templates/website/navbar_collection.mako:9
-#: analytics/templates/website/navbar_collection.mako:27
-#: analytics/templates/website/navbar_document.mako:9
-#: analytics/templates/website/navbar_journal.mako:9
-#: analytics/templates/website/navbar_journal.mako:26
+#: /app/analytics/templates/website/home_collection.mako:24
+#: /app/analytics/templates/website/home_document.mako:21
+#: /app/analytics/templates/website/home_journal.mako:21
+#: /app/analytics/templates/website/home_network.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:9
+#: /app/analytics/templates/website/navbar_collection.mako:27
+#: /app/analytics/templates/website/navbar_document.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Charts"
 
-#: analytics/templates/website/home_document.mako:7
+#: /app/analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Document indicators"
 
-#: analytics/templates/website/journal_selector_modal.mako:6
+#: /app/analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "close"
 
-#: analytics/templates/website/journal_selector_modal.mako:11
+#: /app/analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "choose a journal"
 
-#: analytics/templates/website/journal_selector_modal.mako:20
+#: /app/analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "select"
 
-#: analytics/templates/website/navbar_collection.mako:11
-#: analytics/templates/website/navbar_journal.mako:11
+#: /app/analytics/templates/website/navbar_collection.mako:11
+#: /app/analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 issues"
 
-#: analytics/templates/website/navbar_collection.mako:12
-#: analytics/templates/website/navbar_journal.mako:12
+#: /app/analytics/templates/website/navbar_collection.mako:12
+#: /app/analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 articles"
 
-#: analytics/templates/website/navbar_collection.mako:16
-#: analytics/templates/website/navbar_journal.mako:16
+#: /app/analytics/templates/website/navbar_collection.mako:16
+#: /app/analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publishing"
 
-#: analytics/templates/website/navbar_collection.mako:19
-#: analytics/templates/website/navbar_journal.mako:19
+#: /app/analytics/templates/website/navbar_collection.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Documents charts"
 
-#: analytics/templates/website/navbar_collection.mako:20
-#: analytics/templates/website/navbar_journal.mako:20
+#: /app/analytics/templates/website/navbar_collection.mako:20
+#: /app/analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Documents charts by publishing year"
 
-#: analytics/templates/website/navbar_collection.mako:21
+#: /app/analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Journals charts"
 
-#: analytics/templates/website/navbar_collection.mako:25
-#: analytics/templates/website/navbar_document.mako:13
-#: analytics/templates/website/navbar_journal.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:25
+#: /app/analytics/templates/website/navbar_document.mako:13
+#: /app/analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometrics"
 
-#: analytics/templates/website/navbar_collection.mako:32
-#: analytics/templates/website/navbar_journal.mako:34
+#: /app/analytics/templates/website/navbar_collection.mako:32
+#: /app/analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Granted citations by journals"
 
-#: analytics/templates/website/navbar_collection.mako:34
-#: analytics/templates/website/navbar_journal.mako:36
+#: /app/analytics/templates/website/navbar_collection.mako:34
+#: /app/analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Journal citing forms"
 
-#: analytics/templates/website/navbar_collection.mako:38
-#: analytics/templates/website/navbar_document.mako:19
-#: analytics/templates/website/navbar_journal.mako:40
+#: /app/analytics/templates/website/navbar_collection.mako:35
+#: /app/analytics/templates/website/navbar_journal.mako:37
+msgid "Indicadores Gerais"
+msgstr "General Indicators"
+
+#: /app/analytics/templates/website/navbar_collection.mako:39
+#: /app/analytics/templates/website/navbar_document.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Reports"
 
-#: analytics/templates/website/navbar_document.mako:15
+#: /app/analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Received citations"
 
-#: analytics/templates/website/publication_article.mako:17
+#: /app/analytics/templates/website/publication_article.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. A disponibilidade de indicadores de licença de uso dependem da "
-"adoção da coleção ou periódico selecionado de licenças de uso creative "
-"commons."
-msgstr "This chart shows the distribution of documents by use license. The numbers are related to collection or journal when a journal is selected. The availability of use license of indicators depends on the adoption of creative commons licences by the collection or the selected journal."
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
+msgstr ""
+"This chart shows the distribution of documents by use license. The "
+"numbers are related to collection or journal when a journal is selected. "
+"The availability of use license of indicators depends on the adoption of "
+"creative commons licences by the collection or the selected journal."
 
-#: analytics/templates/website/publication_article.mako:24
-#: analytics/templates/website/publication_article_by_publication_year.mako:24
+#: /app/analytics/templates/website/publication_article.mako:24
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr "Subject areas"
 
-#: analytics/templates/website/publication_article.mako:36
+#: /app/analytics/templates/website/publication_article.mako:36
 msgid ""
-"Este gráfico apresenta o total de documentos publicados por área de atuação."
-" Os números são relacionados a coleção ou ao periódico quando um periódico é"
-" selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas "
-"são determinadas para cada um dos periódicos SciELO, podendo um periódico "
-"estar relacionado a mais de uma área de atuação. Os valores totais de "
-"documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode fazer parte de mais de "
-"uma área de atuação. Este gráfico é recomendado para extração de indicadores"
-" de Coleção."
-msgstr "This chart shows the total number of documents published by expecializacion area. The values relate to the collection or journal when selected daily. The areas correspond to large areas of CNPQ, these areas are determined for each of the SciELO journals periodically and may be related to more than one area of expertise. The total values of these graphic documents can not be considered as total publications of the collection once a document can be part of more than one area of expertise. This graphical is recommended for collecting indicators extraction."
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
+msgstr ""
+"This chart shows the total number of documents published by "
+"expecializacion area. The values relate to the collection or journal when"
+" selected daily. The areas correspond to large areas of CNPQ, these areas"
+" are determined for each of the SciELO journals periodically and may be "
+"related to more than one area of expertise. The total values of these "
+"graphic documents can not be considered as total publications of the "
+"collection once a document can be part of more than one area of "
+"expertise. This graphical is recommended for collecting indicators "
+"extraction."
 
-#: analytics/templates/website/publication_article.mako:55
+#: /app/analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
 "Citation Index e documentados no SciELO Publishing Schema."
-msgstr "This chart shows the total number of documents by type of document. The numbers are related to collection or journal when a journal is selected. Document types are the types used on the SciELO Citation Index and documented in SciELO Publishing Schema."
+msgstr ""
+"This chart shows the total number of documents by type of document. The "
+"numbers are related to collection or journal when a journal is selected. "
+"Document types are the types used on the SciELO Citation Index and "
+"documented in SciELO Publishing Schema."
 
-#: analytics/templates/website/publication_article.mako:61
-#: analytics/templates/website/publication_article_by_publication_year.mako:61
+#: /app/analytics/templates/website/publication_article.mako:61
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr "Documents languages"
 
-#: analytics/templates/website/publication_article.mako:73
+#: /app/analytics/templates/website/publication_article.mako:73
 msgid ""
-"Este gráfico apresenta o total de documentos por idioma de publicação. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ser publicado em mais de um idioma."
-msgstr "This chart shows the total number of documents by publication language. The numbers are related to collection or journal when a journal is selected. The total values of documents of this chart can not be considered as the total of publications of the collection once a document could be published in more than one language."
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
+msgstr ""
+"This chart shows the total number of documents by publication language. "
+"The numbers are related to collection or journal when a journal is "
+"selected. The total values of documents of this chart can not be "
+"considered as the total of publications of the collection once a document"
+" could be published in more than one language."
 
-#: analytics/templates/website/publication_article.mako:79
+#: /app/analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr "Publishing Years"
 
-#: analytics/templates/website/publication_article.mako:91
+#: /app/analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
-"publicação. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado."
-msgstr "This chart show the total of published documents by publication year. The numbers are related to one collection or to one journal when it is selected."
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
+msgstr ""
+"This chart show the total of published documents by publication year. The"
+" numbers are related to one collection or to one journal when it is "
+"selected."
 
-#: analytics/templates/website/publication_article.mako:97
-#: analytics/templates/website/publication_article_by_publication_year.mako:79
+#: /app/analytics/templates/website/publication_article.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr "Affiliation countries"
 
-#: analytics/templates/website/publication_article.mako:109
+#: /app/analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ter mais um país de afiliação."
-msgstr "This chart show the total of documents by the affiliation country of the authors. The total of documents of this chart can not be considered as the total of publications of the collection once the documents may have more than one affiliation country."
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"This chart show the total of documents by the affiliation country of the "
+"authors. The total of documents of this chart can not be considered as "
+"the total of publications of the collection once the documents may have "
+"more than one affiliation country."
 
-#: analytics/templates/website/publication_article.mako:115
+#: /app/analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr "Map of affiliation countries"
 
-#: analytics/templates/website/publication_article.mako:127
+#: /app/analytics/templates/website/publication_article.mako:127
 msgid ""
-"Este mapa apresenta o total de documentos por país de afiliação dos autores."
-" Os valores totais de documentos deste mapa não podem ser considerados como "
-"totais de publicações da coleção uma vez que um documento pode ter mais um "
-"país de afiliação."
-msgstr "This map shows the total documents by country affiliation of the authors. The total documents of this map can not be considered as the total of publications of the collection as a document can have more than one affiliation country."
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"This map shows the total documents by country affiliation of the authors."
+" The total documents of this map can not be considered as the total of "
+"publications of the collection as a document can have more than one "
+"affiliation country."
 
-#: analytics/templates/website/publication_article.mako:145
+#: /app/analytics/templates/website/publication_article.mako:145
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de autores. "
-"Os números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado."
-msgstr "This chart show the documents distribution by the number of authors. The numbers are related to one collection or to one journal when it is selected."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
+msgstr ""
+"This chart show the documents distribution by the number of authors. The "
+"numbers are related to one collection or to one journal when it is "
+"selected."
 
-#: analytics/templates/website/publication_article.mako:151
+#: /app/analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr "Number of bibliographic references"
 
-#: analytics/templates/website/publication_article.mako:163
+#: /app/analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
-msgstr "This chart show the documents distribution by the number of bibliographic references. The numbers are related to one collection or to one journal when it is selected."
+msgstr ""
+"This chart show the documents distribution by the number of bibliographic"
+" references. The numbers are related to one collection or to one journal "
+"when it is selected."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso e ano"
-" de publicação. Os números são relacionados a coleção ou ao periódico quando"
-" um periódico é selecionado. A disponibilidade de indicadores de licença de "
-"uso dependem da adoção da coleção ou periódico selecionado de licenças de "
-"uso creative commons."
-msgstr "This chart shows the distribution of documents by use of license and publication year. The numbers relate to the collection or journal when a journal is selected. The availability of the license of the indicators depends on the adoption of the journal collection or selected in creative commons licenses."
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:36
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por área de atuação e "
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode fazer parte de mais de uma área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "This chart shows the distribution of documents by area of specialization and year of publication. The numbers relate to the collection or magazine when a document is selected. The total values of these documents in the graphics can not be considered as a value of total publications of the collection, because a document can be part of more than one area of expertise. This graphical is recommended for collecting indicators extraction."
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
+msgstr ""
+"This chart shows the distribution of documents by use of license and "
+"publication year. The numbers relate to the collection or journal when a "
+"journal is selected. The availability of the license of the indicators "
+"depends on the adoption of the journal collection or selected in creative"
+" commons licenses."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:55
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por tipo de publicação e"
-" ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado."
-msgstr "This chart shows the total of published documents by publication year and document type. The numbers are related to one collection or to one journal when it is selected."
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"This chart shows the distribution of documents by area of specialization "
+"and year of publication. The numbers relate to the collection or magazine"
+" when a document is selected. The total values of these documents in the "
+"graphics can not be considered as a value of total publications of the "
+"collection, because a document can be part of more than one area of "
+"expertise. This graphical is recommended for collecting indicators "
+"extraction."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:73
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por idioma de publicação"
-" e ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode ser publicado em mais de um idioma."
-msgstr "This chart shows the distribution of documents by language of publication and year of publication. The numbers are related to collection or journal when a journal is selected. The total values of documents of this chart can not be considered as the total publications of the collection once a document is published in more than one language."
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
+msgstr ""
+"This chart shows the total of published documents by publication year and"
+" document type. The numbers are related to one collection or to one "
+"journal when it is selected."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:91
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por país de afiliação "
-"dos autores e ano de publicação. Os números são relacionados a coleção ou ao"
-" periódico quando um periódico é selecionado. Os valores totais de "
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
 "documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode ser publicado por mais "
-"de um país de afiliação."
-msgstr "This chart show the total of documents by the affiliation country of the authors and the publication year. The numbers are related to the collection or the when a journal is selected. The total of documents of this chart can not be considered as the total of publications of the collection once the documents may have more than one affiliation country."
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
+msgstr ""
+"This chart shows the distribution of documents by language of publication"
+" and year of publication. The numbers are related to collection or "
+"journal when a journal is selected. The total values of documents of this"
+" chart can not be considered as the total publications of the collection "
+"once a document is published in more than one language."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+msgstr ""
+"This chart show the total of documents by the affiliation country of the "
+"authors and the publication year. The numbers are related to the "
+"collection or the when a journal is selected. The total of documents of "
+"this chart can not be considered as the total of publications of the "
+"collection once the documents may have more than one affiliation country."
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr "Received, granted and self citing"
 
-#: analytics/templates/website/publication_journal_licenses.mako:17
-msgid ""
-"Este gráfico apresenta o número de periódicos por licença de uso adotada. Os"
-" valores totais de periódicos deste gráfico não podem ser considerados como "
-"totais da coleção uma vez que um documento pode fazer parte de mais de uma "
-"área de atuação. Este gráfico é recomendado para extração de indicadores de "
-"Coleção."
-msgstr "This chart shows the number of journals adopted by use license. The total values of journals graphic can not be considered as a total value because a document can be part of more than one area of expertise. This graphical is recommended for collecting indicators extraction."
+#: /app/analytics/templates/website/publication_journal.mako:5
+msgid "Licenças de uso dos periódicos"
+msgstr ""
 
-#: analytics/templates/website/publication_journal_status.mako:17
+#: /app/analytics/templates/website/publication_journal.mako:10
+msgid "Áreas temáticas dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:15
+msgid "Ano de inclusão de periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:19
+msgid "Situação de publicação dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
-"Este gráfico apresenta o número de periódicos por status da publicação no "
-"SciELO. O status considerado neste grafíco é o status vigente do periódico, "
-"não são consideradas as mudanças de status a longo da existência do "
-"periódico nas bases SciELO. Este gráfico é recomendado para extração de "
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
 "indicadores de Coleção."
-msgstr "This chart shows the number of journals for publication in SciELO state. The state considered in this graph is the current state of the journal (current, not current, interrupted, etc.), are not considered state changes across the existence of the journal in SciELO. This graphical is recommended for collecting indicators."
+msgstr ""
+"This chart shows the number of journals adopted by use license. The total"
+" values of journals graphic can not be considered as a total value "
+"because a document can be part of more than one area of expertise. This "
+"graphical is recommended for collecting indicators extraction."
 
-#: analytics/templates/website/publication_journal_subject_areas.mako:17
+#: /app/analytics/templates/website/publication_journal_status.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+msgstr ""
+"This chart shows the number of journals for publication in SciELO state. "
+"The state considered in this graph is the current state of the journal "
+"(current, not current, interrupted, etc.), are not considered state "
+"changes across the existence of the journal in SciELO. This graphical is "
+"recommended for collecting indicators."
+
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção. As áreas de "
-"atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada"
-" um dos periódicos SciELO, podendo um periódico estar relacionado a mais de "
-"uma área de atuação. Os valores totais de periódicos deste gráfico não podem"
-" ser considerados como totais da coleção uma vez que um documento pode fazer"
-" parte de mais de uma área de atuação. Este gráfico é recomendado para "
-"extração de indicadores de Coleção."
-msgstr "This chart shows the number of journals per area. This graphical is recommended for collecting indicators. Ccorresponde areas to large areas of CNPQ, these are determined for each of the SciELO journals and a magazine can be related to more than one area of expertise. The total values of this graph can not be considered as the total for collection due to a document may be part of more than one area of expertise. This graphical is recommended for extracting indicators collection."
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"This chart shows the number of journals per area. This graphical is "
+"recommended for collecting indicators. Ccorresponde areas to large areas "
+"of CNPQ, these are determined for each of the SciELO journals and a "
+"magazine can be related to more than one area of expertise. The total "
+"values of this graph can not be considered as the total for collection "
+"due to a document may be part of more than one area of expertise. This "
+"graphical is recommended for extracting indicators collection."
 
-#: analytics/templates/website/publication_journal_year.mako:17
+#: /app/analytics/templates/website/publication_journal_year.mako:17
 msgid ""
-"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. "
-"Este gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "This chart show the number of journals by the inclusion year at SciELO. This chart is recommended for collection indicators."
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
+msgstr ""
+"This chart show the number of journals by the inclusion year at SciELO. "
+"This chart is recommended for collection indicators."
 
-#: analytics/templates/website/publication_size.mako:11
-#: analytics/templates/website/publication_size.mako:22
-#: analytics/templates/website/publication_size.mako:33
-#: analytics/templates/website/publication_size.mako:44
+#: /app/analytics/templates/website/publication_size.mako:11
+#: /app/analytics/templates/website/publication_size.mako:22
+#: /app/analytics/templates/website/publication_size.mako:33
+#: /app/analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "About the numbers"
 
-#: analytics/templates/website/publication_size.mako:14
+#: /app/analytics/templates/website/publication_size.mako:14
 msgid ""
-"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e "
-"artigo publicados. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado na barra superior do site."
-msgstr "The numbers above represents the number of journals with at least 1 issue and published documents. The numbers are related to the collection or journal selected in the top bar of this website."
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
+msgstr ""
+"The numbers above represents the number of journals with at least 1 issue"
+" and published documents. The numbers are related to the collection or "
+"journal selected in the top bar of this website."
 
-#: analytics/templates/website/publication_size.mako:25
+#: /app/analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
-"publicado. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado na barra superior do site."
-msgstr "The numbers above represents the number of issues with at least 1 published document. The numbers are related to the collection or journal selected in the top bar of this website."
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
+msgstr ""
+"The numbers above represents the number of issues with at least 1 "
+"published document. The numbers are related to the collection or journal "
+"selected in the top bar of this website."
 
-#: analytics/templates/website/publication_size.mako:36
+#: /app/analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
-msgstr "The numbers above represents the numberof published documents. The numbers are related to the collection or journal selected in the top bar of this website."
+msgstr ""
+"The numbers above represents the numberof published documents. The "
+"numbers are related to the collection or journal selected in the top bar "
+"of this website."
 
-#: analytics/templates/website/publication_size.mako:47
+#: /app/analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
-"citadas nos documentos publicados. Os números são relacionados a coleção ou "
-"ao periódico quando um periódico é selecionado na barra superior do site."
-msgstr "The numbers above represents the number of bibliographic references cited in the published documents. The numbers are related to the collection or journal selected in the top bar of this website."
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
+msgstr ""
+"The numbers above represents the number of bibliographic references cited"
+" in the published documents. The numbers are related to the collection or"
+" journal selected in the top bar of this website."
 
-#: analytics/templates/website/publication_size_citations.mako:9
+#: /app/analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "references"
 
-#: analytics/templates/website/publication_size_documents.mako:9
+#: /app/analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documents"
 
-#: analytics/templates/website/publication_size_issues.mako:9
+#: /app/analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "issues"
 
-#: analytics/templates/website/publication_size_journals.mako:9
+#: /app/analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "journals"
 
-#: analytics/templates/website/reports.mako:5
+#: /app/analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Spreadsheets"
 
-#: analytics/templates/website/reports.mako:7
+#: /app/analytics/templates/website/reports.mako:7
 msgid ""
-"O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados "
-"utilizados para produção dos indicadores presentes nesta ferramenta. "
-"Qualquer interessado pode fazer o download e produzir análises "
-"bibliométricas de acordo com suas necessidade."
-msgstr "SciELO supply some spreadsheets with some of the metadata used to produce the indicators available in this tool. Any interested people can download it to produce their own analysis."
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
+msgstr ""
+"SciELO supply some spreadsheets with some of the metadata used to produce"
+" the indicators available in this tool. Any interested people can "
+"download it to produce their own analysis."
 
-#: analytics/templates/website/reports.mako:10
-msgid ""
-"Para mais informações sobre as catacterísticas de cada tabulação, acessar"
+#: /app/analytics/templates/website/reports.mako:10
+msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "For more information about the caracteristics of each spreadsheet, access"
 
-#: analytics/templates/website/reports.mako:16
+#: /app/analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "file name"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "updating periodicity"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "monthly"
 
-#: analytics/templates/website/reports.mako:18
+#: /app/analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "file size"
 
-#: analytics/templates/website/reports.mako:19
+#: /app/analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "charset"
 
-#: analytics/templates/website/reports.mako:20
+#: /app/analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "last update"
 
-#: analytics/templates/website/reports.mako:23
+#: /app/analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "file not available for this collection"
 
-#: analytics/templates/website/share.mako:8
+#: /app/analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "share by email"
 
-#: analytics/templates/website/share.mako:10
+#: /app/analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "share at Facebook"
 
-#: analytics/templates/website/share.mako:13
+#: /app/analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "share at Twitter"
 
-#: analytics/templates/website/share.mako:16
+#: /app/analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "share at LinkedIn"

--- a/analytics/locale/es/LC_MESSAGES/analytics.po
+++ b/analytics/locale/es/LC_MESSAGES/analytics.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-09-17 18:21+0000\n"
+"POT-Creation-Date: 2019-09-18 12:50+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
 "Language: es\n"
@@ -25,421 +25,421 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.1\n"
 
-#: /app/analytics/charts_config.py:25
+#: analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fuente: SciELO.org"
 
-#: /app/analytics/charts_config.py:58
+#: analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:59
+#: analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:91
+#: analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Año de publicación de los documentos de la revista. (citados)"
 
-#: /app/analytics/charts_config.py:92
+#: analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Año de publicación de los documentos de la Red scIELO. (citantes)"
 
-#: /app/analytics/charts_config.py:100
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: analytics/charts_config.py:100
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+#: analytics/charts_config.py:103 analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
-#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
-#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
+#: analytics/charts_config.py:113 analytics/charts_config.py:135
+#: analytics/charts_config.py:157 analytics/charts_config.py:179
+#: analytics/charts_config.py:202 analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Año base"
 
-#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
-#: /app/analytics/charts_config.py:134
+#: analytics/charts_config.py:122 analytics/charts_config.py:125
+#: analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
-#: /app/analytics/charts_config.py:156
+#: analytics/charts_config.py:144 analytics/charts_config.py:147
+#: analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
-#: /app/analytics/charts_config.py:178
+#: analytics/charts_config.py:166 analytics/charts_config.py:169
+#: analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:188
+#: analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fuente: Google Scholar"
 
-#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
-#: /app/analytics/charts_config.py:201
+#: analytics/charts_config.py:189 analytics/charts_config.py:192
+#: analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: /app/analytics/charts_config.py:211
+#: analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "inmediatez"
 
-#: /app/analytics/charts_config.py:212
-#: /app/analytics/templates/website/access_datepicker.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: analytics/charts_config.py:212
+#: analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "Un año"
 
-#: /app/analytics/charts_config.py:213
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/charts_config.py:213
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 años"
 
-#: /app/analytics/charts_config.py:214
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/charts_config.py:214
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 años"
 
-#: /app/analytics/charts_config.py:215
+#: analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 años"
 
-#: /app/analytics/charts_config.py:216
+#: analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 años"
 
-#: /app/analytics/charts_config.py:223
+#: analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO en 1, 2, 3, 4, 5 años y Índice de Inmediatez"
 
-#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
-#: /app/analytics/templates/website/bibliometrics_journal.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: analytics/charts_config.py:226 analytics/charts_config.py:228
+#: analytics/templates/website/bibliometrics_journal.mako:23
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citación"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citas concedidas"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citas recibidas"
 
-#: /app/analytics/charts_config.py:244
+#: analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribición de citas concedidas, recibidas y auto citación"
 
-#: /app/analytics/charts_config.py:251
+#: analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citas"
 
-#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
-#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
-#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
-#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
-#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
-#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
-#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: analytics/charts_config.py:256 analytics/charts_config.py:273
+#: analytics/charts_config.py:287 analytics/charts_config.py:414
+#: analytics/charts_config.py:423 analytics/charts_config.py:438
+#: analytics/charts_config.py:446 analytics/charts_config.py:494
+#: analytics/charts_config.py:503 analytics/charts_config.py:562
+#: analytics/charts_config.py:572 analytics/charts_config.py:614
+#: analytics/charts_config.py:623 analytics/charts_config.py:664
+#: analytics/charts_config.py:672 analytics/charts_config.py:788
+#: analytics/templates/website/central_container_for_article_filters.mako:13
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Año de publicación"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citables"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos no citables"
 
-#: /app/analytics/charts_config.py:272
+#: analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribución de documentos citables y no citables"
 
-#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
-#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
-#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
-#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
-#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
-#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
-#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
-#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
+#: analytics/charts_config.py:281 analytics/charts_config.py:305
+#: analytics/charts_config.py:324 analytics/charts_config.py:341
+#: analytics/charts_config.py:388 analytics/charts_config.py:412
+#: analytics/charts_config.py:441 analytics/charts_config.py:467
+#: analytics/charts_config.py:492 analytics/charts_config.py:540
+#: analytics/charts_config.py:560 analytics/charts_config.py:568
+#: analytics/charts_config.py:591 analytics/charts_config.py:612
+#: analytics/charts_config.py:662 analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: /app/analytics/charts_config.py:298
+#: analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribución por número de referencias bibliográficas en los documentos"
 
-#: /app/analytics/charts_config.py:301
+#: analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referencias bibliográficas"
 
-#: /app/analytics/charts_config.py:308
+#: analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s de documentos con %s de referencias bibliográficas"
 
-#: /app/analytics/charts_config.py:317
+#: analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribución por número de autores de los documentos"
 
-#: /app/analytics/charts_config.py:320
-#: /app/analytics/templates/website/publication_article.mako:133
+#: analytics/charts_config.py:320
+#: analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: /app/analytics/charts_config.py:327
+#: analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s de documentos con %s de autores"
 
-#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
+#: analytics/charts_config.py:338 analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
-#: /app/analytics/charts_config.py:694
+#: analytics/charts_config.py:359 analytics/charts_config.py:391
+#: analytics/charts_config.py:446 analytics/charts_config.py:470
+#: analytics/charts_config.py:543 analytics/charts_config.py:594
+#: analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
-#: /app/analytics/charts_config.py:391
+#: analytics/charts_config.py:368 analytics/charts_config.py:383
+#: analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliación"
 
-#: /app/analytics/charts_config.py:404
+#: analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:437
+#: analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribución por año de publicación de los documentos"
 
-#: /app/analytics/charts_config.py:459
+#: analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribución de idiomas de los documentos"
 
-#: /app/analytics/charts_config.py:462
+#: analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicación"
 
-#: /app/analytics/charts_config.py:470
+#: analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma del documento"
 
-#: /app/analytics/charts_config.py:484
+#: analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribución de idiomas de los documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:514
+#: analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribución de revistas por año de incorporación en SciELO"
 
-#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
+#: analytics/charts_config.py:515 analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Año de incorporación"
 
-#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
-#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+#: analytics/charts_config.py:518 analytics/charts_config.py:642
+#: analytics/charts_config.py:711 analytics/charts_config.py:731
 msgid "Número de periódicos"
 msgstr "Número de revistas"
 
-#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
-#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
-#: /app/analytics/templates/website/navbar_collection.mako:10
-#: /app/analytics/templates/website/navbar_journal.mako:10
+#: analytics/charts_config.py:523 analytics/charts_config.py:645
+#: analytics/charts_config.py:714 analytics/charts_config.py:734
+#: analytics/templates/website/navbar_collection.mako:10
+#: analytics/templates/website/navbar_journal.mako:10
 msgid "Periódicos"
 msgstr "Revistas"
 
-#: /app/analytics/charts_config.py:532
+#: analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribución por área temática de los documentos"
 
-#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
+#: analytics/charts_config.py:535 analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Áreas temáticas"
 
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
+#: analytics/charts_config.py:543 analytics/charts_config.py:714
+#: analytics/templates/website/central_container_for_article_filters.mako:30
+#: analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: /app/analytics/charts_config.py:552
+#: analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribución de área temática de los documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:583
+#: analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribución por tipo de documento"
 
-#: /app/analytics/charts_config.py:586
-#: /app/analytics/templates/website/publication_article.mako:43
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
+#: analytics/charts_config.py:586
+#: analytics/templates/website/publication_article.mako:43
+#: analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: /app/analytics/charts_config.py:594
+#: analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: /app/analytics/charts_config.py:604
+#: analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribución de tipos de documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:634
+#: analytics/charts_config.py:634
 msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
 msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
 
-#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+#: analytics/charts_config.py:637 analytics/charts_config.py:645
 msgid "Situação da publicação"
 msgstr "Situación de la publicación"
 
-#: /app/analytics/charts_config.py:654
+#: analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribución de licencias de uso por año de publicación"
 
-#: /app/analytics/charts_config.py:683
+#: analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribución por licencia de uso de los documentos"
 
-#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
-#: /app/analytics/templates/website/publication_article.mako:5
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
+#: analytics/charts_config.py:686 analytics/charts_config.py:726
+#: analytics/templates/website/publication_article.mako:5
+#: analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licencia de uso"
 
-#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
+#: analytics/charts_config.py:694 analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licencia"
 
-#: /app/analytics/charts_config.py:703
+#: analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribución por área temática de las revistas"
 
-#: /app/analytics/charts_config.py:723
+#: analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribución por licencia de uso de las revistas"
 
-#: /app/analytics/charts_config.py:742
+#: analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de accesos por año y mes"
 
-#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
-#: /app/analytics/templates/website/navbar_collection.mako:7
-#: /app/analytics/templates/website/navbar_document.mako:7
-#: /app/analytics/templates/website/navbar_journal.mako:7
+#: analytics/charts_config.py:750 analytics/charts_config.py:785
+#: analytics/templates/website/navbar_collection.mako:7
+#: analytics/templates/website/navbar_document.mako:7
+#: analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesos"
 
-#: /app/analytics/charts_config.py:756
+#: analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesos en"
 
-#: /app/analytics/charts_config.py:767
+#: analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accesos por tipo de documento"
 
-#: /app/analytics/charts_config.py:771
+#: analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesos a documentos de tipo %s"
 
-#: /app/analytics/charts_config.py:783
+#: analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de los articulos por número de accesos en"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Año de consulta"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesos a los documentos del año %s"
 
-#: /app/analytics/templates/website/access_by_document_type.mako:6
-#: /app/analytics/templates/website/access_by_month_and_year.mako:5
-#: /app/analytics/templates/website/access_lifetime.mako:6
-#: /app/analytics/templates/website/accesses_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_authors.mako:5
-#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
-#: /app/analytics/templates/website/publication_article_document_type.mako:5
-#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_languages.mako:5
-#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_licenses.mako:5
-#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_references.mako:5
-#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
-#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: /app/analytics/templates/website/publication_article_year.mako:5
-#: /app/analytics/templates/website/publication_journal_licenses.mako:7
-#: /app/analytics/templates/website/publication_journal_status.mako:7
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
-#: /app/analytics/templates/website/publication_journal_year.mako:7
-#: /app/analytics/templates/website/publication_size_citations.mako:6
-#: /app/analytics/templates/website/publication_size_documents.mako:6
-#: /app/analytics/templates/website/publication_size_issues.mako:6
-#: /app/analytics/templates/website/publication_size_journals.mako:6
+#: analytics/templates/website/access_by_document_type.mako:6
+#: analytics/templates/website/access_by_month_and_year.mako:5
+#: analytics/templates/website/access_lifetime.mako:6
+#: analytics/templates/website/accesses_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: analytics/templates/website/publication_article_affiliations.mako:5
+#: analytics/templates/website/publication_article_affiliations_map.mako:5
+#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: analytics/templates/website/publication_article_authors.mako:5
+#: analytics/templates/website/publication_article_citable_documents.mako:5
+#: analytics/templates/website/publication_article_document_type.mako:5
+#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: analytics/templates/website/publication_article_languages.mako:5
+#: analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: analytics/templates/website/publication_article_licenses.mako:5
+#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: analytics/templates/website/publication_article_references.mako:5
+#: analytics/templates/website/publication_article_subject_areas.mako:6
+#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: analytics/templates/website/publication_article_year.mako:5
+#: analytics/templates/website/publication_journal_licenses.mako:7
+#: analytics/templates/website/publication_journal_status.mako:7
+#: analytics/templates/website/publication_journal_subject_areas.mako:7
+#: analytics/templates/website/publication_journal_year.mako:7
+#: analytics/templates/website/publication_size_citations.mako:6
+#: analytics/templates/website/publication_size_documents.mako:6
+#: analytics/templates/website/publication_size_issues.mako:6
+#: analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "cargando"
 
-#: /app/analytics/templates/website/access_datepicker.mako:5
+#: analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Revista"
 
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "accesos en los últimos 36 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "accesos en los ultimos 24 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "acessos en los últimos 12 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos los accesos disponibles"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "todo"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Seleccione el período a consultar"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
 "recuperação dos dados de acesso. Você pode também selecionar o período de"
@@ -451,96 +451,96 @@ msgstr ""
 "período de 1, 2 ó 3 años, a través de los enlaces rápidos, o puede "
 "seleccionar todos los accesos disponibles mediante la selección de todos."
 
-#: /app/analytics/templates/website/access_list_articles.mako:6
+#: analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 de artículos por número de accesos"
 
-#: /app/analytics/templates/website/access_list_articles.mako:9
+#: analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artículo"
 
-#: /app/analytics/templates/website/access_list_articles.mako:13
-#: /app/analytics/templates/website/access_list_issues.mako:13
-#: /app/analytics/templates/website/access_list_journals.mako:13
+#: analytics/templates/website/access_list_articles.mako:13
+#: analytics/templates/website/access_list_issues.mako:13
+#: analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumen"
 
-#: /app/analytics/templates/website/access_list_articles.mako:14
-#: /app/analytics/templates/website/access_list_issues.mako:14
-#: /app/analytics/templates/website/access_list_journals.mako:14
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
+#: analytics/templates/website/access_list_articles.mako:14
+#: analytics/templates/website/access_list_issues.mako:14
+#: analytics/templates/website/access_list_journals.mako:14
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: analytics/templates/website/bibliometrics_list_granted.mako:19
+#: analytics/templates/website/bibliometrics_list_granted.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: analytics/templates/website/bibliometrics_list_received.mako:26
+#: analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: /app/analytics/templates/website/access_list_issues.mako:6
+#: analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 de fascículos por número de accesos"
 
-#: /app/analytics/templates/website/access_list_issues.mako:9
-#: /app/analytics/templates/website/access_list_journals.mako:9
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: analytics/templates/website/access_list_issues.mako:9
+#: analytics/templates/website/access_list_journals.mako:9
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "revista"
 
-#: /app/analytics/templates/website/access_list_journals.mako:6
+#: analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesos a los documentos por revista"
 
-#: /app/analytics/templates/website/accesses.mako:6
+#: analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:12
+#: analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:18
+#: analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:15
+#: analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:6
+#: analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estadísticas"
 
-#: /app/analytics/templates/website/base.mako:30
+#: analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Colecciones"
 
-#: /app/analytics/templates/website/base.mako:38
-#: /app/analytics/templates/website/journal_selector_modal.mako:7
+#: analytics/templates/website/base.mako:38
+#: analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "seleccionar revista"
 
-#: /app/analytics/templates/website/base.mako:91
+#: analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Herramienta en desarrollo disponible en versión de pruebas Beta."
 
-#: /app/analytics/templates/website/base.mako:93
+#: analytics/templates/website/base.mako:93
 msgid ""
 "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
 " realizar testes de uso e performance. Todos os indicadores carregados "
@@ -553,214 +553,214 @@ msgstr ""
 "gradualmente. Se pueden presentar problemas de lentitud o disponibilidad "
 "durante esta fase."
 
-#: /app/analytics/templates/website/base.mako:114
+#: analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ayuda"
 
-#: /app/analytics/templates/website/base.mako:116
+#: analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: /app/analytics/templates/website/base.mako:117
+#: analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discusión"
 
-#: /app/analytics/templates/website/base.mako:121
+#: analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desarrollo"
 
-#: /app/analytics/templates/website/base.mako:124
+#: analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desarrollo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Enero"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Febrero"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Marzo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Mayo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junio"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julio"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Septiembre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Octubre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Noviembre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Diciembre"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Ene"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citas Recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "año de publicación"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primero autor"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título del documento"
 
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citas recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
+#: analytics/templates/website/bibliometrics_journal.mako:8
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: analytics/templates/website/bibliometrics_list_granted.mako:8
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atención"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
+#: analytics/templates/website/bibliometrics_journal.mako:11
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: analytics/templates/website/bibliometrics_list_granted.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "Es necesario seleccionar una revista para los datos bibliométricos "
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:20
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
+#: analytics/templates/website/bibliometrics_journal.mako:20
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: analytics/templates/website/bibliometrics_list_received.mako:19
+#: analytics/templates/website/central_container_for_article_filters.mako:16
+#: analytics/templates/website/central_container_for_article_filters.mako:33
+#: analytics/templates/website/central_container_for_article_filters.mako:52
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:32
-#: /app/analytics/templates/website/bibliometrics_journal.mako:51
-#: /app/analytics/templates/website/bibliometrics_journal.mako:69
-#: /app/analytics/templates/website/bibliometrics_journal.mako:87
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: /app/analytics/templates/website/publication_article.mako:14
-#: /app/analytics/templates/website/publication_article.mako:33
-#: /app/analytics/templates/website/publication_article.mako:52
-#: /app/analytics/templates/website/publication_article.mako:70
-#: /app/analytics/templates/website/publication_article.mako:88
-#: /app/analytics/templates/website/publication_article.mako:106
-#: /app/analytics/templates/website/publication_article.mako:124
-#: /app/analytics/templates/website/publication_article.mako:142
-#: /app/analytics/templates/website/publication_article.mako:160
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
-#: /app/analytics/templates/website/publication_journal_licenses.mako:14
-#: /app/analytics/templates/website/publication_journal_status.mako:14
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
-#: /app/analytics/templates/website/publication_journal_year.mako:14
+#: analytics/templates/website/bibliometrics_journal.mako:32
+#: analytics/templates/website/bibliometrics_journal.mako:51
+#: analytics/templates/website/bibliometrics_journal.mako:69
+#: analytics/templates/website/bibliometrics_journal.mako:87
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: analytics/templates/website/publication_article.mako:14
+#: analytics/templates/website/publication_article.mako:33
+#: analytics/templates/website/publication_article.mako:52
+#: analytics/templates/website/publication_article.mako:70
+#: analytics/templates/website/publication_article.mako:88
+#: analytics/templates/website/publication_article.mako:106
+#: analytics/templates/website/publication_article.mako:124
+#: analytics/templates/website/publication_article.mako:142
+#: analytics/templates/website/publication_article.mako:160
+#: analytics/templates/website/publication_article_by_publication_year.mako:14
+#: analytics/templates/website/publication_article_by_publication_year.mako:33
+#: analytics/templates/website/publication_article_by_publication_year.mako:52
+#: analytics/templates/website/publication_article_by_publication_year.mako:70
+#: analytics/templates/website/publication_article_by_publication_year.mako:88
+#: analytics/templates/website/publication_article_by_publication_year.mako:106
+#: analytics/templates/website/publication_journal_licenses.mako:14
+#: analytics/templates/website/publication_journal_status.mako:14
+#: analytics/templates/website/publication_journal_subject_areas.mako:14
+#: analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre la gráfica"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:35
+#: analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
@@ -772,12 +772,12 @@ msgstr ""
 "años. La línea de 2 años equivale al factor de impacto de Thomson Reuters"
 " "
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:42
+#: analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:54
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
+#: analytics/templates/website/bibliometrics_journal.mako:54
+#: analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
 "Este gráfico apresenta a distribuição de documentos citáveis e não "
 "citáveis relacionados ao periódico selecionado. De acordo com as regras "
@@ -793,11 +793,11 @@ msgstr ""
 "Communication y Article Commentary. Los demas tipos de documentos no don "
 "tomados en cuenta."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+#: analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:72
+#: analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
 "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
 "indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
@@ -805,17 +805,17 @@ msgid ""
 "ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
 "Ao clicar na série, você será direcionado para o site do Google Scholar."
 msgstr ""
-"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores "
-"son fornecidos anualmente por Google Scholar. La falta de indicadores para "
-"una revista o para un rango de una revista pueden ocurrir. Cuando clicar en "
-"una de las series, el usuário vá a ser direccionado para el sitio del Google "
-" Scholar."
+"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los "
+"idicadores son fornecidos anualmente por Google Scholar. La falta de "
+"indicadores para una revista o para un rango de una revista pueden "
+"ocurrir. Cuando clicar en una de las series, el usuário vá a ser "
+"direccionado para el sitio del Google  Scholar."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:78
+#: analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:90
+#: analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
@@ -825,106 +825,106 @@ msgstr ""
 " citaciones del periódico seleccionado, los datos están distribuidos por "
 "año de publicación."
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:27
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:28
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:29
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfica de calor de las citaciones recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
@@ -934,232 +934,232 @@ msgstr ""
 "corpus de citas corresponde a todas las colecciones de la Red SciELO, "
 "colecciones temáticas y independientes."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Listado de citaciones para el eje seleccionado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Elijir un eixo x/y para obtener el listado de citas para el período."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citaciones recibidas por la revistas"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos de la Red ScIELO publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citarón"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "veces los documentos de la revista"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique en el ele para mirar el listado de artículos citantes y citados."
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citación encontradas para la revista seleccionada"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: analytics/templates/website/bibliometrics_list_granted.mako:18
+#: analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acciones"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar error"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: analytics/templates/website/bibliometrics_list_granted.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sin resultados"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:30
-#: /app/analytics/templates/website/navbar_journal.mako:32
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: analytics/templates/website/navbar_collection.mako:30
+#: analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media de citas"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citas en"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicaciones de"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "total de citas"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citas"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "porcentaje"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "porcentaje acumulado"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:5
 msgid "Indicadores Bibliométricos da Rede SciELO"
 msgstr "Indicadores Bibliométricos de la Red SciELO"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid "Periodicidade de atualização:"
 msgstr "Periodicidad de actualización:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid " anual"
 msgstr " anual"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:13
 msgid "Indicadores de Publicação"
 msgstr "Indicadores de Publicación"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:19
 msgid "Numeros da Rede SciELO por:"
 msgstr "Números de la Red SciELO por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:54
 msgid "Ano de publicação: "
 msgstr "Año de publicación: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:35
 msgid "Periódico: "
 msgstr "Revista: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:55
 msgid "Assunto: "
 msgstr "Área: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:24
 msgid "País de afiliação do autor: "
 msgstr "País de afiliación del autor: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:26
 msgid "País de Afiliação do Autor por: "
 msgstr "País de Afiliación del Autor por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:30
 msgid "País de publicação da revista: "
 msgstr "País de publicación de la revista: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:33
 msgid "Número de Co-autores por: "
 msgstr "Número de Co-autores por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:46
 msgid "Indicadores de Coleção"
 msgstr "Indicadores de la Colección"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:52
 msgid "Periódico por:"
 msgstr "Revista por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:56
 msgid "Indicadores gerais: "
 msgstr "Indicadores generales: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:66
 msgid "Indicadores de Citação"
 msgstr "Indicadores de Citación"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:72
 msgid "Ano de Citação por:"
 msgstr "Año de Citación por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:90
 msgid "Idade do documento citado: "
 msgstr "Edad del documento citado: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:91
 msgid "Tipo de documento citado: "
 msgstr "Tipo de documento citado: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:77
 msgid "Periódico Citante por:"
 msgstr "Revista Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:82
 msgid "Assunto do Periódico Citante por:"
 msgstr "Área de la Revista Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:92
 msgid "Periódico SciELO citado: "
 msgstr "Revista SciELO citada: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:88
 msgid "País de Afiliação do Autor Citante por:"
 msgstr "País de Afiliación del Autor Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
+#: analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citas concedidas por revista"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:29
-#: /app/analytics/templates/website/navbar_journal.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: analytics/templates/website/navbar_collection.mako:29
+#: analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO en 1, 2, 3, 4 y 5 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
 "Aqui são considerados apenas os documentos citáveis. De acordo com as "
 "regras de contagem do SciELO, documentos citáveis devem ser do tipo "
@@ -1173,55 +1173,55 @@ msgstr ""
 "Review Article, Case Report, Brief Report, Rapid Communication y Article "
 "Commentary. Los demas tipos de documentos no don tomados en cuenta."
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:33
-#: /app/analytics/templates/website/navbar_journal.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:22
+#: analytics/templates/website/navbar_collection.mako:33
+#: analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citas recibidas por las revistas"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: analytics/templates/website/central_container_for_article_filters.mako:8
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtrados para documentos"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: analytics/templates/website/central_container_for_article_filters.mako:22
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
+#: analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
+#: analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtrados para revistas"
 
-#: /app/analytics/templates/website/faq.mako:5
+#: analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Preguntas frecuentes (Accesos)"
 
-#: /app/analytics/templates/website/faq.mako:7
+#: analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "¿Por qué algunas colecciones no poseen estadísticas de acceso?"
 
-#: /app/analytics/templates/website/faq.mako:8
+#: analytics/templates/website/faq.mako:8
 msgid ""
 "Para que os dados de acessos sejam computados é necessário que os logs de"
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
@@ -1232,13 +1232,13 @@ msgstr ""
 "estadísticas de acceso debe ser verificada con la coordinación de cada "
 "colección SciELO."
 
-#: /app/analytics/templates/website/faq.mako:11
+#: analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr ""
 "¿Por qué algunas colecciones poseen accesos calculados para una revista "
 "más grande?"
 
-#: /app/analytics/templates/website/faq.mako:12
+#: analytics/templates/website/faq.mako:12
 msgid ""
 "O período disponível de cada uma das coleções depende do período "
 "disponível dos logs de acessos de cada uma das coleções. Este projeto se "
@@ -1250,12 +1250,12 @@ msgstr ""
 " compromiso de calcular los datos de accesos a partir del 2012, siempre "
 "que los logs sean debidamente proporcionados por las colecciones. "
 
-#: /app/analytics/templates/website/faq.mako:15
-#: /app/analytics/templates/website/faq.mako:36
+#: analytics/templates/website/faq.mako:15
+#: analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "¿Qué es lo que se esta contando?"
 
-#: /app/analytics/templates/website/faq.mako:16
+#: analytics/templates/website/faq.mako:16
 msgid ""
 "Estão sendo contabilizados e classificados os acessos ao texto completo "
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
@@ -1265,7 +1265,7 @@ msgstr ""
 "HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de "
 "resumen del artículo."
 
-#: /app/analytics/templates/website/faq.mako:19
+#: analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
@@ -1273,7 +1273,7 @@ msgstr ""
 "¿Por qué los indicadores de esta herramienta son diferentes a los "
 "ofrecidos en otras herramientas de SciELO?"
 
-#: /app/analytics/templates/website/faq.mako:21
+#: analytics/templates/website/faq.mako:21
 msgid ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
@@ -1281,7 +1281,7 @@ msgstr ""
 "Algunas herramientas de SciELO pueden estar utilizando servicios antiguos"
 " de estadísticas de acceso."
 
-#: /app/analytics/templates/website/faq.mako:22
+#: analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
@@ -1289,7 +1289,7 @@ msgstr ""
 "El conteo de accesos de esta herramienta es diferente en diversos "
 "aspectos a las herramientas antiguas."
 
-#: /app/analytics/templates/website/faq.mako:23
+#: analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
@@ -1297,24 +1297,24 @@ msgstr ""
 "Algunas herramientas poseen una delta de actualización para diferencias "
 "los indicadores de acceso."
 
-#: /app/analytics/templates/website/faq.mako:27
-#: /app/analytics/templates/website/faq.mako:40
+#: analytics/templates/website/faq.mako:27
+#: analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "¿Cuál es la periodicidad de actualización de los indicadores?"
 
-#: /app/analytics/templates/website/faq.mako:28
+#: analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensual"
 
-#: /app/analytics/templates/website/faq.mako:30
+#: analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Preguntas frecuentes (Publicación)"
 
-#: /app/analytics/templates/website/faq.mako:32
+#: analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "¿Por qué algunas colecciones tienen datos desactualizados?"
 
-#: /app/analytics/templates/website/faq.mako:33
+#: analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1326,7 +1326,7 @@ msgstr ""
 "indicadores esta directamente relacionada al correcto desarrollo de los "
 "procesos en cada una de las colecciones."
 
-#: /app/analytics/templates/website/faq.mako:37
+#: analytics/templates/website/faq.mako:37
 msgid ""
 "Estão sendo contabilizados indicadores de publicação das coleções com "
 "base nos metadados fornecidos durante todo o processo de publicação de um"
@@ -1339,108 +1339,108 @@ msgstr ""
 "relacionada con la calidad de los procesos implementados por cada una de "
 "las colecciones."
 
-#: /app/analytics/templates/website/faq.mako:41
+#: analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: /app/analytics/templates/website/home_collection.mako:7
-#: /app/analytics/templates/website/home_journal.mako:7
-#: /app/analytics/templates/website/home_network.mako:7
-#: /app/analytics/templates/website/navbar_collection.mako:18
-#: /app/analytics/templates/website/navbar_journal.mako:18
-#: /app/analytics/templates/website/publication_size.mako:5
+#: analytics/templates/website/home_collection.mako:7
+#: analytics/templates/website/home_journal.mako:7
+#: analytics/templates/website/home_network.mako:7
+#: analytics/templates/website/navbar_collection.mako:18
+#: analytics/templates/website/navbar_journal.mako:18
+#: analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composición de la colección"
 
-#: /app/analytics/templates/website/home_collection.mako:24
-#: /app/analytics/templates/website/home_document.mako:21
-#: /app/analytics/templates/website/home_journal.mako:21
-#: /app/analytics/templates/website/home_network.mako:24
-#: /app/analytics/templates/website/navbar_collection.mako:9
-#: /app/analytics/templates/website/navbar_collection.mako:27
-#: /app/analytics/templates/website/navbar_document.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:26
+#: analytics/templates/website/home_collection.mako:24
+#: analytics/templates/website/home_document.mako:21
+#: analytics/templates/website/home_journal.mako:21
+#: analytics/templates/website/home_network.mako:24
+#: analytics/templates/website/navbar_collection.mako:9
+#: analytics/templates/website/navbar_collection.mako:27
+#: analytics/templates/website/navbar_document.mako:9
+#: analytics/templates/website/navbar_journal.mako:9
+#: analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficas"
 
-#: /app/analytics/templates/website/home_document.mako:7
+#: analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores de documentos"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:6
+#: analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "cerrar"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:11
+#: analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "seleccionar una revista"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:20
+#: analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "seleccionar"
 
-#: /app/analytics/templates/website/navbar_collection.mako:11
-#: /app/analytics/templates/website/navbar_journal.mako:11
+#: analytics/templates/website/navbar_collection.mako:11
+#: analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 fascículos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:12
-#: /app/analytics/templates/website/navbar_journal.mako:12
+#: analytics/templates/website/navbar_collection.mako:12
+#: analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 artículos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:16
-#: /app/analytics/templates/website/navbar_journal.mako:16
+#: analytics/templates/website/navbar_collection.mako:16
+#: analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicación"
 
-#: /app/analytics/templates/website/navbar_collection.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:19
+#: analytics/templates/website/navbar_collection.mako:19
+#: analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficas de documentos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:20
-#: /app/analytics/templates/website/navbar_journal.mako:20
+#: analytics/templates/website/navbar_collection.mako:20
+#: analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficas de documentos por año de publicación"
 
-#: /app/analytics/templates/website/navbar_collection.mako:21
+#: analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficas de revistas"
 
-#: /app/analytics/templates/website/navbar_collection.mako:25
-#: /app/analytics/templates/website/navbar_document.mako:13
-#: /app/analytics/templates/website/navbar_journal.mako:24
+#: analytics/templates/website/navbar_collection.mako:25
+#: analytics/templates/website/navbar_document.mako:13
+#: analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometría"
 
-#: /app/analytics/templates/website/navbar_collection.mako:32
-#: /app/analytics/templates/website/navbar_journal.mako:34
+#: analytics/templates/website/navbar_collection.mako:32
+#: analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citas concedidas por las revistas"
 
-#: /app/analytics/templates/website/navbar_collection.mako:34
-#: /app/analytics/templates/website/navbar_journal.mako:36
+#: analytics/templates/website/navbar_collection.mako:34
+#: analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citación de la revista"
 
-#: /app/analytics/templates/website/navbar_collection.mako:35
-#: /app/analytics/templates/website/navbar_journal.mako:37
+#: analytics/templates/website/navbar_collection.mako:35
+#: analytics/templates/website/navbar_journal.mako:37
 msgid "Indicadores Gerais"
 msgstr "Indicadores Generales"
 
-#: /app/analytics/templates/website/navbar_collection.mako:39
-#: /app/analytics/templates/website/navbar_document.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:41
+#: analytics/templates/website/navbar_collection.mako:39
+#: analytics/templates/website/navbar_document.mako:19
+#: analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Informes"
 
-#: /app/analytics/templates/website/navbar_document.mako:15
+#: analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Citas recibidas"
 
-#: /app/analytics/templates/website/publication_article.mako:17
+#: analytics/templates/website/publication_article.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso. "
 "Os números são relacionados a coleção ou ao periódico quando um periódico"
@@ -1454,12 +1454,12 @@ msgstr ""
 "de uso dependen de la adopción de la colección o periódico seleccionado "
 "de licencias de uso creative commons."
 
-#: /app/analytics/templates/website/publication_article.mako:24
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
+#: analytics/templates/website/publication_article.mako:24
+#: analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:36
+#: analytics/templates/website/publication_article.mako:36
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por área de "
 "atuação. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1481,7 +1481,7 @@ msgstr ""
 "hacer parte de una o más áreas de actuación. Esta gráfica es recomendada "
 "para la extracción de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_article.mako:55
+#: analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1494,12 +1494,12 @@ msgstr ""
 "utilizados por el SciELO Citation Index y documentados en el SciELO "
 "Publishing Schema."
 
-#: /app/analytics/templates/website/publication_article.mako:61
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
+#: analytics/templates/website/publication_article.mako:61
+#: analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:73
+#: analytics/templates/website/publication_article.mako:73
 msgid ""
 "Este gráfico apresenta o total de documentos por idioma de publicação. Os"
 " números são relacionados a coleção ou ao periódico quando um periódico é"
@@ -1513,11 +1513,11 @@ msgstr ""
 "gráfica no pueden ser considerados como totales de publicación de la "
 "colección, pues un documento puede ser publicado en uno o más idiomas."
 
-#: /app/analytics/templates/website/publication_article.mako:79
+#: analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:91
+#: analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
@@ -1527,12 +1527,12 @@ msgstr ""
 "publicación. Los número están relacionados a una colección, o al "
 "periódico cuando algún periódico es seleccionado."
 
-#: /app/analytics/templates/website/publication_article.mako:97
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
+#: analytics/templates/website/publication_article.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:109
+#: analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
@@ -1544,11 +1544,11 @@ msgstr ""
 " considerados como totales de la colección dado que un documento puede "
 "tener más de un país de afiliación."
 
-#: /app/analytics/templates/website/publication_article.mako:115
+#: analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:127
+#: analytics/templates/website/publication_article.mako:127
 msgid ""
 "Este mapa apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste mapa não podem ser "
@@ -1560,7 +1560,7 @@ msgstr ""
 "considerarse como totales de publicación de la colección, pues un "
 "documento puede estar asociado a uno o más países de afiliación."
 
-#: /app/analytics/templates/website/publication_article.mako:145
+#: analytics/templates/website/publication_article.mako:145
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1570,11 +1570,11 @@ msgstr ""
 " Los números están relacionados a la colección, o al periódico cuando un "
 "periódico esta seleccionado."
 
-#: /app/analytics/templates/website/publication_article.mako:151
+#: analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:163
+#: analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
@@ -1584,7 +1584,7 @@ msgstr ""
 "referencias bibliográficas. Los número están relacionados a una "
 "colección, o al periódico cuando algún periódico es seleccionado. "
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
+#: analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
@@ -1598,7 +1598,7 @@ msgstr ""
 "indicadores de licencias de uso depende de la adopción de la colección o "
 "de la revista seleccionada por licencias creative commons."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
+#: analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por área de atuação e"
 " ano de publicação. Os números são relacionados a coleção ou ao periódico"
@@ -1616,7 +1616,7 @@ msgstr ""
 " más áreas de actuaciones. Esta gráfica es recomendada para la extracción"
 " de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
+#: analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por tipo de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1626,7 +1626,7 @@ msgstr ""
 "publicación y año de publicación. Los numeros están relacionados a una "
 "colección, o a la revista cuando alguna revista es seleccionada."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+#: analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por idioma de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1642,7 +1642,7 @@ msgstr ""
 "publicación de la colección, pues un documento puede ser publicado en uno"
 " o más idiomas."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+#: analytics/templates/website/publication_article_by_publication_year.mako:91
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por país de afiliação"
 " dos autores e ano de publicação. Os números são relacionados a coleção "
@@ -1658,27 +1658,27 @@ msgstr ""
 "como totales de publicación de la colección, pues un documento puede ser "
 "publicado por uno o más países de afiliación."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:5
+#: analytics/templates/website/publication_journal.mako:5
 msgid "Licenças de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:10
+#: analytics/templates/website/publication_journal.mako:10
 msgid "Áreas temáticas dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:15
+#: analytics/templates/website/publication_journal.mako:15
 msgid "Ano de inclusão de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:19
+#: analytics/templates/website/publication_journal.mako:19
 msgid "Situação de publicação dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+#: analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por licença de uso adotada."
 " Os valores totais de periódicos deste gráfico não podem ser considerados"
@@ -1692,7 +1692,7 @@ msgstr ""
 "parte de una o más área de actuación. Esta gráfica es recomendada para "
 "extracción de indicadores de Colección. "
 
-#: /app/analytics/templates/website/publication_journal_status.mako:17
+#: analytics/templates/website/publication_journal_status.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por status da publicação no"
 " SciELO. O status considerado neste grafíco é o status vigente do "
@@ -1706,7 +1706,7 @@ msgstr ""
 " existencia del periódico en las bases SciELO. Esta gráfica es "
 "recomendada para extracción de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
+#: analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
 "gráfico é recomendado para extração de indicadores de Coleção. As áreas "
@@ -1728,7 +1728,7 @@ msgstr ""
 "actuación. Esta gráfica es recomendada para extracción de indicadores de "
 "Colección."
 
-#: /app/analytics/templates/website/publication_journal_year.mako:17
+#: analytics/templates/website/publication_journal_year.mako:17
 msgid ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
@@ -1737,14 +1737,14 @@ msgstr ""
 "SciELO. Este gráfico es recomendado para extracción de indicadores de "
 "Colección."
 
-#: /app/analytics/templates/website/publication_size.mako:11
-#: /app/analytics/templates/website/publication_size.mako:22
-#: /app/analytics/templates/website/publication_size.mako:33
-#: /app/analytics/templates/website/publication_size.mako:44
+#: analytics/templates/website/publication_size.mako:11
+#: analytics/templates/website/publication_size.mako:22
+#: analytics/templates/website/publication_size.mako:33
+#: analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre los números"
 
-#: /app/analytics/templates/website/publication_size.mako:14
+#: analytics/templates/website/publication_size.mako:14
 msgid ""
 "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
@@ -1755,7 +1755,7 @@ msgstr ""
 "colección o a la revista cuando una revista es eligida en la parte "
 "superior del sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:25
+#: analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
@@ -1766,7 +1766,7 @@ msgstr ""
 "colección o a la revista cuando una revista es eligida en la parte "
 "superior el sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:36
+#: analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1776,7 +1776,7 @@ msgstr ""
 " número estan relacionados a la colección o a la revista cuando una "
 "revista es eligida en la parte superior del sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:47
+#: analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
 "citadas nos documentos publicados. Os números são relacionados a coleção "
@@ -1788,27 +1788,27 @@ msgstr ""
 " o a la revista cuando una revista es eligida en la parte superior del "
 "sitio."
 
-#: /app/analytics/templates/website/publication_size_citations.mako:9
+#: analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referencias"
 
-#: /app/analytics/templates/website/publication_size_documents.mako:9
+#: analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: /app/analytics/templates/website/publication_size_issues.mako:9
+#: analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: /app/analytics/templates/website/publication_size_journals.mako:10
+#: analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "revistas"
 
-#: /app/analytics/templates/website/reports.mako:5
+#: analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tablas"
 
-#: /app/analytics/templates/website/reports.mako:7
+#: analytics/templates/website/reports.mako:7
 msgid ""
 "O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
 "metadados utilizados para produção dos indicadores presentes nesta "
@@ -1820,50 +1820,51 @@ msgstr ""
 "herramienta. Cualquiera interesado puede descargar y elaborar análisis "
 "bibliométricos de acuerdo a su necesidad."
 
-#: /app/analytics/templates/website/reports.mako:10
+#: analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mas informaciones sobre las características de cada tabla, acceder"
 
-#: /app/analytics/templates/website/reports.mako:16
+#: analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nombre del archivo"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidad de actualización"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensual"
 
-#: /app/analytics/templates/website/reports.mako:18
+#: analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamaño del archivo"
 
-#: /app/analytics/templates/website/reports.mako:19
+#: analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: /app/analytics/templates/website/reports.mako:20
+#: analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última actualización"
 
-#: /app/analytics/templates/website/reports.mako:23
+#: analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "archivo no disponible para la colección"
 
-#: /app/analytics/templates/website/share.mako:8
+#: analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartir por email"
 
-#: /app/analytics/templates/website/share.mako:10
+#: analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartir en Facebook"
 
-#: /app/analytics/templates/website/share.mako:13
+#: analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartir en Twitter"
 
-#: /app/analytics/templates/website/share.mako:16
+#: analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartir en LinkedIn"
+

--- a/analytics/locale/es/LC_MESSAGES/analytics.po
+++ b/analytics/locale/es/LC_MESSAGES/analytics.po
@@ -1,7 +1,7 @@
-# Translations template for analytics.
+# Spanish translations for analytics.
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the analytics project.
-# 
+#
 # Translators:
 # Arturo Rendón Cruz <herzmx@gmail.com>, 2015
 # fabiobatalha <fabiobatalha@gmail.com>, 2016
@@ -11,1537 +11,1859 @@
 # scielo <tecnologia@scielo.org>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Analytics\n"
+"Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-07-28 11:18-0300\n"
+"POT-Creation-Date: 2019-09-17 18:21+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/scielo/analytics/language/es/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.0\n"
 "Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: Spanish "
+"(http://www.transifex.com/scielo/analytics/language/es/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: analytics/charts_config.py:25
+#: /app/analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fuente: SciELO.org"
 
-#: analytics/charts_config.py:58
+#: /app/analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:59
+#: /app/analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: analytics/charts_config.py:91
+#: /app/analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Año de publicación de los documentos de la revista. (citados)"
 
-#: analytics/charts_config.py:92
+#: /app/analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Año de publicación de los documentos de la Red scIELO. (citantes)"
 
-#: analytics/charts_config.py:100 analytics/charts_config.py:103
-#: analytics/charts_config.py:112
-msgid "Fator de impacto JCR"
+#: /app/analytics/charts_config.py:100
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: analytics/charts_config.py:113 analytics/charts_config.py:136
-#: analytics/charts_config.py:163
+#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+msgid "Média de percentil"
+msgstr ""
+
+#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
+#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Año base"
 
-#: analytics/charts_config.py:122
+#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
+#: /app/analytics/charts_config.py:134
+msgid "Eigen Factor JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
+#: /app/analytics/charts_config.py:156
+msgid "Received Citations JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
+#: /app/analytics/charts_config.py:178
+msgid "Fator de impacto JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fuente: Google Scholar"
 
-#: analytics/charts_config.py:123 analytics/charts_config.py:126
-#: analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
+#: /app/analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: analytics/charts_config.py:145
+#: /app/analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "inmediatez"
 
-#: analytics/charts_config.py:146
-#: analytics/templates/website/access_datepicker.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: /app/analytics/charts_config.py:212
+#: /app/analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "Un año"
 
-#: analytics/charts_config.py:147
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/charts_config.py:213
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 años"
 
-#: analytics/charts_config.py:148
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/charts_config.py:214
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 años"
 
-#: analytics/charts_config.py:149
+#: /app/analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 años"
 
-#: analytics/charts_config.py:150
+#: /app/analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 años"
 
-#: analytics/charts_config.py:157
+#: /app/analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO en 1, 2, 3, 4, 5 años y Índice de Inmediatez"
 
-#: analytics/charts_config.py:160 analytics/charts_config.py:162
-#: analytics/templates/website/bibliometrics_journal.mako:23
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
+#: /app/analytics/templates/website/bibliometrics_journal.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citación"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citas concedidas"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citas recibidas"
 
-#: analytics/charts_config.py:178
+#: /app/analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribición de citas concedidas, recibidas y auto citación"
 
-#: analytics/charts_config.py:185
+#: /app/analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citas"
 
-#: analytics/charts_config.py:190 analytics/charts_config.py:207
-#: analytics/charts_config.py:221 analytics/charts_config.py:348
-#: analytics/charts_config.py:357 analytics/charts_config.py:372
-#: analytics/charts_config.py:380 analytics/charts_config.py:428
-#: analytics/charts_config.py:437 analytics/charts_config.py:516
-#: analytics/charts_config.py:526 analytics/charts_config.py:568
-#: analytics/charts_config.py:577 analytics/charts_config.py:618
-#: analytics/charts_config.py:626 analytics/charts_config.py:742
-#: analytics/templates/website/central_container_for_article_filters.mako:13
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
+#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
+#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
+#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
+#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
+#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Año de publicación"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citables"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos no citables"
 
-#: analytics/charts_config.py:206
+#: /app/analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribución de documentos citables y no citables"
 
-#: analytics/charts_config.py:215 analytics/charts_config.py:239
-#: analytics/charts_config.py:258 analytics/charts_config.py:275
-#: analytics/charts_config.py:322 analytics/charts_config.py:346
-#: analytics/charts_config.py:375 analytics/charts_config.py:401
-#: analytics/charts_config.py:426 analytics/charts_config.py:494
-#: analytics/charts_config.py:514 analytics/charts_config.py:522
-#: analytics/charts_config.py:545 analytics/charts_config.py:566
-#: analytics/charts_config.py:616 analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
+#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
+#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
+#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
+#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
+#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
+#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
+#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: analytics/charts_config.py:232
+#: /app/analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribución por número de referencias bibliográficas en los documentos"
 
-#: analytics/charts_config.py:235
+#: /app/analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referencias bibliográficas"
 
-#: analytics/charts_config.py:242
+#: /app/analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s de documentos con %s de referencias bibliográficas"
 
-#: analytics/charts_config.py:251
+#: /app/analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribución por número de autores de los documentos"
 
-#: analytics/charts_config.py:254
-#: analytics/templates/website/publication_article.mako:133
+#: /app/analytics/charts_config.py:320
+#: /app/analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: analytics/charts_config.py:261
+#: /app/analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s de documentos con %s de autores"
 
-#: analytics/charts_config.py:272 analytics/charts_config.py:314
+#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: analytics/charts_config.py:293 analytics/charts_config.py:325
-#: analytics/charts_config.py:380 analytics/charts_config.py:404
-#: analytics/charts_config.py:497 analytics/charts_config.py:548
-#: analytics/charts_config.py:648
+#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
+#: /app/analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: analytics/charts_config.py:302 analytics/charts_config.py:317
-#: analytics/charts_config.py:325
+#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
+#: /app/analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliación"
 
-#: analytics/charts_config.py:338
+#: /app/analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:371
+#: /app/analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribución por año de publicación de los documentos"
 
-#: analytics/charts_config.py:393
+#: /app/analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribución de idiomas de los documentos"
 
-#: analytics/charts_config.py:396
+#: /app/analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicación"
 
-#: analytics/charts_config.py:404
+#: /app/analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma del documento"
 
-#: analytics/charts_config.py:418
+#: /app/analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribución de idiomas de los documentos por año de publicación"
 
-#: analytics/charts_config.py:448 analytics/charts_config.py:588
-msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
-msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
-
-#: analytics/charts_config.py:451 analytics/charts_config.py:459
-#: analytics/charts_config.py:591 analytics/charts_config.py:599
-msgid "Situação da publicação"
-msgstr "Situación de la publicación"
-
-#: analytics/charts_config.py:456 analytics/charts_config.py:472
-#: analytics/charts_config.py:596 analytics/charts_config.py:665
-#: analytics/charts_config.py:685
-msgid "Número de periódicos"
-msgstr "Número de revistas"
-
-#: analytics/charts_config.py:459 analytics/charts_config.py:477
-#: analytics/charts_config.py:599 analytics/charts_config.py:668
-#: analytics/charts_config.py:688
-#: analytics/templates/website/navbar_collection.mako:10
-#: analytics/templates/website/navbar_journal.mako:10
-msgid "Periódicos"
-msgstr "Revistas"
-
-#: analytics/charts_config.py:468
+#: /app/analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribución de revistas por año de incorporación en SciELO"
 
-#: analytics/charts_config.py:469 analytics/charts_config.py:477
+#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Año de incorporación"
 
-#: analytics/charts_config.py:486
+#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
+#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+msgid "Número de periódicos"
+msgstr "Número de revistas"
+
+#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
+#: /app/analytics/templates/website/navbar_collection.mako:10
+#: /app/analytics/templates/website/navbar_journal.mako:10
+msgid "Periódicos"
+msgstr "Revistas"
+
+#: /app/analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribución por área temática de los documentos"
 
-#: analytics/charts_config.py:489 analytics/charts_config.py:660
+#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Áreas temáticas"
 
-#: analytics/charts_config.py:497 analytics/charts_config.py:668
-#: analytics/templates/website/central_container_for_article_filters.mako:30
-#: analytics/templates/website/central_container_for_journal_filters.mako:13
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: analytics/charts_config.py:506
+#: /app/analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribución de área temática de los documentos por año de publicación"
 
-#: analytics/charts_config.py:537
+#: /app/analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribución por tipo de documento"
 
-#: analytics/charts_config.py:540
-#: analytics/templates/website/publication_article.mako:43
-#: analytics/templates/website/publication_article_by_publication_year.mako:43
+#: /app/analytics/charts_config.py:586
+#: /app/analytics/templates/website/publication_article.mako:43
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: analytics/charts_config.py:548
+#: /app/analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: analytics/charts_config.py:558
+#: /app/analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribución de tipos de documentos por año de publicación"
 
-#: analytics/charts_config.py:608
+#: /app/analytics/charts_config.py:634
+msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
+msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
+
+#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+msgid "Situação da publicação"
+msgstr "Situación de la publicación"
+
+#: /app/analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribución de licencias de uso por año de publicación"
 
-#: analytics/charts_config.py:637
+#: /app/analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribución por licencia de uso de los documentos"
 
-#: analytics/charts_config.py:640 analytics/charts_config.py:680
-#: analytics/templates/website/publication_article.mako:5
-#: analytics/templates/website/publication_article_by_publication_year.mako:5
+#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
+#: /app/analytics/templates/website/publication_article.mako:5
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licencia de uso"
 
-#: analytics/charts_config.py:648 analytics/charts_config.py:688
+#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licencia"
 
-#: analytics/charts_config.py:657
+#: /app/analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribución por área temática de las revistas"
 
-#: analytics/charts_config.py:677
+#: /app/analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribución por licencia de uso de las revistas"
 
-#: analytics/charts_config.py:696
+#: /app/analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de accesos por año y mes"
 
-#: analytics/charts_config.py:704 analytics/charts_config.py:739
-#: analytics/templates/website/navbar_collection.mako:7
-#: analytics/templates/website/navbar_document.mako:7
-#: analytics/templates/website/navbar_journal.mako:7
+#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
+#: /app/analytics/templates/website/navbar_collection.mako:7
+#: /app/analytics/templates/website/navbar_document.mako:7
+#: /app/analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesos"
 
-#: analytics/charts_config.py:710
+#: /app/analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesos en"
 
-#: analytics/charts_config.py:721
+#: /app/analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accesos por tipo de documento"
 
-#: analytics/charts_config.py:725
+#: /app/analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesos a documentos de tipo %s"
 
-#: analytics/charts_config.py:737
+#: /app/analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de los articulos por número de accesos en"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Año de consulta"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesos a los documentos del año %s"
 
-#: analytics/controller.py:354
-msgid "Fator de impacto 5 anos"
-msgstr ""
-
-#: analytics/controller.py:359
-msgid "Fator de impacto 2 anos"
-msgstr ""
-
-#: analytics/controller.py:364
-msgid "Fator de impacto 2 anos, sem auto citação"
-msgstr ""
-
-#: analytics/templates/website/access_by_document_type.mako:6
-#: analytics/templates/website/access_by_month_and_year.mako:5
-#: analytics/templates/website/access_lifetime.mako:6
-#: analytics/templates/website/accesses_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: analytics/templates/website/publication_article_affiliations.mako:5
-#: analytics/templates/website/publication_article_affiliations_map.mako:5
-#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: analytics/templates/website/publication_article_authors.mako:5
-#: analytics/templates/website/publication_article_citable_documents.mako:5
-#: analytics/templates/website/publication_article_document_type.mako:5
-#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: analytics/templates/website/publication_article_languages.mako:5
-#: analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: analytics/templates/website/publication_article_licenses.mako:5
-#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: analytics/templates/website/publication_article_references.mako:5
-#: analytics/templates/website/publication_article_subject_areas.mako:6
-#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: analytics/templates/website/publication_article_year.mako:5
-#: analytics/templates/website/publication_journal_licenses.mako:7
-#: analytics/templates/website/publication_journal_status.mako:7
-#: analytics/templates/website/publication_journal_subject_areas.mako:7
-#: analytics/templates/website/publication_journal_year.mako:7
-#: analytics/templates/website/publication_size_citations.mako:6
-#: analytics/templates/website/publication_size_documents.mako:6
-#: analytics/templates/website/publication_size_issues.mako:6
-#: analytics/templates/website/publication_size_journals.mako:6
+#: /app/analytics/templates/website/access_by_document_type.mako:6
+#: /app/analytics/templates/website/access_by_month_and_year.mako:5
+#: /app/analytics/templates/website/access_lifetime.mako:6
+#: /app/analytics/templates/website/accesses_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_authors.mako:5
+#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
+#: /app/analytics/templates/website/publication_article_document_type.mako:5
+#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_languages.mako:5
+#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_licenses.mako:5
+#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_references.mako:5
+#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
+#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: /app/analytics/templates/website/publication_article_year.mako:5
+#: /app/analytics/templates/website/publication_journal_licenses.mako:7
+#: /app/analytics/templates/website/publication_journal_status.mako:7
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
+#: /app/analytics/templates/website/publication_journal_year.mako:7
+#: /app/analytics/templates/website/publication_size_citations.mako:6
+#: /app/analytics/templates/website/publication_size_documents.mako:6
+#: /app/analytics/templates/website/publication_size_issues.mako:6
+#: /app/analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "cargando"
 
-#: analytics/templates/website/access_datepicker.mako:5
+#: /app/analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Revista"
 
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "accesos en los últimos 36 meses"
 
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "accesos en los ultimos 24 meses"
 
-#: analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "acessos en los últimos 12 meses"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos los accesos disponibles"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "todo"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Seleccione el período a consultar"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
-"recuperação dos dados de acesso. Você pode também selecionar o período de 1,"
-" 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis "
-"selecionando tudo."
-msgstr "Utilice las fechas para seleccionar un periodo de tiempo para la recuperación de información de acceso. También puede seleccionar un período de 1, 2 ó 3 años, a través de los enlaces rápidos, o puede seleccionar todos los accesos disponibles mediante la selección de todos."
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
+msgstr ""
+"Utilice las fechas para seleccionar un periodo de tiempo para la "
+"recuperación de información de acceso. También puede seleccionar un "
+"período de 1, 2 ó 3 años, a través de los enlaces rápidos, o puede "
+"seleccionar todos los accesos disponibles mediante la selección de todos."
 
-#: analytics/templates/website/access_list_articles.mako:6
+#: /app/analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 de artículos por número de accesos"
 
-#: analytics/templates/website/access_list_articles.mako:9
+#: /app/analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artículo"
 
-#: analytics/templates/website/access_list_articles.mako:13
-#: analytics/templates/website/access_list_issues.mako:13
-#: analytics/templates/website/access_list_journals.mako:13
+#: /app/analytics/templates/website/access_list_articles.mako:13
+#: /app/analytics/templates/website/access_list_issues.mako:13
+#: /app/analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumen"
 
-#: analytics/templates/website/access_list_articles.mako:14
-#: analytics/templates/website/access_list_issues.mako:14
-#: analytics/templates/website/access_list_journals.mako:14
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: analytics/templates/website/bibliometrics_list_granted.mako:19
-#: analytics/templates/website/bibliometrics_list_granted.mako:30
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: analytics/templates/website/bibliometrics_list_received.mako:26
-#: analytics/templates/website/bibliometrics_list_received.mako:37
+#: /app/analytics/templates/website/access_list_articles.mako:14
+#: /app/analytics/templates/website/access_list_issues.mako:14
+#: /app/analytics/templates/website/access_list_journals.mako:14
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: analytics/templates/website/access_list_issues.mako:6
+#: /app/analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 de fascículos por número de accesos"
 
-#: analytics/templates/website/access_list_issues.mako:9
-#: analytics/templates/website/access_list_journals.mako:9
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: /app/analytics/templates/website/access_list_issues.mako:9
+#: /app/analytics/templates/website/access_list_journals.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "revista"
 
-#: analytics/templates/website/access_list_journals.mako:6
+#: /app/analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesos a los documentos por revista"
 
-#: analytics/templates/website/accesses.mako:6
+#: /app/analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:12
+#: /app/analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:18
+#: /app/analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:15
+#: /app/analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: analytics/templates/website/base.mako:6
+#: /app/analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estadísticas"
 
-#: analytics/templates/website/base.mako:30
+#: /app/analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Colecciones"
 
-#: analytics/templates/website/base.mako:38
-#: analytics/templates/website/journal_selector_modal.mako:7
+#: /app/analytics/templates/website/base.mako:38
+#: /app/analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "seleccionar revista"
 
-#: analytics/templates/website/base.mako:91
+#: /app/analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Herramienta en desarrollo disponible en versión de pruebas Beta."
 
-#: analytics/templates/website/base.mako:93
+#: /app/analytics/templates/website/base.mako:93
 msgid ""
-"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de "
-"realizar testes de uso e performance. Todos os indicadores carregados são "
-"reais e estão sendo atualizados e inseridos gradativamente. Problemas de "
-"lentidão e indisponibilidade do serviços são esperados nesta fase."
-msgstr "Esta herramienta se encuentra en desarrollo y ha sido publicada con el propósito de realizar pruebas de uso y rendimiento. Todos los indicadores mostrados son reales y están siendo actualizados y agregados gradualmente. Se pueden presentar problemas de lentitud o disponibilidad durante esta fase."
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
+msgstr ""
+"Esta herramienta se encuentra en desarrollo y ha sido publicada con el "
+"propósito de realizar pruebas de uso y rendimiento. Todos los indicadores"
+" mostrados son reales y están siendo actualizados y agregados "
+"gradualmente. Se pueden presentar problemas de lentitud o disponibilidad "
+"durante esta fase."
 
-#: analytics/templates/website/base.mako:114
+#: /app/analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ayuda"
 
-#: analytics/templates/website/base.mako:116
+#: /app/analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: analytics/templates/website/base.mako:117
+#: /app/analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discusión"
 
-#: analytics/templates/website/base.mako:121
+#: /app/analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desarrollo"
 
-#: analytics/templates/website/base.mako:124
+#: /app/analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desarrollo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Enero"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Febrero"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Marzo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Mayo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junio"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julio"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Septiembre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Octubre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Noviembre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Diciembre"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Ene"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citas Recibidas"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "año de publicación"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primero autor"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título del documento"
 
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citas recibidas"
 
-#: analytics/templates/website/bibliometrics_journal.mako:8
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: analytics/templates/website/bibliometrics_list_granted.mako:8
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: analytics/templates/website/bibliometrics_list_received.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atención"
 
-#: analytics/templates/website/bibliometrics_journal.mako:11
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: analytics/templates/website/bibliometrics_list_granted.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: analytics/templates/website/bibliometrics_list_received.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "Es necesario seleccionar una revista para los datos bibliométricos "
 
-#: analytics/templates/website/bibliometrics_journal.mako:20
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: analytics/templates/website/bibliometrics_list_received.mako:19
-#: analytics/templates/website/central_container_for_article_filters.mako:16
-#: analytics/templates/website/central_container_for_article_filters.mako:33
-#: analytics/templates/website/central_container_for_article_filters.mako:52
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: analytics/templates/website/central_container_for_journal_filters.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal.mako:20
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: analytics/templates/website/bibliometrics_journal.mako:32
-#: analytics/templates/website/bibliometrics_journal.mako:51
-#: analytics/templates/website/bibliometrics_journal.mako:69
-#: analytics/templates/website/bibliometrics_journal.mako:87
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: analytics/templates/website/publication_article.mako:14
-#: analytics/templates/website/publication_article.mako:33
-#: analytics/templates/website/publication_article.mako:52
-#: analytics/templates/website/publication_article.mako:70
-#: analytics/templates/website/publication_article.mako:88
-#: analytics/templates/website/publication_article.mako:106
-#: analytics/templates/website/publication_article.mako:124
-#: analytics/templates/website/publication_article.mako:142
-#: analytics/templates/website/publication_article.mako:160
-#: analytics/templates/website/publication_article_by_publication_year.mako:14
-#: analytics/templates/website/publication_article_by_publication_year.mako:33
-#: analytics/templates/website/publication_article_by_publication_year.mako:52
-#: analytics/templates/website/publication_article_by_publication_year.mako:70
-#: analytics/templates/website/publication_article_by_publication_year.mako:88
-#: analytics/templates/website/publication_article_by_publication_year.mako:106
-#: analytics/templates/website/publication_journal_licenses.mako:14
-#: analytics/templates/website/publication_journal_status.mako:14
-#: analytics/templates/website/publication_journal_subject_areas.mako:14
-#: analytics/templates/website/publication_journal_year.mako:14
+#: /app/analytics/templates/website/bibliometrics_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal.mako:51
+#: /app/analytics/templates/website/bibliometrics_journal.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal.mako:87
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: /app/analytics/templates/website/publication_article.mako:14
+#: /app/analytics/templates/website/publication_article.mako:33
+#: /app/analytics/templates/website/publication_article.mako:52
+#: /app/analytics/templates/website/publication_article.mako:70
+#: /app/analytics/templates/website/publication_article.mako:88
+#: /app/analytics/templates/website/publication_article.mako:106
+#: /app/analytics/templates/website/publication_article.mako:124
+#: /app/analytics/templates/website/publication_article.mako:142
+#: /app/analytics/templates/website/publication_article.mako:160
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
+#: /app/analytics/templates/website/publication_journal_licenses.mako:14
+#: /app/analytics/templates/website/publication_journal_status.mako:14
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
+#: /app/analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre la gráfica"
 
-#: analytics/templates/website/bibliometrics_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
 "linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
 "Reuters"
-msgstr "Esta gráfica muestra el factor de impacto del periódico seleccionado considerando los periódicos de inmediatez, más allá de períodos de 1 a 5 años. La línea de 2 años equivale al factor de impacto de Thomson Reuters "
+msgstr ""
+"Esta gráfica muestra el factor de impacto del periódico seleccionado "
+"considerando los periódicos de inmediatez, más allá de períodos de 1 a 5 "
+"años. La línea de 2 años equivale al factor de impacto de Thomson Reuters"
+" "
 
-#: analytics/templates/website/bibliometrics_journal.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:54
-#: analytics/templates/website/publication_article_by_publication_year.mako:109
+#: /app/analytics/templates/website/bibliometrics_journal.mako:54
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
-"Este gráfico apresenta a distribuição de documentos citáveis e não citáveis "
-"relacionados ao periódico selecionado. De acordo com as regras de contagem "
-"do SciELO, documentos citáveis devem ser do tipo \"Research Article\", "
-"\"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid "
-"Communication\" e \"Article Commentary\". Os demais tipos de documentos são "
-"considerados não citáveis."
-msgstr "Esta gráfica muestra la distribución de documentos citables y non citables relacionados al periódico seleccionado. De acuerdo con las reglas de cuenta de citas de SciELO, los documentos citables son de los tipos Research Article, Review Article, Case Report, Brief Report, Rapid Communication y Article Commentary. Los demas tipos de documentos no don tomados en cuenta."
-
-#: analytics/templates/website/bibliometrics_journal.mako:60
-msgid "Google H5M5"
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
 msgstr ""
+"Esta gráfica muestra la distribución de documentos citables y non "
+"citables relacionados al periódico seleccionado. De acuerdo con las "
+"reglas de cuenta de citas de SciELO, los documentos citables son de los "
+"tipos Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication y Article Commentary. Los demas tipos de documentos no don "
+"tomados en cuenta."
 
-#: analytics/templates/website/bibliometrics_journal.mako:72
+#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+msgid "Google H5M5"
+msgstr "Google H5M5"
+
+#: /app/analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
-"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores "
-"são fornecidos anualmente pelo Google Scholar. A ausência de indicadores "
-"para um periódico ou para um período de um periódico pode ocorrer caso esses"
-" dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, "
-"você será direcionado para o site do Google Scholar."
-msgstr "Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores son fornecidos anualmente por Google Scholar. La falta de indicadores para una revista o para un rango de una revista pueden ocurrir. Cuando clicar en una de las series, el usuário vá a ser direccionado para el sitio del Google Scholar."
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
+msgstr ""
+"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores "
+"son fornecidos anualmente por Google Scholar. La falta de indicadores para "
+"una revista o para un rango de una revista pueden ocurrir. Cuando clicar en "
+"una de las series, el usuário vá a ser direccionado para el sitio del Google "
+" Scholar."
 
-#: analytics/templates/website/bibliometrics_journal.mako:78
+#: /app/analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:90
+#: /app/analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
-"citações do periódico selecionado, os dados estão distribuidos por ano de "
-"publicação."
-msgstr "Esta gráfica muestra el número de citaciones concedidas, recibidas y auto citaciones del periódico seleccionado, los datos están distribuidos por año de publicación."
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
+msgstr ""
+"Esta gráfica muestra el número de citaciones concedidas, recibidas y auto"
+" citaciones del periódico seleccionado, los datos están distribuidos por "
+"año de publicación."
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: analytics/templates/website/navbar_journal.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: analytics/templates/website/navbar_journal.mako:28
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+msgid "Dados extraídos em: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:25
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+msgid "Eigen Factor"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: analytics/templates/website/navbar_journal.mako:29
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfica de calor de las citaciones recibidas"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
-msgstr "La gráfica presenta el número de citas recibidas por una revista. El corpus de citas corresponde a todas las colecciones de la Red SciELO, colecciones temáticas y independientes."
+msgstr ""
+"La gráfica presenta el número de citas recibidas por una revista. El "
+"corpus de citas corresponde a todas las colecciones de la Red SciELO, "
+"colecciones temáticas y independientes."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Listado de citaciones para el eje seleccionado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Elijir un eixo x/y para obtener el listado de citas para el período."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citaciones recibidas por la revistas"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos de la Red ScIELO publicados en"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citarón"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "veces los documentos de la revista"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados en"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique en el ele para mirar el listado de artículos citantes y citados."
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citación encontradas para la revista seleccionada"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: analytics/templates/website/bibliometrics_list_granted.mako:18
-#: analytics/templates/website/bibliometrics_list_received.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acciones"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar error"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: analytics/templates/website/bibliometrics_list_granted.mako:35
-#: analytics/templates/website/bibliometrics_list_received.mako:42
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sin resultados"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: analytics/templates/website/navbar_collection.mako:30
-#: analytics/templates/website/navbar_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:30
+#: /app/analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media de citas"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citas en"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicaciones de"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "total de citas"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citas"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "porcentaje"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "porcentaje acumulado"
 
-#: analytics/templates/website/bibliometrics_list_granted.mako:15
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+msgid "Indicadores Bibliométricos da Rede SciELO"
+msgstr "Indicadores Bibliométricos de la Red SciELO"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid "Periodicidade de atualização:"
+msgstr "Periodicidad de actualización:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid " anual"
+msgstr " anual"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+msgid "Indicadores de Publicação"
+msgstr "Indicadores de Publicación"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+msgid "Numeros da Rede SciELO por:"
+msgstr "Números de la Red SciELO por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+msgid "Ano de publicação: "
+msgstr "Año de publicación: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+msgid "Periódico: "
+msgstr "Revista: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+msgid "Assunto: "
+msgstr "Área: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+msgid "País de afiliação do autor: "
+msgstr "País de afiliación del autor: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+msgid "País de Afiliação do Autor por: "
+msgstr "País de Afiliación del Autor por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+msgid "País de publicação da revista: "
+msgstr "País de publicación de la revista: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+msgid "Número de Co-autores por: "
+msgstr "Número de Co-autores por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+msgid "Indicadores de Coleção"
+msgstr "Indicadores de la Colección"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+msgid "Periódico por:"
+msgstr "Revista por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+msgid "Indicadores gerais: "
+msgstr "Indicadores generales: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+msgid "Indicadores de Citação"
+msgstr "Indicadores de Citación"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+msgid "Ano de Citação por:"
+msgstr "Año de Citación por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+msgid "Idade do documento citado: "
+msgstr "Edad del documento citado: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+msgid "Tipo de documento citado: "
+msgstr "Tipo de documento citado: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+msgid "Periódico Citante por:"
+msgstr "Revista Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+msgid "Assunto do Periódico Citante por:"
+msgstr "Área de la Revista Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+msgid "Periódico SciELO citado: "
+msgstr "Revista SciELO citada: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+msgid "País de Afiliação do Autor Citante por:"
+msgstr "País de Afiliación del Autor Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citas concedidas por revista"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: analytics/templates/website/navbar_collection.mako:29
-#: analytics/templates/website/navbar_journal.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:29
+#: /app/analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO en 1, 2, 3, 4 y 5 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados en"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
-"Aqui são considerados apenas os documentos citáveis. De acordo com as regras"
-" de contagem do SciELO, documentos citáveis devem ser do tipo Research "
-"Article, Review Article, Case Report, Brief Report, Rapid Communication e "
-"Article Commentary. Os demais tipos de documentos são considerados não "
-"citáveis."
-msgstr "Esta gráfica muestra la distribución de documentos citables relacionados al periódico seleccionado. De acuerdo con las reglas de cuenta de citas de SciELO, los documentos citables son de los tipos Research Article, Review Article, Case Report, Brief Report, Rapid Communication y Article Commentary. Los demas tipos de documentos no don tomados en cuenta."
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos citables relacionados "
+"al periódico seleccionado. De acuerdo con las reglas de cuenta de citas "
+"de SciELO, los documentos citables son de los tipos Research Article, "
+"Review Article, Case Report, Brief Report, Rapid Communication y Article "
+"Commentary. Los demas tipos de documentos no don tomados en cuenta."
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 años"
 
-#: analytics/templates/website/bibliometrics_list_received.mako:22
-#: analytics/templates/website/navbar_collection.mako:33
-#: analytics/templates/website/navbar_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:33
+#: /app/analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citas recibidas por las revistas"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:8
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtrados para documentos"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:22
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:49
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: analytics/templates/website/central_container_for_journal_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtrados para revistas"
 
-#: analytics/templates/website/faq.mako:5
+#: /app/analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Preguntas frecuentes (Accesos)"
 
-#: analytics/templates/website/faq.mako:7
+#: /app/analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "¿Por qué algunas colecciones no poseen estadísticas de acceso?"
 
-#: analytics/templates/website/faq.mako:8
+#: /app/analytics/templates/website/faq.mako:8
 msgid ""
-"Para que os dados de acessos sejam computados é necessário que os logs de "
-"acessos sejam enviados para processamento. A ausência de estatísticas de "
-"acessos deve ser verificada com a coordenação de cada coleção SciELO."
-msgstr "Para que los datos de accesos sean calculados en necesario que los logs de accesos sean enviados para su procesamiento. La ausencia de estadísticas de acceso debe ser verificada con la coordinación de cada colección SciELO."
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
+msgstr ""
+"Para que los datos de accesos sean calculados en necesario que los logs "
+"de accesos sean enviados para su procesamiento. La ausencia de "
+"estadísticas de acceso debe ser verificada con la coordinación de cada "
+"colección SciELO."
 
-#: analytics/templates/website/faq.mako:11
+#: /app/analytics/templates/website/faq.mako:11
+msgid "Por que algumas coleções possuem acessos computados para um período maior?"
+msgstr ""
+"¿Por qué algunas colecciones poseen accesos calculados para una revista "
+"más grande?"
+
+#: /app/analytics/templates/website/faq.mako:12
 msgid ""
-"Por que algumas coleções possuem acessos computados para um período maior?"
-msgstr "¿Por qué algunas colecciones poseen accesos calculados para una revista más grande?"
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
+msgstr ""
+"Las revistas disponibles en cada colección dependen de las revistas de "
+"los logs de acceso de cada una de las colecciones. Este proyecto tiene el"
+" compromiso de calcular los datos de accesos a partir del 2012, siempre "
+"que los logs sean debidamente proporcionados por las colecciones. "
 
-#: analytics/templates/website/faq.mako:12
-msgid ""
-"O período disponível de cada uma das coleções depende do período disponível "
-"dos logs de acessos de cada uma das coleções. Este projeto se compromete a "
-"computar os dados de acessos à partir de 2012, desde que os logs sejam "
-"devidamente fornecidos pelas coleções."
-msgstr "Las revistas disponibles en cada colección dependen de las revistas de los logs de acceso de cada una de las colecciones. Este proyecto tiene el compromiso de calcular los datos de accesos a partir del 2012, siempre que los logs sean debidamente proporcionados por las colecciones. "
-
-#: analytics/templates/website/faq.mako:15
-#: analytics/templates/website/faq.mako:36
+#: /app/analytics/templates/website/faq.mako:15
+#: /app/analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "¿Qué es lo que se esta contando?"
 
-#: analytics/templates/website/faq.mako:16
+#: /app/analytics/templates/website/faq.mako:16
 msgid ""
-"Estão sendo contabilizados e classificados os acessos ao texto completo em "
-"HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
-msgstr "Están siendo contados y clasificados los accesos a texto completo en HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de resumen del artículo."
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
+msgstr ""
+"Están siendo contados y clasificados los accesos a texto completo en "
+"HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de "
+"resumen del artículo."
 
-#: analytics/templates/website/faq.mako:19
+#: /app/analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
-msgstr "¿Por qué los indicadores de esta herramienta son diferentes a los ofrecidos en otras herramientas de SciELO?"
+msgstr ""
+"¿Por qué los indicadores de esta herramienta son diferentes a los "
+"ofrecidos en otras herramientas de SciELO?"
 
-#: analytics/templates/website/faq.mako:21
+#: /app/analytics/templates/website/faq.mako:21
 msgid ""
-"Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos "
-"de estatísticas de acessos."
-msgstr "Algunas herramientas de SciELO pueden estar utilizando servicios antiguos de estadísticas de acceso."
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
+msgstr ""
+"Algunas herramientas de SciELO pueden estar utilizando servicios antiguos"
+" de estadísticas de acceso."
 
-#: analytics/templates/website/faq.mako:22
+#: /app/analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
-msgstr "El conteo de accesos de esta herramienta es diferente en diversos aspectos a las herramientas antiguas."
+msgstr ""
+"El conteo de accesos de esta herramienta es diferente en diversos "
+"aspectos a las herramientas antiguas."
 
-#: analytics/templates/website/faq.mako:23
+#: /app/analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
-msgstr "Algunas herramientas poseen una delta de actualización para diferencias los indicadores de acceso."
+msgstr ""
+"Algunas herramientas poseen una delta de actualización para diferencias "
+"los indicadores de acceso."
 
-#: analytics/templates/website/faq.mako:27
-#: analytics/templates/website/faq.mako:40
+#: /app/analytics/templates/website/faq.mako:27
+#: /app/analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "¿Cuál es la periodicidad de actualización de los indicadores?"
 
-#: analytics/templates/website/faq.mako:28
+#: /app/analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensual"
 
-#: analytics/templates/website/faq.mako:30
+#: /app/analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Preguntas frecuentes (Publicación)"
 
-#: analytics/templates/website/faq.mako:32
+#: /app/analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "¿Por qué algunas colecciones tienen datos desactualizados?"
 
-#: analytics/templates/website/faq.mako:33
+#: /app/analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
 "diretamente ligada a condução adequada desses processos por cada uma das "
 "coleções."
-msgstr "La actualización de los datos depende de los procesos referentes a cada una de las colecciones certificadas en SciELO. La actualización de estos indicadores esta directamente relacionada al correcto desarrollo de los procesos en cada una de las colecciones."
+msgstr ""
+"La actualización de los datos depende de los procesos referentes a cada "
+"una de las colecciones certificadas en SciELO. La actualización de estos "
+"indicadores esta directamente relacionada al correcto desarrollo de los "
+"procesos en cada una de las colecciones."
 
-#: analytics/templates/website/faq.mako:37
+#: /app/analytics/templates/website/faq.mako:37
 msgid ""
-"Estão sendo contabilizados indicadores de publicação das coleções com base "
-"nos metadados fornecidos durante todo o processo de publicação de um "
-"documento no SciELO. A qualidade desses indicadores esta diretamente ligada "
-"a qualidade dos processos implementados por cada uma das coleções."
-msgstr "Los indicadores de publicación están siendo generados con base en los metadatos proporcionados durante todo el porceso de publicación de un documento en SciELO. La calidad de estos indicadores esta directamente relacionada con la calidad de los procesos implementados por cada una de las colecciones."
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
+msgstr ""
+"Los indicadores de publicación están siendo generados con base en los "
+"metadatos proporcionados durante todo el porceso de publicación de un "
+"documento en SciELO. La calidad de estos indicadores esta directamente "
+"relacionada con la calidad de los procesos implementados por cada una de "
+"las colecciones."
 
-#: analytics/templates/website/faq.mako:41
+#: /app/analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: analytics/templates/website/home_collection.mako:7
-#: analytics/templates/website/home_journal.mako:7
-#: analytics/templates/website/home_network.mako:7
-#: analytics/templates/website/navbar_collection.mako:18
-#: analytics/templates/website/navbar_journal.mako:18
-#: analytics/templates/website/publication_size.mako:5
+#: /app/analytics/templates/website/home_collection.mako:7
+#: /app/analytics/templates/website/home_journal.mako:7
+#: /app/analytics/templates/website/home_network.mako:7
+#: /app/analytics/templates/website/navbar_collection.mako:18
+#: /app/analytics/templates/website/navbar_journal.mako:18
+#: /app/analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composición de la colección"
 
-#: analytics/templates/website/home_collection.mako:24
-#: analytics/templates/website/home_document.mako:21
-#: analytics/templates/website/home_journal.mako:21
-#: analytics/templates/website/home_network.mako:24
-#: analytics/templates/website/navbar_collection.mako:9
-#: analytics/templates/website/navbar_collection.mako:27
-#: analytics/templates/website/navbar_document.mako:9
-#: analytics/templates/website/navbar_journal.mako:9
-#: analytics/templates/website/navbar_journal.mako:26
+#: /app/analytics/templates/website/home_collection.mako:24
+#: /app/analytics/templates/website/home_document.mako:21
+#: /app/analytics/templates/website/home_journal.mako:21
+#: /app/analytics/templates/website/home_network.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:9
+#: /app/analytics/templates/website/navbar_collection.mako:27
+#: /app/analytics/templates/website/navbar_document.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficas"
 
-#: analytics/templates/website/home_document.mako:7
+#: /app/analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores de documentos"
 
-#: analytics/templates/website/journal_selector_modal.mako:6
+#: /app/analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "cerrar"
 
-#: analytics/templates/website/journal_selector_modal.mako:11
+#: /app/analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "seleccionar una revista"
 
-#: analytics/templates/website/journal_selector_modal.mako:20
+#: /app/analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "seleccionar"
 
-#: analytics/templates/website/navbar_collection.mako:11
-#: analytics/templates/website/navbar_journal.mako:11
+#: /app/analytics/templates/website/navbar_collection.mako:11
+#: /app/analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 fascículos"
 
-#: analytics/templates/website/navbar_collection.mako:12
-#: analytics/templates/website/navbar_journal.mako:12
+#: /app/analytics/templates/website/navbar_collection.mako:12
+#: /app/analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 artículos"
 
-#: analytics/templates/website/navbar_collection.mako:16
-#: analytics/templates/website/navbar_journal.mako:16
+#: /app/analytics/templates/website/navbar_collection.mako:16
+#: /app/analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicación"
 
-#: analytics/templates/website/navbar_collection.mako:19
-#: analytics/templates/website/navbar_journal.mako:19
+#: /app/analytics/templates/website/navbar_collection.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficas de documentos"
 
-#: analytics/templates/website/navbar_collection.mako:20
-#: analytics/templates/website/navbar_journal.mako:20
+#: /app/analytics/templates/website/navbar_collection.mako:20
+#: /app/analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficas de documentos por año de publicación"
 
-#: analytics/templates/website/navbar_collection.mako:21
+#: /app/analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficas de revistas"
 
-#: analytics/templates/website/navbar_collection.mako:25
-#: analytics/templates/website/navbar_document.mako:13
-#: analytics/templates/website/navbar_journal.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:25
+#: /app/analytics/templates/website/navbar_document.mako:13
+#: /app/analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometría"
 
-#: analytics/templates/website/navbar_collection.mako:32
-#: analytics/templates/website/navbar_journal.mako:34
+#: /app/analytics/templates/website/navbar_collection.mako:32
+#: /app/analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citas concedidas por las revistas"
 
-#: analytics/templates/website/navbar_collection.mako:34
-#: analytics/templates/website/navbar_journal.mako:36
+#: /app/analytics/templates/website/navbar_collection.mako:34
+#: /app/analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citación de la revista"
 
-#: analytics/templates/website/navbar_collection.mako:38
-#: analytics/templates/website/navbar_document.mako:19
-#: analytics/templates/website/navbar_journal.mako:40
+#: /app/analytics/templates/website/navbar_collection.mako:35
+#: /app/analytics/templates/website/navbar_journal.mako:37
+msgid "Indicadores Gerais"
+msgstr "Indicadores Generales"
+
+#: /app/analytics/templates/website/navbar_collection.mako:39
+#: /app/analytics/templates/website/navbar_document.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Informes"
 
-#: analytics/templates/website/navbar_document.mako:15
+#: /app/analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Citas recibidas"
 
-#: analytics/templates/website/publication_article.mako:17
+#: /app/analytics/templates/website/publication_article.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. A disponibilidade de indicadores de licença de uso dependem da "
-"adoção da coleção ou periódico selecionado de licenças de uso creative "
-"commons."
-msgstr "Esta gráfica muestra la distribución de documentos por licencia de uso. Los números son relacionados a la colección o al periódico cuando se ha seleccionado un periódico. La disponibilidad de indicadores de licencia de uso dependen de la adopción de la colección o periódico seleccionado de licencias de uso creative commons."
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por licencia de uso. "
+"Los números son relacionados a la colección o al periódico cuando se ha "
+"seleccionado un periódico. La disponibilidad de indicadores de licencia "
+"de uso dependen de la adopción de la colección o periódico seleccionado "
+"de licencias de uso creative commons."
 
-#: analytics/templates/website/publication_article.mako:24
-#: analytics/templates/website/publication_article_by_publication_year.mako:24
+#: /app/analytics/templates/website/publication_article.mako:24
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:36
+#: /app/analytics/templates/website/publication_article.mako:36
 msgid ""
-"Este gráfico apresenta o total de documentos publicados por área de atuação."
-" Os números são relacionados a coleção ou ao periódico quando um periódico é"
-" selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas "
-"são determinadas para cada um dos periódicos SciELO, podendo um periódico "
-"estar relacionado a mais de uma área de atuação. Os valores totais de "
-"documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode fazer parte de mais de "
-"uma área de atuação. Este gráfico é recomendado para extração de indicadores"
-" de Coleção."
-msgstr "Esta gráfica muestra el total de documentos publicados por área de actuación. Los números relacionados a la colección,  o a la revista cuando se ha seleccionado una revista. Las áreas de actuación son las grandes áreas del CNPQ, estas áreas son determinadas para cada revista SciELO, permitiendo que un periódico esté relacionado a una o más áreas de actuación. Los valores totales de documentos de esta gráfica no pueden ser considerado como totales de la colección, pues un documento puede hacer parte de una o más áreas de actuación. Esta gráfica es recomendada para la extracción de indicadores de Colección."
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el total de documentos publicados por área de "
+"actuación. Los números relacionados a la colección,  o a la revista "
+"cuando se ha seleccionado una revista. Las áreas de actuación son las "
+"grandes áreas del CNPQ, estas áreas son determinadas para cada revista "
+"SciELO, permitiendo que un periódico esté relacionado a una o más áreas "
+"de actuación. Los valores totales de documentos de esta gráfica no pueden"
+" ser considerado como totales de la colección, pues un documento puede "
+"hacer parte de una o más áreas de actuación. Esta gráfica es recomendada "
+"para la extracción de indicadores de Colección."
 
-#: analytics/templates/website/publication_article.mako:55
+#: /app/analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
 "Citation Index e documentados no SciELO Publishing Schema."
-msgstr "Esta grafica muestra el total de documentos por tipo de documento. Los número están relacionados a la colección, o al periódico cuando se ha seleccionado un periódico. Los tipos de documentos son los tipos utilizados por el SciELO Citation Index y documentados en el SciELO Publishing Schema."
+msgstr ""
+"Esta grafica muestra el total de documentos por tipo de documento. Los "
+"número están relacionados a la colección, o al periódico cuando se ha "
+"seleccionado un periódico. Los tipos de documentos son los tipos "
+"utilizados por el SciELO Citation Index y documentados en el SciELO "
+"Publishing Schema."
 
-#: analytics/templates/website/publication_article.mako:61
-#: analytics/templates/website/publication_article_by_publication_year.mako:61
+#: /app/analytics/templates/website/publication_article.mako:61
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:73
+#: /app/analytics/templates/website/publication_article.mako:73
 msgid ""
-"Este gráfico apresenta o total de documentos por idioma de publicação. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ser publicado em mais de um idioma."
-msgstr "Esta gráfica muestra el total de documentos por idioma de publicación. Los números están relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado en uno o más idiomas."
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
+msgstr ""
+"Esta gráfica muestra el total de documentos por idioma de publicación. "
+"Los números están relacionados a la colección, o a la revista cuando se "
+"ha seleccionado una revista. Los valores totales de documentos de esta "
+"gráfica no pueden ser considerados como totales de publicación de la "
+"colección, pues un documento puede ser publicado en uno o más idiomas."
 
-#: analytics/templates/website/publication_article.mako:79
+#: /app/analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:91
+#: /app/analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
-"publicação. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado."
-msgstr "Esta gráfica muestra el total de documentos publicados por año de publicación. Los número están relacionados a una colección, o al periódico cuando algún periódico es seleccionado."
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
+msgstr ""
+"Esta gráfica muestra el total de documentos publicados por año de "
+"publicación. Los número están relacionados a una colección, o al "
+"periódico cuando algún periódico es seleccionado."
 
-#: analytics/templates/website/publication_article.mako:97
-#: analytics/templates/website/publication_article_by_publication_year.mako:79
+#: /app/analytics/templates/website/publication_article.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:109
+#: /app/analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ter mais um país de afiliação."
-msgstr "Esta gráfica muestra el total de documentos por país de afiliación de los autores. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de la colección dado que un documento puede tener más de un país de afiliación."
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"Esta gráfica muestra el total de documentos por país de afiliación de los"
+" autores. Los valores totales de documentos de esta gráfica no pueden ser"
+" considerados como totales de la colección dado que un documento puede "
+"tener más de un país de afiliación."
 
-#: analytics/templates/website/publication_article.mako:115
+#: /app/analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:127
+#: /app/analytics/templates/website/publication_article.mako:127
 msgid ""
-"Este mapa apresenta o total de documentos por país de afiliação dos autores."
-" Os valores totais de documentos deste mapa não podem ser considerados como "
-"totais de publicações da coleção uma vez que um documento pode ter mais um "
-"país de afiliação."
-msgstr "El mapa muestra el total de documentos por país de afiliación de los autores. Los valores totales de documentos en esta gráfica no pueden considerarse como totales de publicación de la colección, pues un documento puede estar asociado a uno o más países de afiliación."
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"El mapa muestra el total de documentos por país de afiliación de los "
+"autores. Los valores totales de documentos en esta gráfica no pueden "
+"considerarse como totales de publicación de la colección, pues un "
+"documento puede estar asociado a uno o más países de afiliación."
 
-#: analytics/templates/website/publication_article.mako:145
+#: /app/analytics/templates/website/publication_article.mako:145
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de autores. "
-"Os números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado."
-msgstr "Esta gráfica muestra la distribución de documentos por número de autores. Los números están relacionados a la colección, o al periódico cuando un periódico esta seleccionado."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por número de autores."
+" Los números están relacionados a la colección, o al periódico cuando un "
+"periódico esta seleccionado."
 
-#: analytics/templates/website/publication_article.mako:151
+#: /app/analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:163
+#: /app/analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
-msgstr "Esta gráfica muestra la distribución de documentos por número de referencias bibliográficas. Los número están relacionados a una colección, o al periódico cuando algún periódico es seleccionado. "
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por número de "
+"referencias bibliográficas. Los número están relacionados a una "
+"colección, o al periódico cuando algún periódico es seleccionado. "
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso e ano"
-" de publicação. Os números são relacionados a coleção ou ao periódico quando"
-" um periódico é selecionado. A disponibilidade de indicadores de licença de "
-"uso dependem da adoção da coleção ou periódico selecionado de licenças de "
-"uso creative commons."
-msgstr "Esta gráfica muestra el total de documentos por licencia de uso y año de publicación. Los números estan  relacionados a la colección,  o a la revista cuando se ha seleccionado una revista. La disponibilidad de los indicadores de licencias de uso depende de la adopción de la colección o de la revista seleccionada por licencias creative commons."
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:36
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por área de atuação e "
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode fazer parte de mais de uma área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra la distribución de documentos por área de actuación y año de publicación. Los números están relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos en esta gráfica no puede ser considerado como total de publicaciones de la colección, pues el documento puede ser parte de una o más áreas de actuaciones. Esta gráfica es recomendada para la extracción de indicadores de Colección."
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
+msgstr ""
+"Esta gráfica muestra el total de documentos por licencia de uso y año de "
+"publicación. Los números estan  relacionados a la colección,  o a la "
+"revista cuando se ha seleccionado una revista. La disponibilidad de los "
+"indicadores de licencias de uso depende de la adopción de la colección o "
+"de la revista seleccionada por licencias creative commons."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:55
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por tipo de publicação e"
-" ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado."
-msgstr "Esta gráfica muestra la distribución de documentos por tipo de publicación y año de publicación. Los numeros están relacionados a una colección, o a la revista cuando alguna revista es seleccionada."
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por área de actuación "
+"y año de publicación. Los números están relacionados a la colección, o a "
+"la revista cuando se ha seleccionado una revista. Los valores totales de "
+"documentos en esta gráfica no puede ser considerado como total de "
+"publicaciones de la colección, pues el documento puede ser parte de una o"
+" más áreas de actuaciones. Esta gráfica es recomendada para la extracción"
+" de indicadores de Colección."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:73
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por idioma de publicação"
-" e ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode ser publicado em mais de um idioma."
-msgstr "Esta gráfica muestra el total de documentos por idioma de publicación y año de publicación. Los números estan relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado en uno o más idiomas."
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por tipo de "
+"publicación y año de publicación. Los numeros están relacionados a una "
+"colección, o a la revista cuando alguna revista es seleccionada."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:91
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por país de afiliação "
-"dos autores e ano de publicação. Os números são relacionados a coleção ou ao"
-" periódico quando um periódico é selecionado. Os valores totais de "
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
 "documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode ser publicado por mais "
-"de um país de afiliação."
-msgstr "Esta gráfica muestra la distribución de documentos por país de afiliación de los autores y el año de publicación. Los números estan relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado por uno o más países de afiliación."
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
+msgstr ""
+"Esta gráfica muestra el total de documentos por idioma de publicación y "
+"año de publicación. Los números estan relacionados a la colección, o a la"
+" revista cuando se ha seleccionado una revista. Los valores totales de "
+"documentos de esta gráfica no pueden ser considerados como totales de "
+"publicación de la colección, pues un documento puede ser publicado en uno"
+" o más idiomas."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por país de afiliación"
+" de los autores y el año de publicación. Los números estan relacionados a"
+" la colección, o a la revista cuando se ha seleccionado una revista. Los "
+"valores totales de documentos de esta gráfica no pueden ser considerados "
+"como totales de publicación de la colección, pues un documento puede ser "
+"publicado por uno o más países de afiliación."
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr ""
 
-#: analytics/templates/website/publication_journal_licenses.mako:17
-msgid ""
-"Este gráfico apresenta o número de periódicos por licença de uso adotada. Os"
-" valores totais de periódicos deste gráfico não podem ser considerados como "
-"totais da coleção uma vez que um documento pode fazer parte de mais de uma "
-"área de atuação. Este gráfico é recomendado para extração de indicadores de "
-"Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por licencia de uso adoptada. Los valores totales de periódicos en esta gráfica no puede ser considerada como totales de la colección, pues un documento puede ser parte de una o más área de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección. "
+#: /app/analytics/templates/website/publication_journal.mako:5
+msgid "Licenças de uso dos periódicos"
+msgstr ""
 
-#: analytics/templates/website/publication_journal_status.mako:17
+#: /app/analytics/templates/website/publication_journal.mako:10
+msgid "Áreas temáticas dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:15
+msgid "Ano de inclusão de periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:19
+msgid "Situação de publicação dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
-"Este gráfico apresenta o número de periódicos por status da publicação no "
-"SciELO. O status considerado neste grafíco é o status vigente do periódico, "
-"não são consideradas as mudanças de status a longo da existência do "
-"periódico nas bases SciELO. Este gráfico é recomendado para extração de "
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
 "indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por estado de publicación en SciELO. El estado considerado en esta gráfica es el estado vigente del periódico, no se consideran las modificaciones de estado a lo largo de la existencia del periódico en las bases SciELO. Esta gráfica es recomendada para extracción de indicadores de Colección."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por licencia de uso "
+"adoptada. Los valores totales de periódicos en esta gráfica no puede ser "
+"considerada como totales de la colección, pues un documento puede ser "
+"parte de una o más área de actuación. Esta gráfica es recomendada para "
+"extracción de indicadores de Colección. "
 
-#: analytics/templates/website/publication_journal_subject_areas.mako:17
+#: /app/analytics/templates/website/publication_journal_status.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por estado de publicación en"
+" SciELO. El estado considerado en esta gráfica es el estado vigente del "
+"periódico, no se consideran las modificaciones de estado a lo largo de la"
+" existencia del periódico en las bases SciELO. Esta gráfica es "
+"recomendada para extracción de indicadores de Colección."
+
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção. As áreas de "
-"atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada"
-" um dos periódicos SciELO, podendo um periódico estar relacionado a mais de "
-"uma área de atuação. Os valores totais de periódicos deste gráfico não podem"
-" ser considerados como totais da coleção uma vez que um documento pode fazer"
-" parte de mais de uma área de atuação. Este gráfico é recomendado para "
-"extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por área de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección. Las áreas de actuación son las grandes áreas de el CNPQ, estas áreas son determinadas para cada periódico SciELO, permitiendo a un periódico estar relacionado con mas de una área de actuación. Los valores totales de periódicos en esta gráfica no pueden ser considerados como totales de la colección, pues un documento puede ser parte de una o más áreas de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección."
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por área de actuación. Esta "
+"gráfica es recomendada para extracción de indicadores de Colección. Las "
+"áreas de actuación son las grandes áreas de el CNPQ, estas áreas son "
+"determinadas para cada periódico SciELO, permitiendo a un periódico estar"
+" relacionado con mas de una área de actuación. Los valores totales de "
+"periódicos en esta gráfica no pueden ser considerados como totales de la "
+"colección, pues un documento puede ser parte de una o más áreas de "
+"actuación. Esta gráfica es recomendada para extracción de indicadores de "
+"Colección."
 
-#: analytics/templates/website/publication_journal_year.mako:17
+#: /app/analytics/templates/website/publication_journal_year.mako:17
 msgid ""
-"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. "
-"Este gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por año de inclusión en SciELO. Este gráfico es recomendado para extracción de indicadores de Colección."
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por año de inclusión en "
+"SciELO. Este gráfico es recomendado para extracción de indicadores de "
+"Colección."
 
-#: analytics/templates/website/publication_size.mako:11
-#: analytics/templates/website/publication_size.mako:22
-#: analytics/templates/website/publication_size.mako:33
-#: analytics/templates/website/publication_size.mako:44
+#: /app/analytics/templates/website/publication_size.mako:11
+#: /app/analytics/templates/website/publication_size.mako:22
+#: /app/analytics/templates/website/publication_size.mako:33
+#: /app/analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre los números"
 
-#: analytics/templates/website/publication_size.mako:14
+#: /app/analytics/templates/website/publication_size.mako:14
 msgid ""
-"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e "
-"artigo publicados. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden a las revistas con al menos 1 fascículo y artículo publicado. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
+msgstr ""
+"Los números de arriba corresponden a las revistas con al menos 1 "
+"fascículo y artículo publicado. Los números estan relacionados a la "
+"colección o a la revista cuando una revista es eligida en la parte "
+"superior del sitio."
 
-#: analytics/templates/website/publication_size.mako:25
+#: /app/analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
-"publicado. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden a los fascículos con al menos 1 fascículo y artículo publicado. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior el sitio."
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
+msgstr ""
+"Los números de arriba corresponden a los fascículos con al menos 1 "
+"fascículo y artículo publicado. Los números estan relacionados a la "
+"colección o a la revista cuando una revista es eligida en la parte "
+"superior el sitio."
 
-#: analytics/templates/website/publication_size.mako:36
+#: /app/analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden al total de documentos publicados. Los número estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+msgstr ""
+"Los números de arriba corresponden al total de documentos publicados. Los"
+" número estan relacionados a la colección o a la revista cuando una "
+"revista es eligida en la parte superior del sitio."
 
-#: analytics/templates/website/publication_size.mako:47
+#: /app/analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
-"citadas nos documentos publicados. Os números são relacionados a coleção ou "
-"ao periódico quando um periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden al total de referencias bibliográficas citadas en los documentos. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
+msgstr ""
+"Los números de arriba corresponden al total de referencias bibliográficas"
+" citadas en los documentos. Los números estan relacionados a la colección"
+" o a la revista cuando una revista es eligida en la parte superior del "
+"sitio."
 
-#: analytics/templates/website/publication_size_citations.mako:9
+#: /app/analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referencias"
 
-#: analytics/templates/website/publication_size_documents.mako:9
+#: /app/analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: analytics/templates/website/publication_size_issues.mako:9
+#: /app/analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: analytics/templates/website/publication_size_journals.mako:9
+#: /app/analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "revistas"
 
-#: analytics/templates/website/reports.mako:5
+#: /app/analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tablas"
 
-#: analytics/templates/website/reports.mako:7
+#: /app/analytics/templates/website/reports.mako:7
 msgid ""
-"O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados "
-"utilizados para produção dos indicadores presentes nesta ferramenta. "
-"Qualquer interessado pode fazer o download e produzir análises "
-"bibliométricas de acordo com suas necessidade."
-msgstr "SciELO proporciona algunas tablas pre-formateadas con algunos de los metadatos utilizado para la producción de indicadores presentes en esta herramienta. Cualquiera interesado puede descargar y elaborar análisis bibliométricos de acuerdo a su necesidad."
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
+msgstr ""
+"SciELO proporciona algunas tablas pre-formateadas con algunos de los "
+"metadatos utilizado para la producción de indicadores presentes en esta "
+"herramienta. Cualquiera interesado puede descargar y elaborar análisis "
+"bibliométricos de acuerdo a su necesidad."
 
-#: analytics/templates/website/reports.mako:10
-msgid ""
-"Para mais informações sobre as catacterísticas de cada tabulação, acessar"
+#: /app/analytics/templates/website/reports.mako:10
+msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mas informaciones sobre las características de cada tabla, acceder"
 
-#: analytics/templates/website/reports.mako:16
+#: /app/analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nombre del archivo"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidad de actualización"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensual"
 
-#: analytics/templates/website/reports.mako:18
+#: /app/analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamaño del archivo"
 
-#: analytics/templates/website/reports.mako:19
+#: /app/analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: analytics/templates/website/reports.mako:20
+#: /app/analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última actualización"
 
-#: analytics/templates/website/reports.mako:23
+#: /app/analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "archivo no disponible para la colección"
 
-#: analytics/templates/website/share.mako:8
+#: /app/analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartir por email"
 
-#: analytics/templates/website/share.mako:10
+#: /app/analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartir en Facebook"
 
-#: analytics/templates/website/share.mako:13
+#: /app/analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartir en Twitter"
 
-#: analytics/templates/website/share.mako:16
+#: /app/analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartir en LinkedIn"

--- a/analytics/locale/es_MX/LC_MESSAGES/analytics.po
+++ b/analytics/locale/es_MX/LC_MESSAGES/analytics.po
@@ -1,1544 +1,1865 @@
-# Translations template for analytics.
+# Spanish (Mexico) translations for analytics.
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the analytics project.
-# 
+#
 # Translators:
 # Arturo Rendón Cruz <herzmx@gmail.com>, 2015-2016
 # fabiobatalha <fabiobatalha@gmail.com>, 2016
-# fabiobatalha <fabiobatalha@gmail.com>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Analytics\n"
+"Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-07-28 11:18-0300\n"
+"POT-Creation-Date: 2019-09-17 18:21+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
-"Language-Team: Spanish (Mexico) (http://www.transifex.com/scielo/analytics/language/es_MX/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.0\n"
 "Language: es_MX\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: Spanish (Mexico) "
+"(http://www.transifex.com/scielo/analytics/language/es_MX/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: analytics/charts_config.py:25
+#: /app/analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fuente: SciELO.org"
 
-#: analytics/charts_config.py:58
+#: /app/analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: analytics/charts_config.py:59
+#: /app/analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: analytics/charts_config.py:91
+#: /app/analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Año de publicación de los documentos de la revista. (citados)"
 
-#: analytics/charts_config.py:92
+#: /app/analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Año de publicación de los documentos de la Red SciELO. (citantes)"
 
-#: analytics/charts_config.py:100 analytics/charts_config.py:103
-#: analytics/charts_config.py:112
-msgid "Fator de impacto JCR"
+#: /app/analytics/charts_config.py:100
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: analytics/charts_config.py:113 analytics/charts_config.py:136
-#: analytics/charts_config.py:163
+#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+msgid "Média de percentil"
+msgstr ""
+
+#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
+#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Año base"
 
-#: analytics/charts_config.py:122
+#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
+#: /app/analytics/charts_config.py:134
+msgid "Eigen Factor JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
+#: /app/analytics/charts_config.py:156
+msgid "Received Citations JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
+#: /app/analytics/charts_config.py:178
+msgid "Fator de impacto JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fuente: Google Scholar"
 
-#: analytics/charts_config.py:123 analytics/charts_config.py:126
-#: analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
+#: /app/analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: analytics/charts_config.py:145
+#: /app/analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "inmediatez"
 
-#: analytics/charts_config.py:146
-#: analytics/templates/website/access_datepicker.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: /app/analytics/charts_config.py:212
+#: /app/analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "Un año"
 
-#: analytics/charts_config.py:147
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/charts_config.py:213
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 años"
 
-#: analytics/charts_config.py:148
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/charts_config.py:214
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 años"
 
-#: analytics/charts_config.py:149
+#: /app/analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 años"
 
-#: analytics/charts_config.py:150
+#: /app/analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 años"
 
-#: analytics/charts_config.py:157
+#: /app/analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO en 1, 2, 3, 4, 5 años y Índice de Inmediatez"
 
-#: analytics/charts_config.py:160 analytics/charts_config.py:162
-#: analytics/templates/website/bibliometrics_journal.mako:23
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
+#: /app/analytics/templates/website/bibliometrics_journal.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citación"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citas concedidas"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citas recibidas"
 
-#: analytics/charts_config.py:178
+#: /app/analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribición de citas concedidas, recibidas y auto citación"
 
-#: analytics/charts_config.py:185
+#: /app/analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citas"
 
-#: analytics/charts_config.py:190 analytics/charts_config.py:207
-#: analytics/charts_config.py:221 analytics/charts_config.py:348
-#: analytics/charts_config.py:357 analytics/charts_config.py:372
-#: analytics/charts_config.py:380 analytics/charts_config.py:428
-#: analytics/charts_config.py:437 analytics/charts_config.py:516
-#: analytics/charts_config.py:526 analytics/charts_config.py:568
-#: analytics/charts_config.py:577 analytics/charts_config.py:618
-#: analytics/charts_config.py:626 analytics/charts_config.py:742
-#: analytics/templates/website/central_container_for_article_filters.mako:13
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
+#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
+#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
+#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
+#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
+#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Año de publicación"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citables"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos no citables"
 
-#: analytics/charts_config.py:206
+#: /app/analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribución de documentos citables y no citables"
 
-#: analytics/charts_config.py:215 analytics/charts_config.py:239
-#: analytics/charts_config.py:258 analytics/charts_config.py:275
-#: analytics/charts_config.py:322 analytics/charts_config.py:346
-#: analytics/charts_config.py:375 analytics/charts_config.py:401
-#: analytics/charts_config.py:426 analytics/charts_config.py:494
-#: analytics/charts_config.py:514 analytics/charts_config.py:522
-#: analytics/charts_config.py:545 analytics/charts_config.py:566
-#: analytics/charts_config.py:616 analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
+#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
+#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
+#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
+#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
+#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
+#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
+#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: analytics/charts_config.py:232
+#: /app/analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribución por número de referencias bibliográficas en los documentos"
 
-#: analytics/charts_config.py:235
+#: /app/analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referencias bibliográficas"
 
-#: analytics/charts_config.py:242
+#: /app/analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documentos con %s referencias bibliográficas"
 
-#: analytics/charts_config.py:251
+#: /app/analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribución por número de autores de los documentos"
 
-#: analytics/charts_config.py:254
-#: analytics/templates/website/publication_article.mako:133
+#: /app/analytics/charts_config.py:320
+#: /app/analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: analytics/charts_config.py:261
+#: /app/analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documentos con %s autores"
 
-#: analytics/charts_config.py:272 analytics/charts_config.py:314
+#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: analytics/charts_config.py:293 analytics/charts_config.py:325
-#: analytics/charts_config.py:380 analytics/charts_config.py:404
-#: analytics/charts_config.py:497 analytics/charts_config.py:548
-#: analytics/charts_config.py:648
+#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
+#: /app/analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: analytics/charts_config.py:302 analytics/charts_config.py:317
-#: analytics/charts_config.py:325
+#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
+#: /app/analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliación"
 
-#: analytics/charts_config.py:338
+#: /app/analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: analytics/charts_config.py:371
+#: /app/analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribución por año de publicación de los documentos"
 
-#: analytics/charts_config.py:393
+#: /app/analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribución de idiomas de los documentos"
 
-#: analytics/charts_config.py:396
+#: /app/analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicación"
 
-#: analytics/charts_config.py:404
+#: /app/analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma del documento"
 
-#: analytics/charts_config.py:418
+#: /app/analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribución de idiomas de los documentos por año de publicación"
 
-#: analytics/charts_config.py:448 analytics/charts_config.py:588
-msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
-msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
-
-#: analytics/charts_config.py:451 analytics/charts_config.py:459
-#: analytics/charts_config.py:591 analytics/charts_config.py:599
-msgid "Situação da publicação"
-msgstr "Situación de la publicación"
-
-#: analytics/charts_config.py:456 analytics/charts_config.py:472
-#: analytics/charts_config.py:596 analytics/charts_config.py:665
-#: analytics/charts_config.py:685
-msgid "Número de periódicos"
-msgstr "Número de revistas"
-
-#: analytics/charts_config.py:459 analytics/charts_config.py:477
-#: analytics/charts_config.py:599 analytics/charts_config.py:668
-#: analytics/charts_config.py:688
-#: analytics/templates/website/navbar_collection.mako:10
-#: analytics/templates/website/navbar_journal.mako:10
-msgid "Periódicos"
-msgstr "Revistas"
-
-#: analytics/charts_config.py:468
+#: /app/analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribución de revistas por año de incorporación en SciELO"
 
-#: analytics/charts_config.py:469 analytics/charts_config.py:477
+#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Año de incorporación"
 
-#: analytics/charts_config.py:486
+#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
+#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+msgid "Número de periódicos"
+msgstr "Número de revistas"
+
+#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
+#: /app/analytics/templates/website/navbar_collection.mako:10
+#: /app/analytics/templates/website/navbar_journal.mako:10
+msgid "Periódicos"
+msgstr "Revistas"
+
+#: /app/analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribución por área temática de los documentos"
 
-#: analytics/charts_config.py:489 analytics/charts_config.py:660
+#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Áreas temáticas"
 
-#: analytics/charts_config.py:497 analytics/charts_config.py:668
-#: analytics/templates/website/central_container_for_article_filters.mako:30
-#: analytics/templates/website/central_container_for_journal_filters.mako:13
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: analytics/charts_config.py:506
+#: /app/analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribución de área temática de los documentos por año de publicación"
 
-#: analytics/charts_config.py:537
+#: /app/analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribución por tipo de documento"
 
-#: analytics/charts_config.py:540
-#: analytics/templates/website/publication_article.mako:43
-#: analytics/templates/website/publication_article_by_publication_year.mako:43
+#: /app/analytics/charts_config.py:586
+#: /app/analytics/templates/website/publication_article.mako:43
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: analytics/charts_config.py:548
+#: /app/analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: analytics/charts_config.py:558
+#: /app/analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribución de tipos de documentos por año de publicación"
 
-#: analytics/charts_config.py:608
+#: /app/analytics/charts_config.py:634
+msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
+msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
+
+#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+msgid "Situação da publicação"
+msgstr "Situación de la publicación"
+
+#: /app/analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribución de licencias de uso por año de publicación"
 
-#: analytics/charts_config.py:637
+#: /app/analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribución por licencia de uso de los documentos"
 
-#: analytics/charts_config.py:640 analytics/charts_config.py:680
-#: analytics/templates/website/publication_article.mako:5
-#: analytics/templates/website/publication_article_by_publication_year.mako:5
+#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
+#: /app/analytics/templates/website/publication_article.mako:5
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licencia de uso"
 
-#: analytics/charts_config.py:648 analytics/charts_config.py:688
+#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licencia"
 
-#: analytics/charts_config.py:657
+#: /app/analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribución por área temática de las revistas"
 
-#: analytics/charts_config.py:677
+#: /app/analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribución por licencia de uso de las revistas"
 
-#: analytics/charts_config.py:696
+#: /app/analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de accesos por año y mes"
 
-#: analytics/charts_config.py:704 analytics/charts_config.py:739
-#: analytics/templates/website/navbar_collection.mako:7
-#: analytics/templates/website/navbar_document.mako:7
-#: analytics/templates/website/navbar_journal.mako:7
+#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
+#: /app/analytics/templates/website/navbar_collection.mako:7
+#: /app/analytics/templates/website/navbar_document.mako:7
+#: /app/analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesos"
 
-#: analytics/charts_config.py:710
+#: /app/analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesos en"
 
-#: analytics/charts_config.py:721
+#: /app/analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accesos por tipo de documento"
 
-#: analytics/charts_config.py:725
+#: /app/analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesos a documentos de tipo %s"
 
-#: analytics/charts_config.py:737
+#: /app/analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de los articulos por número de accesos en"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Año de consulta"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesos a los documentos del año %s"
 
-#: analytics/controller.py:354
-msgid "Fator de impacto 5 anos"
-msgstr ""
-
-#: analytics/controller.py:359
-msgid "Fator de impacto 2 anos"
-msgstr ""
-
-#: analytics/controller.py:364
-msgid "Fator de impacto 2 anos, sem auto citação"
-msgstr ""
-
-#: analytics/templates/website/access_by_document_type.mako:6
-#: analytics/templates/website/access_by_month_and_year.mako:5
-#: analytics/templates/website/access_lifetime.mako:6
-#: analytics/templates/website/accesses_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: analytics/templates/website/publication_article_affiliations.mako:5
-#: analytics/templates/website/publication_article_affiliations_map.mako:5
-#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: analytics/templates/website/publication_article_authors.mako:5
-#: analytics/templates/website/publication_article_citable_documents.mako:5
-#: analytics/templates/website/publication_article_document_type.mako:5
-#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: analytics/templates/website/publication_article_languages.mako:5
-#: analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: analytics/templates/website/publication_article_licenses.mako:5
-#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: analytics/templates/website/publication_article_references.mako:5
-#: analytics/templates/website/publication_article_subject_areas.mako:6
-#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: analytics/templates/website/publication_article_year.mako:5
-#: analytics/templates/website/publication_journal_licenses.mako:7
-#: analytics/templates/website/publication_journal_status.mako:7
-#: analytics/templates/website/publication_journal_subject_areas.mako:7
-#: analytics/templates/website/publication_journal_year.mako:7
-#: analytics/templates/website/publication_size_citations.mako:6
-#: analytics/templates/website/publication_size_documents.mako:6
-#: analytics/templates/website/publication_size_issues.mako:6
-#: analytics/templates/website/publication_size_journals.mako:6
+#: /app/analytics/templates/website/access_by_document_type.mako:6
+#: /app/analytics/templates/website/access_by_month_and_year.mako:5
+#: /app/analytics/templates/website/access_lifetime.mako:6
+#: /app/analytics/templates/website/accesses_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_authors.mako:5
+#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
+#: /app/analytics/templates/website/publication_article_document_type.mako:5
+#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_languages.mako:5
+#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_licenses.mako:5
+#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_references.mako:5
+#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
+#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: /app/analytics/templates/website/publication_article_year.mako:5
+#: /app/analytics/templates/website/publication_journal_licenses.mako:7
+#: /app/analytics/templates/website/publication_journal_status.mako:7
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
+#: /app/analytics/templates/website/publication_journal_year.mako:7
+#: /app/analytics/templates/website/publication_size_citations.mako:6
+#: /app/analytics/templates/website/publication_size_documents.mako:6
+#: /app/analytics/templates/website/publication_size_issues.mako:6
+#: /app/analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "cargando"
 
-#: analytics/templates/website/access_datepicker.mako:5
+#: /app/analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Revista"
 
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "accesos en los últimos 36 meses"
 
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "accesos en los últimos 24 meses"
 
-#: analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "accesos en los últimos 12 meses"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos los accesos disponíbles"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "todo"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Selector de rango de accesos"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
-"recuperação dos dados de acesso. Você pode também selecionar o período de 1,"
-" 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis "
-"selecionando tudo."
-msgstr "Utilize el campo con fechas para elijir un rango costomizado para la recuperación de los datos de accesos. Usted podrá también elijir el rango de 1, 2 o 3 años, por medio de los enlaces rápidos o todos los accesos disponíbles."
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
+msgstr ""
+"Utilize el campo con fechas para elijir un rango costomizado para la "
+"recuperación de los datos de accesos. Usted podrá también elijir el rango"
+" de 1, 2 o 3 años, por medio de los enlaces rápidos o todos los accesos "
+"disponíbles."
 
-#: analytics/templates/website/access_list_articles.mako:6
+#: /app/analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 de artículos por número de accesos"
 
-#: analytics/templates/website/access_list_articles.mako:9
+#: /app/analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artículo"
 
-#: analytics/templates/website/access_list_articles.mako:13
-#: analytics/templates/website/access_list_issues.mako:13
-#: analytics/templates/website/access_list_journals.mako:13
+#: /app/analytics/templates/website/access_list_articles.mako:13
+#: /app/analytics/templates/website/access_list_issues.mako:13
+#: /app/analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumen"
 
-#: analytics/templates/website/access_list_articles.mako:14
-#: analytics/templates/website/access_list_issues.mako:14
-#: analytics/templates/website/access_list_journals.mako:14
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: analytics/templates/website/bibliometrics_list_granted.mako:19
-#: analytics/templates/website/bibliometrics_list_granted.mako:30
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: analytics/templates/website/bibliometrics_list_received.mako:26
-#: analytics/templates/website/bibliometrics_list_received.mako:37
+#: /app/analytics/templates/website/access_list_articles.mako:14
+#: /app/analytics/templates/website/access_list_issues.mako:14
+#: /app/analytics/templates/website/access_list_journals.mako:14
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: analytics/templates/website/access_list_issues.mako:6
+#: /app/analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 de fascículos por número de accesos"
 
-#: analytics/templates/website/access_list_issues.mako:9
-#: analytics/templates/website/access_list_journals.mako:9
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: /app/analytics/templates/website/access_list_issues.mako:9
+#: /app/analytics/templates/website/access_list_journals.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "revista"
 
-#: analytics/templates/website/access_list_journals.mako:6
+#: /app/analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesos a los documentos por revista"
 
-#: analytics/templates/website/accesses.mako:6
+#: /app/analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:12
+#: /app/analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses.mako:18
+#: /app/analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:15
+#: /app/analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: analytics/templates/website/base.mako:6
+#: /app/analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estadísticas"
 
-#: analytics/templates/website/base.mako:30
+#: /app/analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Colecciones"
 
-#: analytics/templates/website/base.mako:38
-#: analytics/templates/website/journal_selector_modal.mako:7
+#: /app/analytics/templates/website/base.mako:38
+#: /app/analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "seleccionar revista"
 
-#: analytics/templates/website/base.mako:91
+#: /app/analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Herramienta en desarrollo disponible en versión de pruebas Beta."
 
-#: analytics/templates/website/base.mako:93
+#: /app/analytics/templates/website/base.mako:93
 msgid ""
-"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de "
-"realizar testes de uso e performance. Todos os indicadores carregados são "
-"reais e estão sendo atualizados e inseridos gradativamente. Problemas de "
-"lentidão e indisponibilidade do serviços são esperados nesta fase."
-msgstr "Esta herramienta se encuentra en desarrollo y ha sido publicada con el propósito de realizar pruebas de uso y rendimiento. Todos los indicadores mostrados son reales y están siendo actualizados y agregados gradualmente. Se pueden presentar problemas de lentitud o disponibilidad durante esta fase."
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
+msgstr ""
+"Esta herramienta se encuentra en desarrollo y ha sido publicada con el "
+"propósito de realizar pruebas de uso y rendimiento. Todos los indicadores"
+" mostrados son reales y están siendo actualizados y agregados "
+"gradualmente. Se pueden presentar problemas de lentitud o disponibilidad "
+"durante esta fase."
 
-#: analytics/templates/website/base.mako:114
+#: /app/analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ayuda"
 
-#: analytics/templates/website/base.mako:116
+#: /app/analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: analytics/templates/website/base.mako:117
+#: /app/analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discusión"
 
-#: analytics/templates/website/base.mako:121
+#: /app/analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desarrollo"
 
-#: analytics/templates/website/base.mako:124
+#: /app/analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desarrollo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Enero"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Febrero"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Marzo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Mayo"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junio"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julio"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Septiembre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Octubre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Noviembre"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Diciembre"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Ene"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citas Recibidas"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "año de publicación"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primer autor"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título del documento"
 
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citas recibidas"
 
-#: analytics/templates/website/bibliometrics_journal.mako:8
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: analytics/templates/website/bibliometrics_list_granted.mako:8
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: analytics/templates/website/bibliometrics_list_received.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atención"
 
-#: analytics/templates/website/bibliometrics_journal.mako:11
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: analytics/templates/website/bibliometrics_list_granted.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: analytics/templates/website/bibliometrics_list_received.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "Es necesario seleccionar una revista para los datos bibliométricos "
 
-#: analytics/templates/website/bibliometrics_journal.mako:20
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: analytics/templates/website/bibliometrics_list_received.mako:19
-#: analytics/templates/website/central_container_for_article_filters.mako:16
-#: analytics/templates/website/central_container_for_article_filters.mako:33
-#: analytics/templates/website/central_container_for_article_filters.mako:52
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: analytics/templates/website/central_container_for_journal_filters.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal.mako:20
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: analytics/templates/website/bibliometrics_journal.mako:32
-#: analytics/templates/website/bibliometrics_journal.mako:51
-#: analytics/templates/website/bibliometrics_journal.mako:69
-#: analytics/templates/website/bibliometrics_journal.mako:87
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: analytics/templates/website/publication_article.mako:14
-#: analytics/templates/website/publication_article.mako:33
-#: analytics/templates/website/publication_article.mako:52
-#: analytics/templates/website/publication_article.mako:70
-#: analytics/templates/website/publication_article.mako:88
-#: analytics/templates/website/publication_article.mako:106
-#: analytics/templates/website/publication_article.mako:124
-#: analytics/templates/website/publication_article.mako:142
-#: analytics/templates/website/publication_article.mako:160
-#: analytics/templates/website/publication_article_by_publication_year.mako:14
-#: analytics/templates/website/publication_article_by_publication_year.mako:33
-#: analytics/templates/website/publication_article_by_publication_year.mako:52
-#: analytics/templates/website/publication_article_by_publication_year.mako:70
-#: analytics/templates/website/publication_article_by_publication_year.mako:88
-#: analytics/templates/website/publication_article_by_publication_year.mako:106
-#: analytics/templates/website/publication_journal_licenses.mako:14
-#: analytics/templates/website/publication_journal_status.mako:14
-#: analytics/templates/website/publication_journal_subject_areas.mako:14
-#: analytics/templates/website/publication_journal_year.mako:14
+#: /app/analytics/templates/website/bibliometrics_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal.mako:51
+#: /app/analytics/templates/website/bibliometrics_journal.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal.mako:87
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: /app/analytics/templates/website/publication_article.mako:14
+#: /app/analytics/templates/website/publication_article.mako:33
+#: /app/analytics/templates/website/publication_article.mako:52
+#: /app/analytics/templates/website/publication_article.mako:70
+#: /app/analytics/templates/website/publication_article.mako:88
+#: /app/analytics/templates/website/publication_article.mako:106
+#: /app/analytics/templates/website/publication_article.mako:124
+#: /app/analytics/templates/website/publication_article.mako:142
+#: /app/analytics/templates/website/publication_article.mako:160
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
+#: /app/analytics/templates/website/publication_journal_licenses.mako:14
+#: /app/analytics/templates/website/publication_journal_status.mako:14
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
+#: /app/analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre la gráfica"
 
-#: analytics/templates/website/bibliometrics_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
 "linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
 "Reuters"
-msgstr "Esta gráfica muestra el factor de impacto del periódico seleccionado considerando los periódicos de inmediatez, más allá de períodos de 1 a 5 años. La línea de 2 años equivale al factor de impacto de Thomson Reuters "
+msgstr ""
+"Esta gráfica muestra el factor de impacto del periódico seleccionado "
+"considerando los periódicos de inmediatez, más allá de períodos de 1 a 5 "
+"años. La línea de 2 años equivale al factor de impacto de Thomson Reuters"
+" "
 
-#: analytics/templates/website/bibliometrics_journal.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:54
-#: analytics/templates/website/publication_article_by_publication_year.mako:109
+#: /app/analytics/templates/website/bibliometrics_journal.mako:54
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
-"Este gráfico apresenta a distribuição de documentos citáveis e não citáveis "
-"relacionados ao periódico selecionado. De acordo com as regras de contagem "
-"do SciELO, documentos citáveis devem ser do tipo \"Research Article\", "
-"\"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid "
-"Communication\" e \"Article Commentary\". Os demais tipos de documentos são "
-"considerados não citáveis."
-msgstr "Esta gráfica muestra la distribución de documentos citables y non citables relacionados al periódico seleccionado. De acuerdo con las regras de cuenta de citas de SciELO, los documentos citables son del tipo Research Article, Review Article, Case Report, Brief Report, Rapid Communication y Article Commentary. Los demas tipos documentos no son considerados citables."
-
-#: analytics/templates/website/bibliometrics_journal.mako:60
-msgid "Google H5M5"
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
 msgstr ""
+"Esta gráfica muestra la distribución de documentos citables y non "
+"citables relacionados al periódico seleccionado. De acuerdo con las "
+"regras de cuenta de citas de SciELO, los documentos citables son del tipo"
+" Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication y Article Commentary. Los demas tipos documentos no son "
+"considerados citables."
 
-#: analytics/templates/website/bibliometrics_journal.mako:72
+#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+msgid "Google H5M5"
+msgstr "Google H5M5"
+
+#: /app/analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
-"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores "
-"são fornecidos anualmente pelo Google Scholar. A ausência de indicadores "
-"para um periódico ou para um período de um periódico pode ocorrer caso esses"
-" dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, "
-"você será direcionado para o site do Google Scholar."
-msgstr "Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores son fornecidos anualmente por Google Scholar. La falta de indicadores para una revista o para un rango de una revista pueden ocurrir. Cuando clicar en una de las series, el usuário vá a ser direccionado para el sitio del Google Scholar."
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
+msgstr ""
+"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores "
+"son fornecidos anualmente por Google Scholar. La falta de indicadores para "
+"una revista o para un rango de una revista pueden ocurrir. Cuando clicar en "
+"una de las series, el usuário vá a ser direccionado para el sitio del Google "
+" Scholar."
 
-#: analytics/templates/website/bibliometrics_journal.mako:78
+#: /app/analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal.mako:90
+#: /app/analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
-"citações do periódico selecionado, os dados estão distribuidos por ano de "
-"publicação."
-msgstr "Esta gráfica muestra el número de citaciones concedidas, recibidas y auto citaciones del periódico seleccionado, los datos están distribuidos por año de publicación."
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
+msgstr ""
+"Esta gráfica muestra el número de citaciones concedidas, recibidas y auto"
+" citaciones del periódico seleccionado, los datos están distribuidos por "
+"año de publicación."
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: analytics/templates/website/navbar_journal.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: analytics/templates/website/navbar_journal.mako:28
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+msgid "Dados extraídos em: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:25
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+msgid "Eigen Factor"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: analytics/templates/website/navbar_journal.mako:29
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfica de calor de citaciones recibidas"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
-msgstr "La gráfica presenta el número de citas recibidas por una revista. El corpus de citas corresponde a todas las colecciones de la Red SciELO, las colecciones Temáticas y independientes."
+msgstr ""
+"La gráfica presenta el número de citas recibidas por una revista. El "
+"corpus de citas corresponde a todas las colecciones de la Red SciELO, las"
+" colecciones Temáticas y independientes."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Lista de citas para el eje seleccionado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Elija in eje x/y para obtener el listado de citaciones para la revista."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citaciones recibidas por la revista"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos de la Red SciELO publicados en"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citarón"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "veces los documentos de la revista"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados en"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique en el eje para mirar el listado de articulos citantes y citados."
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citación encontradas para la revista seleccionada"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: analytics/templates/website/bibliometrics_list_granted.mako:18
-#: analytics/templates/website/bibliometrics_list_received.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acciones"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar error"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: analytics/templates/website/bibliometrics_list_granted.mako:35
-#: analytics/templates/website/bibliometrics_list_received.mako:42
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sin resultados"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: analytics/templates/website/navbar_collection.mako:30
-#: analytics/templates/website/navbar_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:30
+#: /app/analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media de citas"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citas en"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicaciones de"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Total de citas"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citaciones"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "porcentaje"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "porcentaje acumulado"
 
-#: analytics/templates/website/bibliometrics_list_granted.mako:15
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+msgid "Indicadores Bibliométricos da Rede SciELO"
+msgstr "Indicadores Bibliométricos de la Red SciELO"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid "Periodicidade de atualização:"
+msgstr "Periodicidad de actualización:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid " anual"
+msgstr " anual"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+msgid "Indicadores de Publicação"
+msgstr "Indicadores de Publicación"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+msgid "Numeros da Rede SciELO por:"
+msgstr "Números de la Red SciELO por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+msgid "Ano de publicação: "
+msgstr "Año de publicación: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+msgid "Periódico: "
+msgstr "Revista: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+msgid "Assunto: "
+msgstr "Área: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+msgid "País de afiliação do autor: "
+msgstr "País de afiliación del autor: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+msgid "País de Afiliação do Autor por: "
+msgstr "País de Afiliación del Autor por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+msgid "País de publicação da revista: "
+msgstr "País de publicación de la revista: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+msgid "Número de Co-autores por: "
+msgstr "Número de Co-autores por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+msgid "Indicadores de Coleção"
+msgstr "Indicadores de la Colección"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+msgid "Periódico por:"
+msgstr "Revista por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+msgid "Indicadores gerais: "
+msgstr "Indicadores generales: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+msgid "Indicadores de Citação"
+msgstr "Indicadores de Citación"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+msgid "Ano de Citação por:"
+msgstr "Año de Citación por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+msgid "Idade do documento citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+msgid "Tipo de documento citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+msgid "Periódico Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+msgid "Assunto do Periódico Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+msgid "Periódico SciELO citado: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+msgid "País de Afiliação do Autor Citante por:"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citas concedidas por revista"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: analytics/templates/website/navbar_collection.mako:29
-#: analytics/templates/website/navbar_journal.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:29
+#: /app/analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO en 1, 2, 3, 4 y 5 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados en"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
-"Aqui são considerados apenas os documentos citáveis. De acordo com as regras"
-" de contagem do SciELO, documentos citáveis devem ser do tipo Research "
-"Article, Review Article, Case Report, Brief Report, Rapid Communication e "
-"Article Commentary. Os demais tipos de documentos são considerados não "
-"citáveis."
-msgstr "Esta gráfica muestra la distribución de documentos citables relacionados al periódico seleccionado. De acuerdo con las regras de cuenta de citas de SciELO, los documentos citables son del tipo Research Article, Review Article, Case Report, Brief Report, Rapid Communication y Article Commentary. Los demas tipos documentos no son considerados citables."
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos citables relacionados "
+"al periódico seleccionado. De acuerdo con las regras de cuenta de citas "
+"de SciELO, los documentos citables son del tipo Research Article, Review "
+"Article, Case Report, Brief Report, Rapid Communication y Article "
+"Commentary. Los demas tipos documentos no son considerados citables."
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 años"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 años"
 
-#: analytics/templates/website/bibliometrics_list_received.mako:22
-#: analytics/templates/website/navbar_collection.mako:33
-#: analytics/templates/website/navbar_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:33
+#: /app/analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citas recibidas por las revistas"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:8
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtrados para documentos"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:22
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:49
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: analytics/templates/website/central_container_for_journal_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtrados para revistas"
 
-#: analytics/templates/website/faq.mako:5
+#: /app/analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Preguntas frecuentes (Accesos)"
 
-#: analytics/templates/website/faq.mako:7
+#: /app/analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "¿Por qué algunas colecciones no poseen estadísticas de acceso?"
 
-#: analytics/templates/website/faq.mako:8
+#: /app/analytics/templates/website/faq.mako:8
 msgid ""
-"Para que os dados de acessos sejam computados é necessário que os logs de "
-"acessos sejam enviados para processamento. A ausência de estatísticas de "
-"acessos deve ser verificada com a coordenação de cada coleção SciELO."
-msgstr "Para que los datos de accesos sean calculados en necesario que los logs de accesos sean enviados para su procesamiento. La ausencia de estadísticas de acceso debe ser verificada con la coordinación de cada colección SciELO."
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
+msgstr ""
+"Para que los datos de accesos sean calculados en necesario que los logs "
+"de accesos sean enviados para su procesamiento. La ausencia de "
+"estadísticas de acceso debe ser verificada con la coordinación de cada "
+"colección SciELO."
 
-#: analytics/templates/website/faq.mako:11
+#: /app/analytics/templates/website/faq.mako:11
+msgid "Por que algumas coleções possuem acessos computados para um período maior?"
+msgstr ""
+"¿Por qué algunas colecciones poseen accesos calculados para una revista "
+"más grande?"
+
+#: /app/analytics/templates/website/faq.mako:12
 msgid ""
-"Por que algumas coleções possuem acessos computados para um período maior?"
-msgstr "¿Por qué algunas colecciones poseen accesos calculados para una revista más grande?"
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
+msgstr ""
+"Las revistas disponibles en cada colección dependen de las revistas de "
+"los logs de acceso de cada una de las colecciones. Este proyecto tiene el"
+" compromiso de calcular los datos de accesos a partir del 2012, siempre "
+"que los logs sean debidamente proporcionados por las colecciones. "
 
-#: analytics/templates/website/faq.mako:12
-msgid ""
-"O período disponível de cada uma das coleções depende do período disponível "
-"dos logs de acessos de cada uma das coleções. Este projeto se compromete a "
-"computar os dados de acessos à partir de 2012, desde que os logs sejam "
-"devidamente fornecidos pelas coleções."
-msgstr "Las revistas disponibles en cada colección dependen de las revistas de los logs de acceso de cada una de las colecciones. Este proyecto tiene el compromiso de calcular los datos de accesos a partir del 2012, siempre que los logs sean debidamente proporcionados por las colecciones. "
-
-#: analytics/templates/website/faq.mako:15
-#: analytics/templates/website/faq.mako:36
+#: /app/analytics/templates/website/faq.mako:15
+#: /app/analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "¿Qué es lo que se esta contando?"
 
-#: analytics/templates/website/faq.mako:16
+#: /app/analytics/templates/website/faq.mako:16
 msgid ""
-"Estão sendo contabilizados e classificados os acessos ao texto completo em "
-"HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
-msgstr "Están siendo contados y clasificados los accesos a texto completo en HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de resumen del artículo."
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
+msgstr ""
+"Están siendo contados y clasificados los accesos a texto completo en "
+"HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de "
+"resumen del artículo."
 
-#: analytics/templates/website/faq.mako:19
+#: /app/analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
-msgstr "¿Por qué los indicadores de esta herramienta son diferentes a los ofrecidos en otras herramientas de SciELO?"
+msgstr ""
+"¿Por qué los indicadores de esta herramienta son diferentes a los "
+"ofrecidos en otras herramientas de SciELO?"
 
-#: analytics/templates/website/faq.mako:21
+#: /app/analytics/templates/website/faq.mako:21
 msgid ""
-"Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos "
-"de estatísticas de acessos."
-msgstr "Algunas herramientas de SciELO pueden estar utilizando servicios antiguos de estadísticas de acceso."
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
+msgstr ""
+"Algunas herramientas de SciELO pueden estar utilizando servicios antiguos"
+" de estadísticas de acceso."
 
-#: analytics/templates/website/faq.mako:22
+#: /app/analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
-msgstr "El conteo de accesos de esta herramienta es diferente en diversos aspectos a las herramientas antiguas."
+msgstr ""
+"El conteo de accesos de esta herramienta es diferente en diversos "
+"aspectos a las herramientas antiguas."
 
-#: analytics/templates/website/faq.mako:23
+#: /app/analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
-msgstr "Algunas herramientas poseen una delta de actualización para diferencias los indicadores de acceso."
+msgstr ""
+"Algunas herramientas poseen una delta de actualización para diferencias "
+"los indicadores de acceso."
 
-#: analytics/templates/website/faq.mako:27
-#: analytics/templates/website/faq.mako:40
+#: /app/analytics/templates/website/faq.mako:27
+#: /app/analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "¿Cuál es la periodicidad de actualización de los indicadores?"
 
-#: analytics/templates/website/faq.mako:28
+#: /app/analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensual"
 
-#: analytics/templates/website/faq.mako:30
+#: /app/analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Preguntas frecuentes (Publicación)"
 
-#: analytics/templates/website/faq.mako:32
+#: /app/analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "¿Por qué algunas colecciones tienen datos desactualizados?"
 
-#: analytics/templates/website/faq.mako:33
+#: /app/analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
 "diretamente ligada a condução adequada desses processos por cada uma das "
 "coleções."
-msgstr "La actualización de los datos depende de los procesos referentes a cada una de las colecciones certificadas en SciELO. La actualización de estos indicadores esta directamente relacionada al correcto desarrollo de los procesos en cada una de las colecciones."
+msgstr ""
+"La actualización de los datos depende de los procesos referentes a cada "
+"una de las colecciones certificadas en SciELO. La actualización de estos "
+"indicadores esta directamente relacionada al correcto desarrollo de los "
+"procesos en cada una de las colecciones."
 
-#: analytics/templates/website/faq.mako:37
+#: /app/analytics/templates/website/faq.mako:37
 msgid ""
-"Estão sendo contabilizados indicadores de publicação das coleções com base "
-"nos metadados fornecidos durante todo o processo de publicação de um "
-"documento no SciELO. A qualidade desses indicadores esta diretamente ligada "
-"a qualidade dos processos implementados por cada uma das coleções."
-msgstr "Los indicadores de publicación están siendo generados con base en los metadatos proporcionados durante todo el porceso de publicación de un documento en SciELO. La calidad de estos indicadores esta directamente relacionada con la calidad de los procesos implementados por cada una de las colecciones."
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
+msgstr ""
+"Los indicadores de publicación están siendo generados con base en los "
+"metadatos proporcionados durante todo el porceso de publicación de un "
+"documento en SciELO. La calidad de estos indicadores esta directamente "
+"relacionada con la calidad de los procesos implementados por cada una de "
+"las colecciones."
 
-#: analytics/templates/website/faq.mako:41
+#: /app/analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: analytics/templates/website/home_collection.mako:7
-#: analytics/templates/website/home_journal.mako:7
-#: analytics/templates/website/home_network.mako:7
-#: analytics/templates/website/navbar_collection.mako:18
-#: analytics/templates/website/navbar_journal.mako:18
-#: analytics/templates/website/publication_size.mako:5
+#: /app/analytics/templates/website/home_collection.mako:7
+#: /app/analytics/templates/website/home_journal.mako:7
+#: /app/analytics/templates/website/home_network.mako:7
+#: /app/analytics/templates/website/navbar_collection.mako:18
+#: /app/analytics/templates/website/navbar_journal.mako:18
+#: /app/analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composición de la colección"
 
-#: analytics/templates/website/home_collection.mako:24
-#: analytics/templates/website/home_document.mako:21
-#: analytics/templates/website/home_journal.mako:21
-#: analytics/templates/website/home_network.mako:24
-#: analytics/templates/website/navbar_collection.mako:9
-#: analytics/templates/website/navbar_collection.mako:27
-#: analytics/templates/website/navbar_document.mako:9
-#: analytics/templates/website/navbar_journal.mako:9
-#: analytics/templates/website/navbar_journal.mako:26
+#: /app/analytics/templates/website/home_collection.mako:24
+#: /app/analytics/templates/website/home_document.mako:21
+#: /app/analytics/templates/website/home_journal.mako:21
+#: /app/analytics/templates/website/home_network.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:9
+#: /app/analytics/templates/website/navbar_collection.mako:27
+#: /app/analytics/templates/website/navbar_document.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficas"
 
-#: analytics/templates/website/home_document.mako:7
+#: /app/analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores de documento"
 
-#: analytics/templates/website/journal_selector_modal.mako:6
+#: /app/analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "cerrar"
 
-#: analytics/templates/website/journal_selector_modal.mako:11
+#: /app/analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "seleccionar una revista"
 
-#: analytics/templates/website/journal_selector_modal.mako:20
+#: /app/analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "seleccionar"
 
-#: analytics/templates/website/navbar_collection.mako:11
-#: analytics/templates/website/navbar_journal.mako:11
+#: /app/analytics/templates/website/navbar_collection.mako:11
+#: /app/analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 fascículos"
 
-#: analytics/templates/website/navbar_collection.mako:12
-#: analytics/templates/website/navbar_journal.mako:12
+#: /app/analytics/templates/website/navbar_collection.mako:12
+#: /app/analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 artículos"
 
-#: analytics/templates/website/navbar_collection.mako:16
-#: analytics/templates/website/navbar_journal.mako:16
+#: /app/analytics/templates/website/navbar_collection.mako:16
+#: /app/analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicación"
 
-#: analytics/templates/website/navbar_collection.mako:19
-#: analytics/templates/website/navbar_journal.mako:19
+#: /app/analytics/templates/website/navbar_collection.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficas de documentos"
 
-#: analytics/templates/website/navbar_collection.mako:20
-#: analytics/templates/website/navbar_journal.mako:20
+#: /app/analytics/templates/website/navbar_collection.mako:20
+#: /app/analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficas de documentos por año de publicación"
 
-#: analytics/templates/website/navbar_collection.mako:21
+#: /app/analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficas de revistas"
 
-#: analytics/templates/website/navbar_collection.mako:25
-#: analytics/templates/website/navbar_document.mako:13
-#: analytics/templates/website/navbar_journal.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:25
+#: /app/analytics/templates/website/navbar_document.mako:13
+#: /app/analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometría"
 
-#: analytics/templates/website/navbar_collection.mako:32
-#: analytics/templates/website/navbar_journal.mako:34
+#: /app/analytics/templates/website/navbar_collection.mako:32
+#: /app/analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citas concedidas por las revistas"
 
-#: analytics/templates/website/navbar_collection.mako:34
-#: analytics/templates/website/navbar_journal.mako:36
+#: /app/analytics/templates/website/navbar_collection.mako:34
+#: /app/analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citación de la revista"
 
-#: analytics/templates/website/navbar_collection.mako:38
-#: analytics/templates/website/navbar_document.mako:19
-#: analytics/templates/website/navbar_journal.mako:40
+#: /app/analytics/templates/website/navbar_collection.mako:35
+#: /app/analytics/templates/website/navbar_journal.mako:37
+msgid "Indicadores Gerais"
+msgstr "Indicadores Generales"
+
+#: /app/analytics/templates/website/navbar_collection.mako:39
+#: /app/analytics/templates/website/navbar_document.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Informes"
 
-#: analytics/templates/website/navbar_document.mako:15
+#: /app/analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Citas Recibidas"
 
-#: analytics/templates/website/publication_article.mako:17
+#: /app/analytics/templates/website/publication_article.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. A disponibilidade de indicadores de licença de uso dependem da "
-"adoção da coleção ou periódico selecionado de licenças de uso creative "
-"commons."
-msgstr "Esta gráfica muestra la distribución de documentos por licencia de uso. Los números son relacionados a la colección o al periódico cuando se ha seleccionado un periódico. La disponibilidad de indicadores de licencia de uso dependen de la adopción de la colección o periódico seleccionado de licencias de uso creative commons."
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por licencia de uso. "
+"Los números son relacionados a la colección o al periódico cuando se ha "
+"seleccionado un periódico. La disponibilidad de indicadores de licencia "
+"de uso dependen de la adopción de la colección o periódico seleccionado "
+"de licencias de uso creative commons."
 
-#: analytics/templates/website/publication_article.mako:24
-#: analytics/templates/website/publication_article_by_publication_year.mako:24
+#: /app/analytics/templates/website/publication_article.mako:24
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:36
+#: /app/analytics/templates/website/publication_article.mako:36
 msgid ""
-"Este gráfico apresenta o total de documentos publicados por área de atuação."
-" Os números são relacionados a coleção ou ao periódico quando um periódico é"
-" selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas "
-"são determinadas para cada um dos periódicos SciELO, podendo um periódico "
-"estar relacionado a mais de uma área de atuação. Os valores totais de "
-"documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode fazer parte de mais de "
-"uma área de atuação. Este gráfico é recomendado para extração de indicadores"
-" de Coleção."
-msgstr "Esta gráfica muestra el total de documentos publicados por área de actuación. Los números relacionados a la colección,  o a la revista cuando se ha seleccionado una revista. Las áreas de actuación son las grandes áreas del CNPQ, estas áreas son determinadas para cada revista SciELO, permitiendo que un periódico esté relacionado a una o más áreas de actuación. Los valores totales de documentos de esta gráfica no pueden ser considerado como totales de la colección, pues un documento puede hacer parte de una o más áreas de actuación. Esta gráfica es recomendada para la extracción de indicadores de Colección."
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el total de documentos publicados por área de "
+"actuación. Los números relacionados a la colección,  o a la revista "
+"cuando se ha seleccionado una revista. Las áreas de actuación son las "
+"grandes áreas del CNPQ, estas áreas son determinadas para cada revista "
+"SciELO, permitiendo que un periódico esté relacionado a una o más áreas "
+"de actuación. Los valores totales de documentos de esta gráfica no pueden"
+" ser considerado como totales de la colección, pues un documento puede "
+"hacer parte de una o más áreas de actuación. Esta gráfica es recomendada "
+"para la extracción de indicadores de Colección."
 
-#: analytics/templates/website/publication_article.mako:55
+#: /app/analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
 "Citation Index e documentados no SciELO Publishing Schema."
-msgstr "Esta grafica muestra el total de documentos por tipo de documento. Los número están relacionados a la colección, o al periódico cuando se ha seleccionado un periódico. Los tipos de documentos son los tipos utilizados por el SciELO Citation Index y documentados en el SciELO Publishing Schema."
+msgstr ""
+"Esta grafica muestra el total de documentos por tipo de documento. Los "
+"número están relacionados a la colección, o al periódico cuando se ha "
+"seleccionado un periódico. Los tipos de documentos son los tipos "
+"utilizados por el SciELO Citation Index y documentados en el SciELO "
+"Publishing Schema."
 
-#: analytics/templates/website/publication_article.mako:61
-#: analytics/templates/website/publication_article_by_publication_year.mako:61
+#: /app/analytics/templates/website/publication_article.mako:61
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:73
+#: /app/analytics/templates/website/publication_article.mako:73
 msgid ""
-"Este gráfico apresenta o total de documentos por idioma de publicação. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ser publicado em mais de um idioma."
-msgstr "Esta gráfica muestra el total de documentos por idioma de publicación. Los números están relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado en uno o más idiomas."
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
+msgstr ""
+"Esta gráfica muestra el total de documentos por idioma de publicación. "
+"Los números están relacionados a la colección, o a la revista cuando se "
+"ha seleccionado una revista. Los valores totales de documentos de esta "
+"gráfica no pueden ser considerados como totales de publicación de la "
+"colección, pues un documento puede ser publicado en uno o más idiomas."
 
-#: analytics/templates/website/publication_article.mako:79
+#: /app/analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:91
+#: /app/analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
-"publicação. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado."
-msgstr "Esta gráfica muestra el total de documentos publicados por año de publicación. Los número están relacionados a una colección, o al periódico cuando algún periódico es seleccionado."
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
+msgstr ""
+"Esta gráfica muestra el total de documentos publicados por año de "
+"publicación. Los número están relacionados a una colección, o al "
+"periódico cuando algún periódico es seleccionado."
 
-#: analytics/templates/website/publication_article.mako:97
-#: analytics/templates/website/publication_article_by_publication_year.mako:79
+#: /app/analytics/templates/website/publication_article.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:109
+#: /app/analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ter mais um país de afiliação."
-msgstr "Esta gráfica muestra el total de documentos por país de afiliación de los autores. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de la colección dado que un documento puede tener más de un país de afiliación."
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"Esta gráfica muestra el total de documentos por país de afiliación de los"
+" autores. Los valores totales de documentos de esta gráfica no pueden ser"
+" considerados como totales de la colección dado que un documento puede "
+"tener más de un país de afiliación."
 
-#: analytics/templates/website/publication_article.mako:115
+#: /app/analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:127
+#: /app/analytics/templates/website/publication_article.mako:127
 msgid ""
-"Este mapa apresenta o total de documentos por país de afiliação dos autores."
-" Os valores totais de documentos deste mapa não podem ser considerados como "
-"totais de publicações da coleção uma vez que um documento pode ter mais um "
-"país de afiliação."
-msgstr "Ese mapa muestra el total de documentos por país de afiliación de los autores. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de la colección dado que un documento puede tener más de un país de afiliación."
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"Ese mapa muestra el total de documentos por país de afiliación de los "
+"autores. Los valores totales de documentos de esta gráfica no pueden ser "
+"considerados como totales de la colección dado que un documento puede "
+"tener más de un país de afiliación."
 
-#: analytics/templates/website/publication_article.mako:145
+#: /app/analytics/templates/website/publication_article.mako:145
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de autores. "
-"Os números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado."
-msgstr "Esta gráfica muestra la distribución de documentos por número de autores. Los números están relacionados a la colección, o al periódico cuando un periódico esta seleccionado."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por número de autores."
+" Los números están relacionados a la colección, o al periódico cuando un "
+"periódico esta seleccionado."
 
-#: analytics/templates/website/publication_article.mako:151
+#: /app/analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: analytics/templates/website/publication_article.mako:163
+#: /app/analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
-msgstr "Esta gráfica muestra la distribución de documentos por número de referencias bibliográficas. Los número están relacionados a una colección, o al periódico cuando algún periódico es seleccionado. "
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por número de "
+"referencias bibliográficas. Los número están relacionados a una "
+"colección, o al periódico cuando algún periódico es seleccionado. "
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso e ano"
-" de publicação. Os números são relacionados a coleção ou ao periódico quando"
-" um periódico é selecionado. A disponibilidade de indicadores de licença de "
-"uso dependem da adoção da coleção ou periódico selecionado de licenças de "
-"uso creative commons."
-msgstr "Esta gráfica muestra el total de documentos por licencia de uso y año de publicación. Los números estan  relacionados a la colección,  o a la revista cuando se ha seleccionado una revista. La disponibilidad de los indicadores de licencias de uso depende de la adopción de la colección o de la revista seleccionada por licencias creative commons."
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:36
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por área de atuação e "
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode fazer parte de mais de uma área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra la distribución de documentos por área de actuación y año de publicación. Los números están relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos en esta gráfica no puede ser considerado como total de publicaciones de la colección, pues el documento puede ser parte de una o más áreas de actuaciones. Esta gráfica es recomendada para la extracción de indicadores de Colección."
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
+msgstr ""
+"Esta gráfica muestra el total de documentos por licencia de uso y año de "
+"publicación. Los números estan  relacionados a la colección,  o a la "
+"revista cuando se ha seleccionado una revista. La disponibilidad de los "
+"indicadores de licencias de uso depende de la adopción de la colección o "
+"de la revista seleccionada por licencias creative commons."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:55
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por tipo de publicação e"
-" ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado."
-msgstr "Esta gráfica muesta la distribución de documentos por tipo de publicación y año de publcación.  Los número están relacionados a una colección, o a una revista cuando alguna revista es seleccionada."
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por área de actuación "
+"y año de publicación. Los números están relacionados a la colección, o a "
+"la revista cuando se ha seleccionado una revista. Los valores totales de "
+"documentos en esta gráfica no puede ser considerado como total de "
+"publicaciones de la colección, pues el documento puede ser parte de una o"
+" más áreas de actuaciones. Esta gráfica es recomendada para la extracción"
+" de indicadores de Colección."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:73
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por idioma de publicação"
-" e ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode ser publicado em mais de um idioma."
-msgstr "Esta gráfica muestra el total de documentos por idioma de publicación y año de publicación. Los números estan relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado en uno o más idiomas."
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
+msgstr ""
+"Esta gráfica muesta la distribución de documentos por tipo de publicación"
+" y año de publcación.  Los número están relacionados a una colección, o a"
+" una revista cuando alguna revista es seleccionada."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:91
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por país de afiliação "
-"dos autores e ano de publicação. Os números são relacionados a coleção ou ao"
-" periódico quando um periódico é selecionado. Os valores totais de "
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
 "documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode ser publicado por mais "
-"de um país de afiliação."
-msgstr "Esta gráfica muestra la distribución de documentos por país de afiliación de los autores y el año de publicación. Los números estan relacionados a la colección, o a la revista cuando se ha seleccionado una revista. Los valores totales de documentos de esta gráfica no pueden ser considerados como totales de publicación de la colección, pues un documento puede ser publicado por uno o más países de afiliación."
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
+msgstr ""
+"Esta gráfica muestra el total de documentos por idioma de publicación y "
+"año de publicación. Los números estan relacionados a la colección, o a la"
+" revista cuando se ha seleccionado una revista. Los valores totales de "
+"documentos de esta gráfica no pueden ser considerados como totales de "
+"publicación de la colección, pues un documento puede ser publicado en uno"
+" o más idiomas."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+msgstr ""
+"Esta gráfica muestra la distribución de documentos por país de afiliación"
+" de los autores y el año de publicación. Los números estan relacionados a"
+" la colección, o a la revista cuando se ha seleccionado una revista. Los "
+"valores totales de documentos de esta gráfica no pueden ser considerados "
+"como totales de publicación de la colección, pues un documento puede ser "
+"publicado por uno o más países de afiliación."
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr ""
 
-#: analytics/templates/website/publication_journal_licenses.mako:17
-msgid ""
-"Este gráfico apresenta o número de periódicos por licença de uso adotada. Os"
-" valores totais de periódicos deste gráfico não podem ser considerados como "
-"totais da coleção uma vez que um documento pode fazer parte de mais de uma "
-"área de atuação. Este gráfico é recomendado para extração de indicadores de "
-"Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por licencia de uso adoptada. Los valores totales de periódicos en esta gráfica no puede ser considerada como totales de la colección, pues un documento puede ser parte de una o más área de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección. "
+#: /app/analytics/templates/website/publication_journal.mako:5
+msgid "Licenças de uso dos periódicos"
+msgstr ""
 
-#: analytics/templates/website/publication_journal_status.mako:17
+#: /app/analytics/templates/website/publication_journal.mako:10
+msgid "Áreas temáticas dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:15
+msgid "Ano de inclusão de periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:19
+msgid "Situação de publicação dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
-"Este gráfico apresenta o número de periódicos por status da publicação no "
-"SciELO. O status considerado neste grafíco é o status vigente do periódico, "
-"não são consideradas as mudanças de status a longo da existência do "
-"periódico nas bases SciELO. Este gráfico é recomendado para extração de "
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
 "indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por estado de publicación en SciELO. El estado considerado en esta gráfica es el estado vigente del periódico, no se consideran las modificaciones de estado a lo largo de la existencia del periódico en las bases SciELO. Esta gráfica es recomendada para extracción de indicadores de Colección."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por licencia de uso "
+"adoptada. Los valores totales de periódicos en esta gráfica no puede ser "
+"considerada como totales de la colección, pues un documento puede ser "
+"parte de una o más área de actuación. Esta gráfica es recomendada para "
+"extracción de indicadores de Colección. "
 
-#: analytics/templates/website/publication_journal_subject_areas.mako:17
+#: /app/analytics/templates/website/publication_journal_status.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por estado de publicación en"
+" SciELO. El estado considerado en esta gráfica es el estado vigente del "
+"periódico, no se consideran las modificaciones de estado a lo largo de la"
+" existencia del periódico en las bases SciELO. Esta gráfica es "
+"recomendada para extracción de indicadores de Colección."
+
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção. As áreas de "
-"atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada"
-" um dos periódicos SciELO, podendo um periódico estar relacionado a mais de "
-"uma área de atuação. Os valores totais de periódicos deste gráfico não podem"
-" ser considerados como totais da coleção uma vez que um documento pode fazer"
-" parte de mais de uma área de atuação. Este gráfico é recomendado para "
-"extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por área de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección. Las áreas de actuación son las grandes áreas de el CNPQ, estas áreas son determinadas para cada periódico SciELO, permitiendo a un periódico estar relacionado con mas de una área de actuación. Los valores totales de periódicos en esta gráfica no pueden ser considerados como totales de la colección, pues un documento puede ser parte de una o más áreas de actuación. Esta gráfica es recomendada para extracción de indicadores de Colección."
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por área de actuación. Esta "
+"gráfica es recomendada para extracción de indicadores de Colección. Las "
+"áreas de actuación son las grandes áreas de el CNPQ, estas áreas son "
+"determinadas para cada periódico SciELO, permitiendo a un periódico estar"
+" relacionado con mas de una área de actuación. Los valores totales de "
+"periódicos en esta gráfica no pueden ser considerados como totales de la "
+"colección, pues un documento puede ser parte de una o más áreas de "
+"actuación. Esta gráfica es recomendada para extracción de indicadores de "
+"Colección."
 
-#: analytics/templates/website/publication_journal_year.mako:17
+#: /app/analytics/templates/website/publication_journal_year.mako:17
 msgid ""
-"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. "
-"Este gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Esta gráfica muestra el número de periódicos por año de inclusión en SciELO. Este gráfico es recomendado para extracción de indicadores de Colección."
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
+msgstr ""
+"Esta gráfica muestra el número de periódicos por año de inclusión en "
+"SciELO. Este gráfico es recomendado para extracción de indicadores de "
+"Colección."
 
-#: analytics/templates/website/publication_size.mako:11
-#: analytics/templates/website/publication_size.mako:22
-#: analytics/templates/website/publication_size.mako:33
-#: analytics/templates/website/publication_size.mako:44
+#: /app/analytics/templates/website/publication_size.mako:11
+#: /app/analytics/templates/website/publication_size.mako:22
+#: /app/analytics/templates/website/publication_size.mako:33
+#: /app/analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre los números"
 
-#: analytics/templates/website/publication_size.mako:14
+#: /app/analytics/templates/website/publication_size.mako:14
 msgid ""
-"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e "
-"artigo publicados. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden a las revistas con al menos 1 fascículo y artículo publicado. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
+msgstr ""
+"Los números de arriba corresponden a las revistas con al menos 1 "
+"fascículo y artículo publicado. Los números estan relacionados a la "
+"colección o a la revista cuando una revista es eligida en la parte "
+"superior del sitio."
 
-#: analytics/templates/website/publication_size.mako:25
+#: /app/analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
-"publicado. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden a los fascículos con al menos 1 fascículo y artículo publicado. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior el sitio."
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
+msgstr ""
+"Los números de arriba corresponden a los fascículos con al menos 1 "
+"fascículo y artículo publicado. Los números estan relacionados a la "
+"colección o a la revista cuando una revista es eligida en la parte "
+"superior el sitio."
 
-#: analytics/templates/website/publication_size.mako:36
+#: /app/analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden al total de documentos publicados. Los número estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+msgstr ""
+"Los números de arriba corresponden al total de documentos publicados. Los"
+" número estan relacionados a la colección o a la revista cuando una "
+"revista es eligida en la parte superior del sitio."
 
-#: analytics/templates/website/publication_size.mako:47
+#: /app/analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
-"citadas nos documentos publicados. Os números são relacionados a coleção ou "
-"ao periódico quando um periódico é selecionado na barra superior do site."
-msgstr "Los números de arriba corresponden al total de referencias bibliográficas citadas en los documentos. Los números estan relacionados a la colección o a la revista cuando una revista es eligida en la parte superior del sitio."
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
+msgstr ""
+"Los números de arriba corresponden al total de referencias bibliográficas"
+" citadas en los documentos. Los números estan relacionados a la colección"
+" o a la revista cuando una revista es eligida en la parte superior del "
+"sitio."
 
-#: analytics/templates/website/publication_size_citations.mako:9
+#: /app/analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referencias"
 
-#: analytics/templates/website/publication_size_documents.mako:9
+#: /app/analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: analytics/templates/website/publication_size_issues.mako:9
+#: /app/analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: analytics/templates/website/publication_size_journals.mako:9
+#: /app/analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "revistas"
 
-#: analytics/templates/website/reports.mako:5
+#: /app/analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tablas"
 
-#: analytics/templates/website/reports.mako:7
+#: /app/analytics/templates/website/reports.mako:7
 msgid ""
-"O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados "
-"utilizados para produção dos indicadores presentes nesta ferramenta. "
-"Qualquer interessado pode fazer o download e produzir análises "
-"bibliométricas de acordo com suas necessidade."
-msgstr "El SciELO fornece algunas tablas preformatadas con algunis de los metadatos utilizados para la producción de los indicadores presentes en esa herramienta. Cualquier interesado puede bajar y produzir analisis bibliometricas de acuerdo con sus necesidades."
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
+msgstr ""
+"El SciELO fornece algunas tablas preformatadas con algunis de los "
+"metadatos utilizados para la producción de los indicadores presentes en "
+"esa herramienta. Cualquier interesado puede bajar y produzir analisis "
+"bibliometricas de acuerdo con sus necesidades."
 
-#: analytics/templates/website/reports.mako:10
-msgid ""
-"Para mais informações sobre as catacterísticas de cada tabulação, acessar"
+#: /app/analytics/templates/website/reports.mako:10
+msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mas informaciones sobre las características de cada tabla, acceder"
 
-#: analytics/templates/website/reports.mako:16
+#: /app/analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nombre del archivo"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidad de actualización"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensual"
 
-#: analytics/templates/website/reports.mako:18
+#: /app/analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamaño del archivo"
 
-#: analytics/templates/website/reports.mako:19
+#: /app/analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: analytics/templates/website/reports.mako:20
+#: /app/analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última actualización"
 
-#: analytics/templates/website/reports.mako:23
+#: /app/analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "archivo no disponible para la colección"
 
-#: analytics/templates/website/share.mako:8
+#: /app/analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartir por email"
 
-#: analytics/templates/website/share.mako:10
+#: /app/analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartir en Facebook"
 
-#: analytics/templates/website/share.mako:13
+#: /app/analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartir en Twitter"
 
-#: analytics/templates/website/share.mako:16
+#: /app/analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartir en LinkedIn"

--- a/analytics/locale/es_MX/LC_MESSAGES/analytics.po
+++ b/analytics/locale/es_MX/LC_MESSAGES/analytics.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-09-17 18:21+0000\n"
+"POT-Creation-Date: 2019-09-18 12:50+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
 "Language: es_MX\n"
@@ -21,421 +21,421 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.1\n"
 
-#: /app/analytics/charts_config.py:25
+#: analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fuente: SciELO.org"
 
-#: /app/analytics/charts_config.py:58
+#: analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:59
+#: analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr ""
 
-#: /app/analytics/charts_config.py:91
+#: analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Año de publicación de los documentos de la revista. (citados)"
 
-#: /app/analytics/charts_config.py:92
+#: analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Año de publicación de los documentos de la Red SciELO. (citantes)"
 
-#: /app/analytics/charts_config.py:100
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: analytics/charts_config.py:100
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+#: analytics/charts_config.py:103 analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
-#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
-#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
+#: analytics/charts_config.py:113 analytics/charts_config.py:135
+#: analytics/charts_config.py:157 analytics/charts_config.py:179
+#: analytics/charts_config.py:202 analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Año base"
 
-#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
-#: /app/analytics/charts_config.py:134
+#: analytics/charts_config.py:122 analytics/charts_config.py:125
+#: analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
-#: /app/analytics/charts_config.py:156
+#: analytics/charts_config.py:144 analytics/charts_config.py:147
+#: analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
-#: /app/analytics/charts_config.py:178
+#: analytics/charts_config.py:166 analytics/charts_config.py:169
+#: analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:188
+#: analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fuente: Google Scholar"
 
-#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
-#: /app/analytics/charts_config.py:201
+#: analytics/charts_config.py:189 analytics/charts_config.py:192
+#: analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: /app/analytics/charts_config.py:211
+#: analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "inmediatez"
 
-#: /app/analytics/charts_config.py:212
-#: /app/analytics/templates/website/access_datepicker.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: analytics/charts_config.py:212
+#: analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "Un año"
 
-#: /app/analytics/charts_config.py:213
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/charts_config.py:213
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 años"
 
-#: /app/analytics/charts_config.py:214
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/charts_config.py:214
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 años"
 
-#: /app/analytics/charts_config.py:215
+#: analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 años"
 
-#: /app/analytics/charts_config.py:216
+#: analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 años"
 
-#: /app/analytics/charts_config.py:223
+#: analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO en 1, 2, 3, 4, 5 años y Índice de Inmediatez"
 
-#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
-#: /app/analytics/templates/website/bibliometrics_journal.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: analytics/charts_config.py:226 analytics/charts_config.py:228
+#: analytics/templates/website/bibliometrics_journal.mako:23
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citación"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citas concedidas"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citas recibidas"
 
-#: /app/analytics/charts_config.py:244
+#: analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribición de citas concedidas, recibidas y auto citación"
 
-#: /app/analytics/charts_config.py:251
+#: analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citas"
 
-#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
-#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
-#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
-#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
-#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
-#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
-#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: analytics/charts_config.py:256 analytics/charts_config.py:273
+#: analytics/charts_config.py:287 analytics/charts_config.py:414
+#: analytics/charts_config.py:423 analytics/charts_config.py:438
+#: analytics/charts_config.py:446 analytics/charts_config.py:494
+#: analytics/charts_config.py:503 analytics/charts_config.py:562
+#: analytics/charts_config.py:572 analytics/charts_config.py:614
+#: analytics/charts_config.py:623 analytics/charts_config.py:664
+#: analytics/charts_config.py:672 analytics/charts_config.py:788
+#: analytics/templates/website/central_container_for_article_filters.mako:13
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Año de publicación"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citables"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos no citables"
 
-#: /app/analytics/charts_config.py:272
+#: analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribución de documentos citables y no citables"
 
-#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
-#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
-#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
-#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
-#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
-#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
-#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
-#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
+#: analytics/charts_config.py:281 analytics/charts_config.py:305
+#: analytics/charts_config.py:324 analytics/charts_config.py:341
+#: analytics/charts_config.py:388 analytics/charts_config.py:412
+#: analytics/charts_config.py:441 analytics/charts_config.py:467
+#: analytics/charts_config.py:492 analytics/charts_config.py:540
+#: analytics/charts_config.py:560 analytics/charts_config.py:568
+#: analytics/charts_config.py:591 analytics/charts_config.py:612
+#: analytics/charts_config.py:662 analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: /app/analytics/charts_config.py:298
+#: analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribución por número de referencias bibliográficas en los documentos"
 
-#: /app/analytics/charts_config.py:301
+#: analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referencias bibliográficas"
 
-#: /app/analytics/charts_config.py:308
+#: analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documentos con %s referencias bibliográficas"
 
-#: /app/analytics/charts_config.py:317
+#: analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribución por número de autores de los documentos"
 
-#: /app/analytics/charts_config.py:320
-#: /app/analytics/templates/website/publication_article.mako:133
+#: analytics/charts_config.py:320
+#: analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: /app/analytics/charts_config.py:327
+#: analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documentos con %s autores"
 
-#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
+#: analytics/charts_config.py:338 analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr ""
 
-#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
-#: /app/analytics/charts_config.py:694
+#: analytics/charts_config.py:359 analytics/charts_config.py:391
+#: analytics/charts_config.py:446 analytics/charts_config.py:470
+#: analytics/charts_config.py:543 analytics/charts_config.py:594
+#: analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
-#: /app/analytics/charts_config.py:391
+#: analytics/charts_config.py:368 analytics/charts_config.py:383
+#: analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliación"
 
-#: /app/analytics/charts_config.py:404
+#: analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr ""
 
-#: /app/analytics/charts_config.py:437
+#: analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribución por año de publicación de los documentos"
 
-#: /app/analytics/charts_config.py:459
+#: analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribución de idiomas de los documentos"
 
-#: /app/analytics/charts_config.py:462
+#: analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicación"
 
-#: /app/analytics/charts_config.py:470
+#: analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma del documento"
 
-#: /app/analytics/charts_config.py:484
+#: analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribución de idiomas de los documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:514
+#: analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribución de revistas por año de incorporación en SciELO"
 
-#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
+#: analytics/charts_config.py:515 analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Año de incorporación"
 
-#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
-#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+#: analytics/charts_config.py:518 analytics/charts_config.py:642
+#: analytics/charts_config.py:711 analytics/charts_config.py:731
 msgid "Número de periódicos"
 msgstr "Número de revistas"
 
-#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
-#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
-#: /app/analytics/templates/website/navbar_collection.mako:10
-#: /app/analytics/templates/website/navbar_journal.mako:10
+#: analytics/charts_config.py:523 analytics/charts_config.py:645
+#: analytics/charts_config.py:714 analytics/charts_config.py:734
+#: analytics/templates/website/navbar_collection.mako:10
+#: analytics/templates/website/navbar_journal.mako:10
 msgid "Periódicos"
 msgstr "Revistas"
 
-#: /app/analytics/charts_config.py:532
+#: analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribución por área temática de los documentos"
 
-#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
+#: analytics/charts_config.py:535 analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Áreas temáticas"
 
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
+#: analytics/charts_config.py:543 analytics/charts_config.py:714
+#: analytics/templates/website/central_container_for_article_filters.mako:30
+#: analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: /app/analytics/charts_config.py:552
+#: analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribución de área temática de los documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:583
+#: analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribución por tipo de documento"
 
-#: /app/analytics/charts_config.py:586
-#: /app/analytics/templates/website/publication_article.mako:43
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
+#: analytics/charts_config.py:586
+#: analytics/templates/website/publication_article.mako:43
+#: analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: /app/analytics/charts_config.py:594
+#: analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: /app/analytics/charts_config.py:604
+#: analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribución de tipos de documentos por año de publicación"
 
-#: /app/analytics/charts_config.py:634
+#: analytics/charts_config.py:634
 msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
 msgstr "Distribución de revistas de acuerdo a su situación actual en SciELO"
 
-#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+#: analytics/charts_config.py:637 analytics/charts_config.py:645
 msgid "Situação da publicação"
 msgstr "Situación de la publicación"
 
-#: /app/analytics/charts_config.py:654
+#: analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribución de licencias de uso por año de publicación"
 
-#: /app/analytics/charts_config.py:683
+#: analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribución por licencia de uso de los documentos"
 
-#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
-#: /app/analytics/templates/website/publication_article.mako:5
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
+#: analytics/charts_config.py:686 analytics/charts_config.py:726
+#: analytics/templates/website/publication_article.mako:5
+#: analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licencia de uso"
 
-#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
+#: analytics/charts_config.py:694 analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licencia"
 
-#: /app/analytics/charts_config.py:703
+#: analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribución por área temática de las revistas"
 
-#: /app/analytics/charts_config.py:723
+#: analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribución por licencia de uso de las revistas"
 
-#: /app/analytics/charts_config.py:742
+#: analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de accesos por año y mes"
 
-#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
-#: /app/analytics/templates/website/navbar_collection.mako:7
-#: /app/analytics/templates/website/navbar_document.mako:7
-#: /app/analytics/templates/website/navbar_journal.mako:7
+#: analytics/charts_config.py:750 analytics/charts_config.py:785
+#: analytics/templates/website/navbar_collection.mako:7
+#: analytics/templates/website/navbar_document.mako:7
+#: analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Accesos"
 
-#: /app/analytics/charts_config.py:756
+#: analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Accesos en"
 
-#: /app/analytics/charts_config.py:767
+#: analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accesos por tipo de documento"
 
-#: /app/analytics/charts_config.py:771
+#: analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s accesos a documentos de tipo %s"
 
-#: /app/analytics/charts_config.py:783
+#: analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de los articulos por número de accesos en"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Año de consulta"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s accesos a los documentos del año %s"
 
-#: /app/analytics/templates/website/access_by_document_type.mako:6
-#: /app/analytics/templates/website/access_by_month_and_year.mako:5
-#: /app/analytics/templates/website/access_lifetime.mako:6
-#: /app/analytics/templates/website/accesses_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_authors.mako:5
-#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
-#: /app/analytics/templates/website/publication_article_document_type.mako:5
-#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_languages.mako:5
-#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_licenses.mako:5
-#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_references.mako:5
-#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
-#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: /app/analytics/templates/website/publication_article_year.mako:5
-#: /app/analytics/templates/website/publication_journal_licenses.mako:7
-#: /app/analytics/templates/website/publication_journal_status.mako:7
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
-#: /app/analytics/templates/website/publication_journal_year.mako:7
-#: /app/analytics/templates/website/publication_size_citations.mako:6
-#: /app/analytics/templates/website/publication_size_documents.mako:6
-#: /app/analytics/templates/website/publication_size_issues.mako:6
-#: /app/analytics/templates/website/publication_size_journals.mako:6
+#: analytics/templates/website/access_by_document_type.mako:6
+#: analytics/templates/website/access_by_month_and_year.mako:5
+#: analytics/templates/website/access_lifetime.mako:6
+#: analytics/templates/website/accesses_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: analytics/templates/website/publication_article_affiliations.mako:5
+#: analytics/templates/website/publication_article_affiliations_map.mako:5
+#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: analytics/templates/website/publication_article_authors.mako:5
+#: analytics/templates/website/publication_article_citable_documents.mako:5
+#: analytics/templates/website/publication_article_document_type.mako:5
+#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: analytics/templates/website/publication_article_languages.mako:5
+#: analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: analytics/templates/website/publication_article_licenses.mako:5
+#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: analytics/templates/website/publication_article_references.mako:5
+#: analytics/templates/website/publication_article_subject_areas.mako:6
+#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: analytics/templates/website/publication_article_year.mako:5
+#: analytics/templates/website/publication_journal_licenses.mako:7
+#: analytics/templates/website/publication_journal_status.mako:7
+#: analytics/templates/website/publication_journal_subject_areas.mako:7
+#: analytics/templates/website/publication_journal_year.mako:7
+#: analytics/templates/website/publication_size_citations.mako:6
+#: analytics/templates/website/publication_size_documents.mako:6
+#: analytics/templates/website/publication_size_issues.mako:6
+#: analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "cargando"
 
-#: /app/analytics/templates/website/access_datepicker.mako:5
+#: analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Revista"
 
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "accesos en los últimos 36 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "accesos en los últimos 24 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "accesos en los últimos 12 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos los accesos disponíbles"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "todo"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Selector de rango de accesos"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
 "recuperação dos dados de acesso. Você pode também selecionar o período de"
@@ -447,96 +447,96 @@ msgstr ""
 " de 1, 2 o 3 años, por medio de los enlaces rápidos o todos los accesos "
 "disponíbles."
 
-#: /app/analytics/templates/website/access_list_articles.mako:6
+#: analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 de artículos por número de accesos"
 
-#: /app/analytics/templates/website/access_list_articles.mako:9
+#: analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artículo"
 
-#: /app/analytics/templates/website/access_list_articles.mako:13
-#: /app/analytics/templates/website/access_list_issues.mako:13
-#: /app/analytics/templates/website/access_list_journals.mako:13
+#: analytics/templates/website/access_list_articles.mako:13
+#: analytics/templates/website/access_list_issues.mako:13
+#: analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumen"
 
-#: /app/analytics/templates/website/access_list_articles.mako:14
-#: /app/analytics/templates/website/access_list_issues.mako:14
-#: /app/analytics/templates/website/access_list_journals.mako:14
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
+#: analytics/templates/website/access_list_articles.mako:14
+#: analytics/templates/website/access_list_issues.mako:14
+#: analytics/templates/website/access_list_journals.mako:14
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: analytics/templates/website/bibliometrics_list_granted.mako:19
+#: analytics/templates/website/bibliometrics_list_granted.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: analytics/templates/website/bibliometrics_list_received.mako:26
+#: analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: /app/analytics/templates/website/access_list_issues.mako:6
+#: analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 de fascículos por número de accesos"
 
-#: /app/analytics/templates/website/access_list_issues.mako:9
-#: /app/analytics/templates/website/access_list_journals.mako:9
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: analytics/templates/website/access_list_issues.mako:9
+#: analytics/templates/website/access_list_journals.mako:9
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "revista"
 
-#: /app/analytics/templates/website/access_list_journals.mako:6
+#: analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Accesos a los documentos por revista"
 
-#: /app/analytics/templates/website/accesses.mako:6
+#: analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:12
+#: analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses.mako:18
+#: analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:15
+#: analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr ""
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr ""
 
-#: /app/analytics/templates/website/base.mako:6
+#: analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estadísticas"
 
-#: /app/analytics/templates/website/base.mako:30
+#: analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Colecciones"
 
-#: /app/analytics/templates/website/base.mako:38
-#: /app/analytics/templates/website/journal_selector_modal.mako:7
+#: analytics/templates/website/base.mako:38
+#: analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "seleccionar revista"
 
-#: /app/analytics/templates/website/base.mako:91
+#: analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Herramienta en desarrollo disponible en versión de pruebas Beta."
 
-#: /app/analytics/templates/website/base.mako:93
+#: analytics/templates/website/base.mako:93
 msgid ""
 "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
 " realizar testes de uso e performance. Todos os indicadores carregados "
@@ -549,214 +549,214 @@ msgstr ""
 "gradualmente. Se pueden presentar problemas de lentitud o disponibilidad "
 "durante esta fase."
 
-#: /app/analytics/templates/website/base.mako:114
+#: analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ayuda"
 
-#: /app/analytics/templates/website/base.mako:116
+#: analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: /app/analytics/templates/website/base.mako:117
+#: analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discusión"
 
-#: /app/analytics/templates/website/base.mako:121
+#: analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desarrollo"
 
-#: /app/analytics/templates/website/base.mako:124
+#: analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desarrollo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Enero"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Febrero"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Marzo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Mayo"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junio"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julio"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Septiembre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Octubre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Noviembre"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Diciembre"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Ene"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Feb"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "May"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Sep"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Oct"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dic"
 
-#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citas Recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "año de publicación"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primer autor"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título del documento"
 
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citas recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
+#: analytics/templates/website/bibliometrics_journal.mako:8
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: analytics/templates/website/bibliometrics_list_granted.mako:8
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atención"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
+#: analytics/templates/website/bibliometrics_journal.mako:11
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: analytics/templates/website/bibliometrics_list_granted.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "Es necesario seleccionar una revista para los datos bibliométricos "
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:20
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
+#: analytics/templates/website/bibliometrics_journal.mako:20
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: analytics/templates/website/bibliometrics_list_received.mako:19
+#: analytics/templates/website/central_container_for_article_filters.mako:16
+#: analytics/templates/website/central_container_for_article_filters.mako:33
+#: analytics/templates/website/central_container_for_article_filters.mako:52
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:32
-#: /app/analytics/templates/website/bibliometrics_journal.mako:51
-#: /app/analytics/templates/website/bibliometrics_journal.mako:69
-#: /app/analytics/templates/website/bibliometrics_journal.mako:87
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: /app/analytics/templates/website/publication_article.mako:14
-#: /app/analytics/templates/website/publication_article.mako:33
-#: /app/analytics/templates/website/publication_article.mako:52
-#: /app/analytics/templates/website/publication_article.mako:70
-#: /app/analytics/templates/website/publication_article.mako:88
-#: /app/analytics/templates/website/publication_article.mako:106
-#: /app/analytics/templates/website/publication_article.mako:124
-#: /app/analytics/templates/website/publication_article.mako:142
-#: /app/analytics/templates/website/publication_article.mako:160
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
-#: /app/analytics/templates/website/publication_journal_licenses.mako:14
-#: /app/analytics/templates/website/publication_journal_status.mako:14
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
-#: /app/analytics/templates/website/publication_journal_year.mako:14
+#: analytics/templates/website/bibliometrics_journal.mako:32
+#: analytics/templates/website/bibliometrics_journal.mako:51
+#: analytics/templates/website/bibliometrics_journal.mako:69
+#: analytics/templates/website/bibliometrics_journal.mako:87
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: analytics/templates/website/publication_article.mako:14
+#: analytics/templates/website/publication_article.mako:33
+#: analytics/templates/website/publication_article.mako:52
+#: analytics/templates/website/publication_article.mako:70
+#: analytics/templates/website/publication_article.mako:88
+#: analytics/templates/website/publication_article.mako:106
+#: analytics/templates/website/publication_article.mako:124
+#: analytics/templates/website/publication_article.mako:142
+#: analytics/templates/website/publication_article.mako:160
+#: analytics/templates/website/publication_article_by_publication_year.mako:14
+#: analytics/templates/website/publication_article_by_publication_year.mako:33
+#: analytics/templates/website/publication_article_by_publication_year.mako:52
+#: analytics/templates/website/publication_article_by_publication_year.mako:70
+#: analytics/templates/website/publication_article_by_publication_year.mako:88
+#: analytics/templates/website/publication_article_by_publication_year.mako:106
+#: analytics/templates/website/publication_journal_licenses.mako:14
+#: analytics/templates/website/publication_journal_status.mako:14
+#: analytics/templates/website/publication_journal_subject_areas.mako:14
+#: analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre la gráfica"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:35
+#: analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
@@ -768,12 +768,12 @@ msgstr ""
 "años. La línea de 2 años equivale al factor de impacto de Thomson Reuters"
 " "
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:42
+#: analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:54
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
+#: analytics/templates/website/bibliometrics_journal.mako:54
+#: analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
 "Este gráfico apresenta a distribuição de documentos citáveis e não "
 "citáveis relacionados ao periódico selecionado. De acordo com as regras "
@@ -789,11 +789,11 @@ msgstr ""
 "Communication y Article Commentary. Los demas tipos documentos no son "
 "considerados citables."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+#: analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:72
+#: analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
 "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
 "indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
@@ -801,17 +801,17 @@ msgid ""
 "ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
 "Ao clicar na série, você será direcionado para o site do Google Scholar."
 msgstr ""
-"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los idicadores "
-"son fornecidos anualmente por Google Scholar. La falta de indicadores para "
-"una revista o para un rango de una revista pueden ocurrir. Cuando clicar en "
-"una de las series, el usuário vá a ser direccionado para el sitio del Google "
-" Scholar."
+"Esta gráfica muestra los indices H5 y M5 del Google Scholar. Los "
+"idicadores son fornecidos anualmente por Google Scholar. La falta de "
+"indicadores para una revista o para un rango de una revista pueden "
+"ocurrir. Cuando clicar en una de las series, el usuário vá a ser "
+"direccionado para el sitio del Google  Scholar."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:78
+#: analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:90
+#: analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
@@ -821,106 +821,106 @@ msgstr ""
 " citaciones del periódico seleccionado, los datos están distribuidos por "
 "año de publicación."
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:27
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:28
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:29
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfica de calor de citaciones recibidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
@@ -930,232 +930,232 @@ msgstr ""
 "corpus de citas corresponde a todas las colecciones de la Red SciELO, las"
 " colecciones Temáticas y independientes."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Lista de citas para el eje seleccionado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Elija in eje x/y para obtener el listado de citaciones para la revista."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citaciones recibidas por la revista"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos de la Red SciELO publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citarón"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "veces los documentos de la revista"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique en el eje para mirar el listado de articulos citantes y citados."
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citación encontradas para la revista seleccionada"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: analytics/templates/website/bibliometrics_list_granted.mako:18
+#: analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "acciones"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar error"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: analytics/templates/website/bibliometrics_list_granted.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sin resultados"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:30
-#: /app/analytics/templates/website/navbar_journal.mako:32
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: analytics/templates/website/navbar_collection.mako:30
+#: analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media de citas"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citas en"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicaciones de"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Total de citas"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citaciones"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "porcentaje"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "porcentaje acumulado"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:5
 msgid "Indicadores Bibliométricos da Rede SciELO"
 msgstr "Indicadores Bibliométricos de la Red SciELO"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid "Periodicidade de atualização:"
 msgstr "Periodicidad de actualización:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid " anual"
 msgstr " anual"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:13
 msgid "Indicadores de Publicação"
 msgstr "Indicadores de Publicación"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:19
 msgid "Numeros da Rede SciELO por:"
 msgstr "Números de la Red SciELO por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:54
 msgid "Ano de publicação: "
 msgstr "Año de publicación: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:35
 msgid "Periódico: "
 msgstr "Revista: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:55
 msgid "Assunto: "
 msgstr "Área: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:24
 msgid "País de afiliação do autor: "
 msgstr "País de afiliación del autor: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:26
 msgid "País de Afiliação do Autor por: "
 msgstr "País de Afiliación del Autor por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:30
 msgid "País de publicação da revista: "
 msgstr "País de publicación de la revista: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:33
 msgid "Número de Co-autores por: "
 msgstr "Número de Co-autores por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:46
 msgid "Indicadores de Coleção"
 msgstr "Indicadores de la Colección"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:52
 msgid "Periódico por:"
 msgstr "Revista por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:56
 msgid "Indicadores gerais: "
 msgstr "Indicadores generales: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:66
 msgid "Indicadores de Citação"
 msgstr "Indicadores de Citación"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:72
 msgid "Ano de Citação por:"
 msgstr "Año de Citación por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:90
 msgid "Idade do documento citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:91
 msgid "Tipo de documento citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:77
 msgid "Periódico Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:82
 msgid "Assunto do Periódico Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:92
 msgid "Periódico SciELO citado: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:88
 msgid "País de Afiliação do Autor Citante por:"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
+#: analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citas concedidas por revista"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:29
-#: /app/analytics/templates/website/navbar_journal.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: analytics/templates/website/navbar_collection.mako:29
+#: analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO en 1, 2, 3, 4 y 5 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados en"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
 "Aqui são considerados apenas os documentos citáveis. De acordo com as "
 "regras de contagem do SciELO, documentos citáveis devem ser do tipo "
@@ -1169,55 +1169,55 @@ msgstr ""
 "Article, Case Report, Brief Report, Rapid Communication y Article "
 "Commentary. Los demas tipos documentos no son considerados citables."
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 años"
 
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:33
-#: /app/analytics/templates/website/navbar_journal.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:22
+#: analytics/templates/website/navbar_collection.mako:33
+#: analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citas recibidas por las revistas"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: analytics/templates/website/central_container_for_article_filters.mako:8
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtrados para documentos"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: analytics/templates/website/central_container_for_article_filters.mako:22
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
+#: analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
+#: analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtrados para revistas"
 
-#: /app/analytics/templates/website/faq.mako:5
+#: analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Preguntas frecuentes (Accesos)"
 
-#: /app/analytics/templates/website/faq.mako:7
+#: analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "¿Por qué algunas colecciones no poseen estadísticas de acceso?"
 
-#: /app/analytics/templates/website/faq.mako:8
+#: analytics/templates/website/faq.mako:8
 msgid ""
 "Para que os dados de acessos sejam computados é necessário que os logs de"
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
@@ -1228,13 +1228,13 @@ msgstr ""
 "estadísticas de acceso debe ser verificada con la coordinación de cada "
 "colección SciELO."
 
-#: /app/analytics/templates/website/faq.mako:11
+#: analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr ""
 "¿Por qué algunas colecciones poseen accesos calculados para una revista "
 "más grande?"
 
-#: /app/analytics/templates/website/faq.mako:12
+#: analytics/templates/website/faq.mako:12
 msgid ""
 "O período disponível de cada uma das coleções depende do período "
 "disponível dos logs de acessos de cada uma das coleções. Este projeto se "
@@ -1246,12 +1246,12 @@ msgstr ""
 " compromiso de calcular los datos de accesos a partir del 2012, siempre "
 "que los logs sean debidamente proporcionados por las colecciones. "
 
-#: /app/analytics/templates/website/faq.mako:15
-#: /app/analytics/templates/website/faq.mako:36
+#: analytics/templates/website/faq.mako:15
+#: analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "¿Qué es lo que se esta contando?"
 
-#: /app/analytics/templates/website/faq.mako:16
+#: analytics/templates/website/faq.mako:16
 msgid ""
 "Estão sendo contabilizados e classificados os acessos ao texto completo "
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
@@ -1261,7 +1261,7 @@ msgstr ""
 "HTML, PDF y EPDF (ReadCube), además de los accesos a las páginas de "
 "resumen del artículo."
 
-#: /app/analytics/templates/website/faq.mako:19
+#: analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
@@ -1269,7 +1269,7 @@ msgstr ""
 "¿Por qué los indicadores de esta herramienta son diferentes a los "
 "ofrecidos en otras herramientas de SciELO?"
 
-#: /app/analytics/templates/website/faq.mako:21
+#: analytics/templates/website/faq.mako:21
 msgid ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
@@ -1277,7 +1277,7 @@ msgstr ""
 "Algunas herramientas de SciELO pueden estar utilizando servicios antiguos"
 " de estadísticas de acceso."
 
-#: /app/analytics/templates/website/faq.mako:22
+#: analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
@@ -1285,7 +1285,7 @@ msgstr ""
 "El conteo de accesos de esta herramienta es diferente en diversos "
 "aspectos a las herramientas antiguas."
 
-#: /app/analytics/templates/website/faq.mako:23
+#: analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
@@ -1293,24 +1293,24 @@ msgstr ""
 "Algunas herramientas poseen una delta de actualización para diferencias "
 "los indicadores de acceso."
 
-#: /app/analytics/templates/website/faq.mako:27
-#: /app/analytics/templates/website/faq.mako:40
+#: analytics/templates/website/faq.mako:27
+#: analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "¿Cuál es la periodicidad de actualización de los indicadores?"
 
-#: /app/analytics/templates/website/faq.mako:28
+#: analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensual"
 
-#: /app/analytics/templates/website/faq.mako:30
+#: analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Preguntas frecuentes (Publicación)"
 
-#: /app/analytics/templates/website/faq.mako:32
+#: analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "¿Por qué algunas colecciones tienen datos desactualizados?"
 
-#: /app/analytics/templates/website/faq.mako:33
+#: analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1322,7 +1322,7 @@ msgstr ""
 "indicadores esta directamente relacionada al correcto desarrollo de los "
 "procesos en cada una de las colecciones."
 
-#: /app/analytics/templates/website/faq.mako:37
+#: analytics/templates/website/faq.mako:37
 msgid ""
 "Estão sendo contabilizados indicadores de publicação das coleções com "
 "base nos metadados fornecidos durante todo o processo de publicação de um"
@@ -1335,108 +1335,108 @@ msgstr ""
 "relacionada con la calidad de los procesos implementados por cada una de "
 "las colecciones."
 
-#: /app/analytics/templates/website/faq.mako:41
+#: analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: /app/analytics/templates/website/home_collection.mako:7
-#: /app/analytics/templates/website/home_journal.mako:7
-#: /app/analytics/templates/website/home_network.mako:7
-#: /app/analytics/templates/website/navbar_collection.mako:18
-#: /app/analytics/templates/website/navbar_journal.mako:18
-#: /app/analytics/templates/website/publication_size.mako:5
+#: analytics/templates/website/home_collection.mako:7
+#: analytics/templates/website/home_journal.mako:7
+#: analytics/templates/website/home_network.mako:7
+#: analytics/templates/website/navbar_collection.mako:18
+#: analytics/templates/website/navbar_journal.mako:18
+#: analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composición de la colección"
 
-#: /app/analytics/templates/website/home_collection.mako:24
-#: /app/analytics/templates/website/home_document.mako:21
-#: /app/analytics/templates/website/home_journal.mako:21
-#: /app/analytics/templates/website/home_network.mako:24
-#: /app/analytics/templates/website/navbar_collection.mako:9
-#: /app/analytics/templates/website/navbar_collection.mako:27
-#: /app/analytics/templates/website/navbar_document.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:26
+#: analytics/templates/website/home_collection.mako:24
+#: analytics/templates/website/home_document.mako:21
+#: analytics/templates/website/home_journal.mako:21
+#: analytics/templates/website/home_network.mako:24
+#: analytics/templates/website/navbar_collection.mako:9
+#: analytics/templates/website/navbar_collection.mako:27
+#: analytics/templates/website/navbar_document.mako:9
+#: analytics/templates/website/navbar_journal.mako:9
+#: analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficas"
 
-#: /app/analytics/templates/website/home_document.mako:7
+#: analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores de documento"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:6
+#: analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "cerrar"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:11
+#: analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "seleccionar una revista"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:20
+#: analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "seleccionar"
 
-#: /app/analytics/templates/website/navbar_collection.mako:11
-#: /app/analytics/templates/website/navbar_journal.mako:11
+#: analytics/templates/website/navbar_collection.mako:11
+#: analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 fascículos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:12
-#: /app/analytics/templates/website/navbar_journal.mako:12
+#: analytics/templates/website/navbar_collection.mako:12
+#: analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 artículos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:16
-#: /app/analytics/templates/website/navbar_journal.mako:16
+#: analytics/templates/website/navbar_collection.mako:16
+#: analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicación"
 
-#: /app/analytics/templates/website/navbar_collection.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:19
+#: analytics/templates/website/navbar_collection.mako:19
+#: analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficas de documentos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:20
-#: /app/analytics/templates/website/navbar_journal.mako:20
+#: analytics/templates/website/navbar_collection.mako:20
+#: analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficas de documentos por año de publicación"
 
-#: /app/analytics/templates/website/navbar_collection.mako:21
+#: analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficas de revistas"
 
-#: /app/analytics/templates/website/navbar_collection.mako:25
-#: /app/analytics/templates/website/navbar_document.mako:13
-#: /app/analytics/templates/website/navbar_journal.mako:24
+#: analytics/templates/website/navbar_collection.mako:25
+#: analytics/templates/website/navbar_document.mako:13
+#: analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometría"
 
-#: /app/analytics/templates/website/navbar_collection.mako:32
-#: /app/analytics/templates/website/navbar_journal.mako:34
+#: analytics/templates/website/navbar_collection.mako:32
+#: analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citas concedidas por las revistas"
 
-#: /app/analytics/templates/website/navbar_collection.mako:34
-#: /app/analytics/templates/website/navbar_journal.mako:36
+#: analytics/templates/website/navbar_collection.mako:34
+#: analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citación de la revista"
 
-#: /app/analytics/templates/website/navbar_collection.mako:35
-#: /app/analytics/templates/website/navbar_journal.mako:37
+#: analytics/templates/website/navbar_collection.mako:35
+#: analytics/templates/website/navbar_journal.mako:37
 msgid "Indicadores Gerais"
 msgstr "Indicadores Generales"
 
-#: /app/analytics/templates/website/navbar_collection.mako:39
-#: /app/analytics/templates/website/navbar_document.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:41
+#: analytics/templates/website/navbar_collection.mako:39
+#: analytics/templates/website/navbar_document.mako:19
+#: analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Informes"
 
-#: /app/analytics/templates/website/navbar_document.mako:15
+#: analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Citas Recibidas"
 
-#: /app/analytics/templates/website/publication_article.mako:17
+#: analytics/templates/website/publication_article.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso. "
 "Os números são relacionados a coleção ou ao periódico quando um periódico"
@@ -1450,12 +1450,12 @@ msgstr ""
 "de uso dependen de la adopción de la colección o periódico seleccionado "
 "de licencias de uso creative commons."
 
-#: /app/analytics/templates/website/publication_article.mako:24
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
+#: analytics/templates/website/publication_article.mako:24
+#: analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:36
+#: analytics/templates/website/publication_article.mako:36
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por área de "
 "atuação. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1477,7 +1477,7 @@ msgstr ""
 "hacer parte de una o más áreas de actuación. Esta gráfica es recomendada "
 "para la extracción de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_article.mako:55
+#: analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1490,12 +1490,12 @@ msgstr ""
 "utilizados por el SciELO Citation Index y documentados en el SciELO "
 "Publishing Schema."
 
-#: /app/analytics/templates/website/publication_article.mako:61
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
+#: analytics/templates/website/publication_article.mako:61
+#: analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:73
+#: analytics/templates/website/publication_article.mako:73
 msgid ""
 "Este gráfico apresenta o total de documentos por idioma de publicação. Os"
 " números são relacionados a coleção ou ao periódico quando um periódico é"
@@ -1509,11 +1509,11 @@ msgstr ""
 "gráfica no pueden ser considerados como totales de publicación de la "
 "colección, pues un documento puede ser publicado en uno o más idiomas."
 
-#: /app/analytics/templates/website/publication_article.mako:79
+#: analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:91
+#: analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
@@ -1523,12 +1523,12 @@ msgstr ""
 "publicación. Los número están relacionados a una colección, o al "
 "periódico cuando algún periódico es seleccionado."
 
-#: /app/analytics/templates/website/publication_article.mako:97
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
+#: analytics/templates/website/publication_article.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:109
+#: analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
@@ -1540,11 +1540,11 @@ msgstr ""
 " considerados como totales de la colección dado que un documento puede "
 "tener más de un país de afiliación."
 
-#: /app/analytics/templates/website/publication_article.mako:115
+#: analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:127
+#: analytics/templates/website/publication_article.mako:127
 msgid ""
 "Este mapa apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste mapa não podem ser "
@@ -1556,7 +1556,7 @@ msgstr ""
 "considerados como totales de la colección dado que un documento puede "
 "tener más de un país de afiliación."
 
-#: /app/analytics/templates/website/publication_article.mako:145
+#: analytics/templates/website/publication_article.mako:145
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1566,11 +1566,11 @@ msgstr ""
 " Los números están relacionados a la colección, o al periódico cuando un "
 "periódico esta seleccionado."
 
-#: /app/analytics/templates/website/publication_article.mako:151
+#: analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_article.mako:163
+#: analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
@@ -1580,7 +1580,7 @@ msgstr ""
 "referencias bibliográficas. Los número están relacionados a una "
 "colección, o al periódico cuando algún periódico es seleccionado. "
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
+#: analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
@@ -1594,7 +1594,7 @@ msgstr ""
 "indicadores de licencias de uso depende de la adopción de la colección o "
 "de la revista seleccionada por licencias creative commons."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
+#: analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por área de atuação e"
 " ano de publicação. Os números são relacionados a coleção ou ao periódico"
@@ -1612,7 +1612,7 @@ msgstr ""
 " más áreas de actuaciones. Esta gráfica es recomendada para la extracción"
 " de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
+#: analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por tipo de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1622,7 +1622,7 @@ msgstr ""
 " y año de publcación.  Los número están relacionados a una colección, o a"
 " una revista cuando alguna revista es seleccionada."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+#: analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por idioma de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1638,7 +1638,7 @@ msgstr ""
 "publicación de la colección, pues un documento puede ser publicado en uno"
 " o más idiomas."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+#: analytics/templates/website/publication_article_by_publication_year.mako:91
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por país de afiliação"
 " dos autores e ano de publicação. Os números são relacionados a coleção "
@@ -1654,27 +1654,27 @@ msgstr ""
 "como totales de publicación de la colección, pues un documento puede ser "
 "publicado por uno o más países de afiliación."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:5
+#: analytics/templates/website/publication_journal.mako:5
 msgid "Licenças de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:10
+#: analytics/templates/website/publication_journal.mako:10
 msgid "Áreas temáticas dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:15
+#: analytics/templates/website/publication_journal.mako:15
 msgid "Ano de inclusão de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:19
+#: analytics/templates/website/publication_journal.mako:19
 msgid "Situação de publicação dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+#: analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por licença de uso adotada."
 " Os valores totais de periódicos deste gráfico não podem ser considerados"
@@ -1688,7 +1688,7 @@ msgstr ""
 "parte de una o más área de actuación. Esta gráfica es recomendada para "
 "extracción de indicadores de Colección. "
 
-#: /app/analytics/templates/website/publication_journal_status.mako:17
+#: analytics/templates/website/publication_journal_status.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por status da publicação no"
 " SciELO. O status considerado neste grafíco é o status vigente do "
@@ -1702,7 +1702,7 @@ msgstr ""
 " existencia del periódico en las bases SciELO. Esta gráfica es "
 "recomendada para extracción de indicadores de Colección."
 
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
+#: analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
 "gráfico é recomendado para extração de indicadores de Coleção. As áreas "
@@ -1724,7 +1724,7 @@ msgstr ""
 "actuación. Esta gráfica es recomendada para extracción de indicadores de "
 "Colección."
 
-#: /app/analytics/templates/website/publication_journal_year.mako:17
+#: analytics/templates/website/publication_journal_year.mako:17
 msgid ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
@@ -1733,14 +1733,14 @@ msgstr ""
 "SciELO. Este gráfico es recomendado para extracción de indicadores de "
 "Colección."
 
-#: /app/analytics/templates/website/publication_size.mako:11
-#: /app/analytics/templates/website/publication_size.mako:22
-#: /app/analytics/templates/website/publication_size.mako:33
-#: /app/analytics/templates/website/publication_size.mako:44
+#: analytics/templates/website/publication_size.mako:11
+#: analytics/templates/website/publication_size.mako:22
+#: analytics/templates/website/publication_size.mako:33
+#: analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre los números"
 
-#: /app/analytics/templates/website/publication_size.mako:14
+#: analytics/templates/website/publication_size.mako:14
 msgid ""
 "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
@@ -1751,7 +1751,7 @@ msgstr ""
 "colección o a la revista cuando una revista es eligida en la parte "
 "superior del sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:25
+#: analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
@@ -1762,7 +1762,7 @@ msgstr ""
 "colección o a la revista cuando una revista es eligida en la parte "
 "superior el sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:36
+#: analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1772,7 +1772,7 @@ msgstr ""
 " número estan relacionados a la colección o a la revista cuando una "
 "revista es eligida en la parte superior del sitio."
 
-#: /app/analytics/templates/website/publication_size.mako:47
+#: analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
 "citadas nos documentos publicados. Os números são relacionados a coleção "
@@ -1784,27 +1784,27 @@ msgstr ""
 " o a la revista cuando una revista es eligida en la parte superior del "
 "sitio."
 
-#: /app/analytics/templates/website/publication_size_citations.mako:9
+#: analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referencias"
 
-#: /app/analytics/templates/website/publication_size_documents.mako:9
+#: analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: /app/analytics/templates/website/publication_size_issues.mako:9
+#: analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: /app/analytics/templates/website/publication_size_journals.mako:10
+#: analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "revistas"
 
-#: /app/analytics/templates/website/reports.mako:5
+#: analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tablas"
 
-#: /app/analytics/templates/website/reports.mako:7
+#: analytics/templates/website/reports.mako:7
 msgid ""
 "O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
 "metadados utilizados para produção dos indicadores presentes nesta "
@@ -1816,50 +1816,51 @@ msgstr ""
 "esa herramienta. Cualquier interesado puede bajar y produzir analisis "
 "bibliometricas de acuerdo con sus necesidades."
 
-#: /app/analytics/templates/website/reports.mako:10
+#: analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mas informaciones sobre las características de cada tabla, acceder"
 
-#: /app/analytics/templates/website/reports.mako:16
+#: analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nombre del archivo"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidad de actualización"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensual"
 
-#: /app/analytics/templates/website/reports.mako:18
+#: analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamaño del archivo"
 
-#: /app/analytics/templates/website/reports.mako:19
+#: analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: /app/analytics/templates/website/reports.mako:20
+#: analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última actualización"
 
-#: /app/analytics/templates/website/reports.mako:23
+#: analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "archivo no disponible para la colección"
 
-#: /app/analytics/templates/website/share.mako:8
+#: analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartir por email"
 
-#: /app/analytics/templates/website/share.mako:10
+#: analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartir en Facebook"
 
-#: /app/analytics/templates/website/share.mako:13
+#: analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartir en Twitter"
 
-#: /app/analytics/templates/website/share.mako:16
+#: analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartir en LinkedIn"
+

--- a/analytics/locale/pt/LC_MESSAGES/analytics.po
+++ b/analytics/locale/pt/LC_MESSAGES/analytics.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-09-17 18:21+0000\n"
+"POT-Creation-Date: 2019-09-18 12:50+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
 "Language: pt\n"
@@ -19,421 +19,421 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.1\n"
 
-#: /app/analytics/charts_config.py:25
+#: analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fonte: SciELO.org"
 
-#: /app/analytics/charts_config.py:58
+#: analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr "Ano de acesso aos documentos"
 
-#: /app/analytics/charts_config.py:59
+#: analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr "Ano de publicação de documentos"
 
-#: /app/analytics/charts_config.py:91
+#: analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Ano de publicação de documentos do periódico. (citados)"
 
-#: /app/analytics/charts_config.py:92
+#: analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 
-#: /app/analytics/charts_config.py:100
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+#: analytics/charts_config.py:100
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:28
 msgid "Fator de impacto (Média de percentil)"
 msgstr ""
 
-#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+#: analytics/charts_config.py:103 analytics/charts_config.py:112
 msgid "Média de percentil"
 msgstr ""
 
-#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
-#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
-#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
+#: analytics/charts_config.py:113 analytics/charts_config.py:135
+#: analytics/charts_config.py:157 analytics/charts_config.py:179
+#: analytics/charts_config.py:202 analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Ano base"
 
-#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
-#: /app/analytics/charts_config.py:134
+#: analytics/charts_config.py:122 analytics/charts_config.py:125
+#: analytics/charts_config.py:134
 msgid "Eigen Factor JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
-#: /app/analytics/charts_config.py:156
+#: analytics/charts_config.py:144 analytics/charts_config.py:147
+#: analytics/charts_config.py:156
 msgid "Received Citations JCR"
 msgstr ""
 
-#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
-#: /app/analytics/charts_config.py:178
+#: analytics/charts_config.py:166 analytics/charts_config.py:169
+#: analytics/charts_config.py:178
 msgid "Fator de impacto JCR"
 msgstr "Fator de impacto JCR"
 
-#: /app/analytics/charts_config.py:188
+#: analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fonte: Google Scholar"
 
-#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
-#: /app/analytics/charts_config.py:201
+#: analytics/charts_config.py:189 analytics/charts_config.py:192
+#: analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: /app/analytics/charts_config.py:211
+#: analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "imediatez"
 
-#: /app/analytics/charts_config.py:212
-#: /app/analytics/templates/website/access_datepicker.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: analytics/charts_config.py:212
+#: analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "1 ano"
 
-#: /app/analytics/charts_config.py:213
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/charts_config.py:213
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 anos"
 
-#: /app/analytics/charts_config.py:214
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/charts_config.py:214
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 anos"
 
-#: /app/analytics/charts_config.py:215
+#: analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 anos"
 
-#: /app/analytics/charts_config.py:216
+#: analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 anos"
 
-#: /app/analytics/charts_config.py:223
+#: analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 
-#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
-#: /app/analytics/templates/website/bibliometrics_journal.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: analytics/charts_config.py:226 analytics/charts_config.py:228
+#: analytics/templates/website/bibliometrics_journal.mako:23
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citação"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citações concedidas"
 
-#: /app/analytics/charts_config.py:237
+#: analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citações recebidas"
 
-#: /app/analytics/charts_config.py:244
+#: analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribuição de citações concedidas, recebidas e auto citações"
 
-#: /app/analytics/charts_config.py:251
+#: analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citações"
 
-#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
-#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
-#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
-#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
-#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
-#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
-#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: analytics/charts_config.py:256 analytics/charts_config.py:273
+#: analytics/charts_config.py:287 analytics/charts_config.py:414
+#: analytics/charts_config.py:423 analytics/charts_config.py:438
+#: analytics/charts_config.py:446 analytics/charts_config.py:494
+#: analytics/charts_config.py:503 analytics/charts_config.py:562
+#: analytics/charts_config.py:572 analytics/charts_config.py:614
+#: analytics/charts_config.py:623 analytics/charts_config.py:664
+#: analytics/charts_config.py:672 analytics/charts_config.py:788
+#: analytics/templates/website/central_container_for_article_filters.mako:13
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Ano de publicação"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citáveis"
 
-#: /app/analytics/charts_config.py:265
+#: analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos não citáveis"
 
-#: /app/analytics/charts_config.py:272
+#: analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribuição de documentos citáveis e não citáveis"
 
-#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
-#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
-#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
-#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
-#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
-#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
-#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
-#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
+#: analytics/charts_config.py:281 analytics/charts_config.py:305
+#: analytics/charts_config.py:324 analytics/charts_config.py:341
+#: analytics/charts_config.py:388 analytics/charts_config.py:412
+#: analytics/charts_config.py:441 analytics/charts_config.py:467
+#: analytics/charts_config.py:492 analytics/charts_config.py:540
+#: analytics/charts_config.py:560 analytics/charts_config.py:568
+#: analytics/charts_config.py:591 analytics/charts_config.py:612
+#: analytics/charts_config.py:662 analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: /app/analytics/charts_config.py:298
+#: analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribuição de número de referências bibliográficas dos documentos"
 
-#: /app/analytics/charts_config.py:301
+#: analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referências bibliográficas"
 
-#: /app/analytics/charts_config.py:308
+#: analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documentos com %s referências bibliográficas"
 
-#: /app/analytics/charts_config.py:317
+#: analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribuição de número de autores dos documentos"
 
-#: /app/analytics/charts_config.py:320
-#: /app/analytics/templates/website/publication_article.mako:133
+#: analytics/charts_config.py:320
+#: analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: /app/analytics/charts_config.py:327
+#: analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documentos com %s autores"
 
-#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
+#: analytics/charts_config.py:338 analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr "Distribuição de países de afiliação dos autores"
 
-#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
-#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
-#: /app/analytics/charts_config.py:694
+#: analytics/charts_config.py:359 analytics/charts_config.py:391
+#: analytics/charts_config.py:446 analytics/charts_config.py:470
+#: analytics/charts_config.py:543 analytics/charts_config.py:594
+#: analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
-#: /app/analytics/charts_config.py:391
+#: analytics/charts_config.py:368 analytics/charts_config.py:383
+#: analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliação"
 
-#: /app/analytics/charts_config.py:404
+#: analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr "Distribuição de países de afiliação dos autores por ano de publicação"
 
-#: /app/analytics/charts_config.py:437
+#: analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribuição de ano de publicação dos documentos"
 
-#: /app/analytics/charts_config.py:459
+#: analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribuição de idiomas dos documentos"
 
-#: /app/analytics/charts_config.py:462
+#: analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicação"
 
-#: /app/analytics/charts_config.py:470
+#: analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma do documento"
 
-#: /app/analytics/charts_config.py:484
+#: analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribuição de idiomas dos documentos por ano de publicação"
 
-#: /app/analytics/charts_config.py:514
+#: analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribuição de periódicos por ano de inclusão no SciELO"
 
-#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
+#: analytics/charts_config.py:515 analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Ano de inclusão"
 
-#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
-#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+#: analytics/charts_config.py:518 analytics/charts_config.py:642
+#: analytics/charts_config.py:711 analytics/charts_config.py:731
 msgid "Número de periódicos"
 msgstr "Número de periódicos"
 
-#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
-#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
-#: /app/analytics/templates/website/navbar_collection.mako:10
-#: /app/analytics/templates/website/navbar_journal.mako:10
+#: analytics/charts_config.py:523 analytics/charts_config.py:645
+#: analytics/charts_config.py:714 analytics/charts_config.py:734
+#: analytics/templates/website/navbar_collection.mako:10
+#: analytics/templates/website/navbar_journal.mako:10
 msgid "Periódicos"
 msgstr "Periódicos"
 
-#: /app/analytics/charts_config.py:532
+#: analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribuição de área temática dos documentos"
 
-#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
+#: analytics/charts_config.py:535 analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Areas temáticas"
 
-#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
+#: analytics/charts_config.py:543 analytics/charts_config.py:714
+#: analytics/templates/website/central_container_for_article_filters.mako:30
+#: analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: /app/analytics/charts_config.py:552
+#: analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribuição de área temática dos documentos por ano de publicação"
 
-#: /app/analytics/charts_config.py:583
+#: analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribuição por tipo de documento"
 
-#: /app/analytics/charts_config.py:586
-#: /app/analytics/templates/website/publication_article.mako:43
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
+#: analytics/charts_config.py:586
+#: analytics/templates/website/publication_article.mako:43
+#: analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: /app/analytics/charts_config.py:594
+#: analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: /app/analytics/charts_config.py:604
+#: analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribuição de tipos de documentos por ano de publicação"
 
-#: /app/analytics/charts_config.py:634
+#: analytics/charts_config.py:634
 msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
 msgstr "Distribuição de periódicos por situação atual de publicação no SciELO"
 
-#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+#: analytics/charts_config.py:637 analytics/charts_config.py:645
 msgid "Situação da publicação"
 msgstr "Situação da publicação"
 
-#: /app/analytics/charts_config.py:654
+#: analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribuição de licenças de uso por ano de publicação"
 
-#: /app/analytics/charts_config.py:683
+#: analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribuição de licença de uso dos documentos"
 
-#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
-#: /app/analytics/templates/website/publication_article.mako:5
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
+#: analytics/charts_config.py:686 analytics/charts_config.py:726
+#: analytics/templates/website/publication_article.mako:5
+#: analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licenças de uso"
 
-#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
+#: analytics/charts_config.py:694 analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licença"
 
-#: /app/analytics/charts_config.py:703
+#: analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribuição de área temática dos periódicos"
 
-#: /app/analytics/charts_config.py:723
+#: analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribuição de licença de uso dos periódicos"
 
-#: /app/analytics/charts_config.py:742
+#: analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de acessos por ano e mês"
 
-#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
-#: /app/analytics/templates/website/navbar_collection.mako:7
-#: /app/analytics/templates/website/navbar_document.mako:7
-#: /app/analytics/templates/website/navbar_journal.mako:7
+#: analytics/charts_config.py:750 analytics/charts_config.py:785
+#: analytics/templates/website/navbar_collection.mako:7
+#: analytics/templates/website/navbar_document.mako:7
+#: analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Acessos"
 
-#: /app/analytics/charts_config.py:756
+#: analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Acessos em"
 
-#: /app/analytics/charts_config.py:767
+#: analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accessos por tipo de documento"
 
-#: /app/analytics/charts_config.py:771
+#: analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s acessos a documentos do tipo %s"
 
-#: /app/analytics/charts_config.py:783
+#: analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de artigos por número de acessos em"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Ano de referência"
 
-#: /app/analytics/charts_config.py:792
+#: analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s acessos aos documentos do ano %s"
 
-#: /app/analytics/templates/website/access_by_document_type.mako:6
-#: /app/analytics/templates/website/access_by_month_and_year.mako:5
-#: /app/analytics/templates/website/access_lifetime.mako:6
-#: /app/analytics/templates/website/accesses_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
-#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_authors.mako:5
-#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
-#: /app/analytics/templates/website/publication_article_document_type.mako:5
-#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_languages.mako:5
-#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_licenses.mako:5
-#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: /app/analytics/templates/website/publication_article_references.mako:5
-#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
-#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: /app/analytics/templates/website/publication_article_year.mako:5
-#: /app/analytics/templates/website/publication_journal_licenses.mako:7
-#: /app/analytics/templates/website/publication_journal_status.mako:7
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
-#: /app/analytics/templates/website/publication_journal_year.mako:7
-#: /app/analytics/templates/website/publication_size_citations.mako:6
-#: /app/analytics/templates/website/publication_size_documents.mako:6
-#: /app/analytics/templates/website/publication_size_issues.mako:6
-#: /app/analytics/templates/website/publication_size_journals.mako:6
+#: analytics/templates/website/access_by_document_type.mako:6
+#: analytics/templates/website/access_by_month_and_year.mako:5
+#: analytics/templates/website/access_lifetime.mako:6
+#: analytics/templates/website/accesses_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: analytics/templates/website/publication_article_affiliations.mako:5
+#: analytics/templates/website/publication_article_affiliations_map.mako:5
+#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: analytics/templates/website/publication_article_authors.mako:5
+#: analytics/templates/website/publication_article_citable_documents.mako:5
+#: analytics/templates/website/publication_article_document_type.mako:5
+#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: analytics/templates/website/publication_article_languages.mako:5
+#: analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: analytics/templates/website/publication_article_licenses.mako:5
+#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: analytics/templates/website/publication_article_references.mako:5
+#: analytics/templates/website/publication_article_subject_areas.mako:6
+#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: analytics/templates/website/publication_article_year.mako:5
+#: analytics/templates/website/publication_journal_licenses.mako:7
+#: analytics/templates/website/publication_journal_status.mako:7
+#: analytics/templates/website/publication_journal_subject_areas.mako:7
+#: analytics/templates/website/publication_journal_year.mako:7
+#: analytics/templates/website/publication_size_citations.mako:6
+#: analytics/templates/website/publication_size_documents.mako:6
+#: analytics/templates/website/publication_size_issues.mako:6
+#: analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "loading"
 
-#: /app/analytics/templates/website/access_datepicker.mako:5
+#: analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Período"
 
-#: /app/analytics/templates/website/access_datepicker.mako:9
+#: analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "acessos nos últimos 36 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:10
+#: analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "acessos nos últimos 24 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:11
+#: analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "acessos nos últimos 12 meses"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos acessos disponíveis"
 
-#: /app/analytics/templates/website/access_datepicker.mako:12
+#: analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "tudo"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Seletor de período de acessos"
 
-#: /app/analytics/templates/website/access_datepicker.mako:14
+#: analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
 "recuperação dos dados de acesso. Você pode também selecionar o período de"
@@ -445,96 +445,96 @@ msgstr ""
 " 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
 " selecionando tudo."
 
-#: /app/analytics/templates/website/access_list_articles.mako:6
+#: analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 artigos por número de acessos"
 
-#: /app/analytics/templates/website/access_list_articles.mako:9
+#: analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artigo"
 
-#: /app/analytics/templates/website/access_list_articles.mako:13
-#: /app/analytics/templates/website/access_list_issues.mako:13
-#: /app/analytics/templates/website/access_list_journals.mako:13
+#: analytics/templates/website/access_list_articles.mako:13
+#: analytics/templates/website/access_list_issues.mako:13
+#: analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumo"
 
-#: /app/analytics/templates/website/access_list_articles.mako:14
-#: /app/analytics/templates/website/access_list_issues.mako:14
-#: /app/analytics/templates/website/access_list_journals.mako:14
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
+#: analytics/templates/website/access_list_articles.mako:14
+#: analytics/templates/website/access_list_issues.mako:14
+#: analytics/templates/website/access_list_journals.mako:14
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: analytics/templates/website/bibliometrics_list_granted.mako:19
+#: analytics/templates/website/bibliometrics_list_granted.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: analytics/templates/website/bibliometrics_list_received.mako:26
+#: analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: /app/analytics/templates/website/access_list_issues.mako:6
+#: analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 fascículos por número de acessos"
 
-#: /app/analytics/templates/website/access_list_issues.mako:9
-#: /app/analytics/templates/website/access_list_journals.mako:9
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: analytics/templates/website/access_list_issues.mako:9
+#: analytics/templates/website/access_list_journals.mako:9
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "periódico"
 
-#: /app/analytics/templates/website/access_list_journals.mako:6
+#: analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Acessos aos documentos por periódicos"
 
-#: /app/analytics/templates/website/accesses.mako:6
+#: analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr "Gráfico da evolução de acessos aos documentos"
 
-#: /app/analytics/templates/website/accesses.mako:12
+#: analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr "Gráfico de calor de acessos"
 
-#: /app/analytics/templates/website/accesses.mako:18
+#: analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr "Gráfico de tempo de vida de documentos através do número de acessos"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:15
+#: analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr "Acessos aos documentos"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr "Documentos publicados em"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr "tiveram"
 
-#: /app/analytics/templates/website/accesses_heat_chart.mako:19
+#: analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr "acessos em"
 
-#: /app/analytics/templates/website/base.mako:6
+#: analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estatísticas"
 
-#: /app/analytics/templates/website/base.mako:30
+#: analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Coleções"
 
-#: /app/analytics/templates/website/base.mako:38
-#: /app/analytics/templates/website/journal_selector_modal.mako:7
+#: analytics/templates/website/base.mako:38
+#: analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "selecionar periódico"
 
-#: /app/analytics/templates/website/base.mako:91
+#: analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Ferramenta em desenvolvimento disponível em versão Beta Test."
 
-#: /app/analytics/templates/website/base.mako:93
+#: analytics/templates/website/base.mako:93
 msgid ""
 "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
 " realizar testes de uso e performance. Todos os indicadores carregados "
@@ -546,214 +546,214 @@ msgstr ""
 "são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
 " de lentidão e indisponibilidade do serviços são esperados nesta fase."
 
-#: /app/analytics/templates/website/base.mako:114
+#: analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ajuda"
 
-#: /app/analytics/templates/website/base.mako:116
+#: analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: /app/analytics/templates/website/base.mako:117
+#: analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discussão"
 
-#: /app/analytics/templates/website/base.mako:121
+#: analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desenvolvimento"
 
-#: /app/analytics/templates/website/base.mako:124
+#: analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desenvolvimento"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Janeiro"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Fevereiro"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Março"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Maio"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junho"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julho"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Setembro"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Outubro"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Novembro"
 
-#: /app/analytics/templates/website/base.mako:168
+#: analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Dezembro"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Jan"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Fev"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "Mai"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Set"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Out"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: /app/analytics/templates/website/base.mako:169
+#: analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dez"
 
-#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citações Recebidas"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "ano de publicação"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primeiro autor"
 
-#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título do documento"
 
-#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citações recebidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
+#: analytics/templates/website/bibliometrics_journal.mako:8
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: analytics/templates/website/bibliometrics_list_granted.mako:8
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atenção"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
+#: analytics/templates/website/bibliometrics_journal.mako:11
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: analytics/templates/website/bibliometrics_list_granted.mako:11
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "É necessário selecionar um periódico para dados bibliométricos."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:20
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
+#: analytics/templates/website/bibliometrics_journal.mako:20
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: analytics/templates/website/bibliometrics_list_received.mako:19
+#: analytics/templates/website/central_container_for_article_filters.mako:16
+#: analytics/templates/website/central_container_for_article_filters.mako:33
+#: analytics/templates/website/central_container_for_article_filters.mako:52
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:32
-#: /app/analytics/templates/website/bibliometrics_journal.mako:51
-#: /app/analytics/templates/website/bibliometrics_journal.mako:69
-#: /app/analytics/templates/website/bibliometrics_journal.mako:87
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: /app/analytics/templates/website/publication_article.mako:14
-#: /app/analytics/templates/website/publication_article.mako:33
-#: /app/analytics/templates/website/publication_article.mako:52
-#: /app/analytics/templates/website/publication_article.mako:70
-#: /app/analytics/templates/website/publication_article.mako:88
-#: /app/analytics/templates/website/publication_article.mako:106
-#: /app/analytics/templates/website/publication_article.mako:124
-#: /app/analytics/templates/website/publication_article.mako:142
-#: /app/analytics/templates/website/publication_article.mako:160
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
-#: /app/analytics/templates/website/publication_journal_licenses.mako:14
-#: /app/analytics/templates/website/publication_journal_status.mako:14
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
-#: /app/analytics/templates/website/publication_journal_year.mako:14
+#: analytics/templates/website/bibliometrics_journal.mako:32
+#: analytics/templates/website/bibliometrics_journal.mako:51
+#: analytics/templates/website/bibliometrics_journal.mako:69
+#: analytics/templates/website/bibliometrics_journal.mako:87
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: analytics/templates/website/publication_article.mako:14
+#: analytics/templates/website/publication_article.mako:33
+#: analytics/templates/website/publication_article.mako:52
+#: analytics/templates/website/publication_article.mako:70
+#: analytics/templates/website/publication_article.mako:88
+#: analytics/templates/website/publication_article.mako:106
+#: analytics/templates/website/publication_article.mako:124
+#: analytics/templates/website/publication_article.mako:142
+#: analytics/templates/website/publication_article.mako:160
+#: analytics/templates/website/publication_article_by_publication_year.mako:14
+#: analytics/templates/website/publication_article_by_publication_year.mako:33
+#: analytics/templates/website/publication_article_by_publication_year.mako:52
+#: analytics/templates/website/publication_article_by_publication_year.mako:70
+#: analytics/templates/website/publication_article_by_publication_year.mako:88
+#: analytics/templates/website/publication_article_by_publication_year.mako:106
+#: analytics/templates/website/publication_journal_licenses.mako:14
+#: analytics/templates/website/publication_journal_status.mako:14
+#: analytics/templates/website/publication_journal_subject_areas.mako:14
+#: analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre o gráfico"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:35
+#: analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
@@ -765,12 +765,12 @@ msgstr ""
 "linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
 "Reuters"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:42
+#: analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr "Documentos citáveis e não citáveis"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:54
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
+#: analytics/templates/website/bibliometrics_journal.mako:54
+#: analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
 "Este gráfico apresenta a distribuição de documentos citáveis e não "
 "citáveis relacionados ao periódico selecionado. De acordo com as regras "
@@ -786,11 +786,11 @@ msgstr ""
 " Communication\" e \"Article Commentary\". Os demais tipos de documentos "
 "são considerados não citáveis."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:60
+#: analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:72
+#: analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
 "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
 "indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
@@ -804,11 +804,11 @@ msgstr ""
 "ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
 "Ao clicar na série, você será direcionado para o site do Google Scholar."
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:78
+#: analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr "Citações concedidas, recebidas e auto citação"
 
-#: /app/analytics/templates/website/bibliometrics_journal.mako:90
+#: analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
@@ -818,106 +818,106 @@ msgstr ""
 "citações do periódico selecionado, os dados estão distribuidos por ano de"
 " publicação."
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:27
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr "Indicadores Altmetric"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr "Não há indicadores Altmetric para este periódico"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr "Não há indicadores Altmetric para este periódico neste timeframe"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr "Posts"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr "Soma de pontuação"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr "Mediana de pontuação"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr "Soma de pontuação no timeframe"
 
-#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr "Mediana de pontuação no timeframe"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:28
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr "Indicadores JCR"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:16
 msgid "Dados extraídos em: "
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr "Não há indicadores JCR para este periódico"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr "Fator de impacto"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:32
 msgid "Eigen Factor"
 msgstr ""
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr "Dados de todos os anos"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr "Total de citações"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr "FI 2 anos"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr "FI 2 anos sem auto citações"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr "FI 5 anos"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr "Indice de imediatez"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr "Vida média de citações"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr "Eigen Factor normalizado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr "Percentíl de média de fator de FI de periódico"
 
-#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
+#: analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr "Porcentagem de artigos em itens citáveis"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: /app/analytics/templates/website/navbar_journal.mako:29
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfico de calor de citações recebidas"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
@@ -927,232 +927,232 @@ msgstr ""
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Lista de citações para o eixo selecionado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Selecione um eixo x/y para obter a lista de citações para o período."
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citações recebidas pelo periódico"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos da Rede SciELO publicados em"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citaram"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "vezes os documentos do periódico"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados em"
 
-#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique no ponto para ver a lista de artigos."
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citação encontrada para o periódico selecionado"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: analytics/templates/website/bibliometrics_list_granted.mako:18
+#: analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "ações"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar erro"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
+#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: analytics/templates/website/bibliometrics_list_granted.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sem resultados"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:30
-#: /app/analytics/templates/website/navbar_journal.mako:32
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: analytics/templates/website/navbar_collection.mako:30
+#: analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media da citação"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citações em"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicações de"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Citação total"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citações"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "percentagem"
 
-#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "percentagem acumulado"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:5
 msgid "Indicadores Bibliométricos da Rede SciELO"
 msgstr "Indicadores Bibliométricos da Rede SciELO"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid "Periodicidade de atualização:"
 msgstr "Periodicidade de atualização:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:6
 msgid " anual"
 msgstr " anual"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:13
 msgid "Indicadores de Publicação"
 msgstr "Indicadores de Publicação"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:19
 msgid "Numeros da Rede SciELO por:"
 msgstr "Numeros da Rede SciELO por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:54
 msgid "Ano de publicação: "
 msgstr "Ano de publicação: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:35
 msgid "Periódico: "
 msgstr "Periódico: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:55
 msgid "Assunto: "
 msgstr "Assunto: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:24
 msgid "País de afiliação do autor: "
 msgstr "País de afiliação do autor: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:26
 msgid "País de Afiliação do Autor por: "
 msgstr "País de Afiliação do Autor por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:30
 msgid "País de publicação da revista: "
 msgstr "País de publicação da revista: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:33
 msgid "Número de Co-autores por: "
 msgstr "Número de Co-autores por: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:46
 msgid "Indicadores de Coleção"
 msgstr "Indicadores de Coleção"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:52
 msgid "Periódico por:"
 msgstr "Periódico por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:56
 msgid "Indicadores gerais: "
 msgstr "Indicadores gerais: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:66
 msgid "Indicadores de Citação"
 msgstr "Indicadores de Citação"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:72
 msgid "Ano de Citação por:"
 msgstr "Ano de Citação por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:90
 msgid "Idade do documento citado: "
 msgstr "Idade do documento citado: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:91
 msgid "Tipo de documento citado: "
 msgstr "Tipo de documento citado: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:77
 msgid "Periódico Citante por:"
 msgstr "Periódico Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:82
 msgid "Assunto do Periódico Citante por:"
 msgstr "Assunto do Periódico Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:92
 msgid "Periódico SciELO citado: "
 msgstr "Periódico SciELO citado: "
 
-#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+#: analytics/templates/website/bibliometrics_list_general_indicators.mako:88
 msgid "País de Afiliação do Autor Citante por:"
 msgstr "País de Afiliação do Autor Citante por:"
 
-#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
+#: analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citações concedidas por periódico"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:29
-#: /app/analytics/templates/website/navbar_journal.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: analytics/templates/website/navbar_collection.mako:29
+#: analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados em"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
 "Aqui são considerados apenas os documentos citáveis. De acordo com as "
 "regras de contagem do SciELO, documentos citáveis devem ser do tipo "
@@ -1166,55 +1166,55 @@ msgstr ""
 "Communication e Article Commentary. Os demais tipos de documentos são "
 "considerados não citáveis."
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 ano"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 ano"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 ano"
 
-#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 ano"
 
-#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
-#: /app/analytics/templates/website/navbar_collection.mako:33
-#: /app/analytics/templates/website/navbar_journal.mako:35
+#: analytics/templates/website/bibliometrics_list_received.mako:22
+#: analytics/templates/website/navbar_collection.mako:33
+#: analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citações recebidas por periódicos"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: analytics/templates/website/central_container_for_article_filters.mako:8
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtros para documentos"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
-#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: analytics/templates/website/central_container_for_article_filters.mako:22
+#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
+#: analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
+#: analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtros para periódicos"
 
-#: /app/analytics/templates/website/faq.mako:5
+#: analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Perguntas Frequentes (Acessos)"
 
-#: /app/analytics/templates/website/faq.mako:7
+#: analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "Por que algumas coleções não possuem estatísticas de acesso?"
 
-#: /app/analytics/templates/website/faq.mako:8
+#: analytics/templates/website/faq.mako:8
 msgid ""
 "Para que os dados de acessos sejam computados é necessário que os logs de"
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
@@ -1224,11 +1224,11 @@ msgstr ""
 " acessos sejam enviados para processamento. A ausência de estatísticas de"
 " acessos deve ser verificada com a coordenação de cada coleção SciELO."
 
-#: /app/analytics/templates/website/faq.mako:11
+#: analytics/templates/website/faq.mako:11
 msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr "Por que algumas coleções possuem acessos computados para um período maior?"
 
-#: /app/analytics/templates/website/faq.mako:12
+#: analytics/templates/website/faq.mako:12
 msgid ""
 "O período disponível de cada uma das coleções depende do período "
 "disponível dos logs de acessos de cada uma das coleções. Este projeto se "
@@ -1240,12 +1240,12 @@ msgstr ""
 "compromete a computar os dados de acessos à partir de 2012, desde que os "
 "logs sejam devidamente fornecidos pelas coleções."
 
-#: /app/analytics/templates/website/faq.mako:15
-#: /app/analytics/templates/website/faq.mako:36
+#: analytics/templates/website/faq.mako:15
+#: analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "O que esta sendo contabilizado?"
 
-#: /app/analytics/templates/website/faq.mako:16
+#: analytics/templates/website/faq.mako:16
 msgid ""
 "Estão sendo contabilizados e classificados os acessos ao texto completo "
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
@@ -1255,7 +1255,7 @@ msgstr ""
 "em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
 "artigo."
 
-#: /app/analytics/templates/website/faq.mako:19
+#: analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
@@ -1263,7 +1263,7 @@ msgstr ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
 
-#: /app/analytics/templates/website/faq.mako:21
+#: analytics/templates/website/faq.mako:21
 msgid ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
@@ -1271,7 +1271,7 @@ msgstr ""
 "Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
 "antigos de estatísticas de acessos."
 
-#: /app/analytics/templates/website/faq.mako:22
+#: analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
@@ -1279,7 +1279,7 @@ msgstr ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
 
-#: /app/analytics/templates/website/faq.mako:23
+#: analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
@@ -1287,24 +1287,24 @@ msgstr ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
 
-#: /app/analytics/templates/website/faq.mako:27
-#: /app/analytics/templates/website/faq.mako:40
+#: analytics/templates/website/faq.mako:27
+#: analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "Qual a periodicidade de atualização dos indicadores?"
 
-#: /app/analytics/templates/website/faq.mako:28
+#: analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensal"
 
-#: /app/analytics/templates/website/faq.mako:30
+#: analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Perguntas Frequentes (Publicação)"
 
-#: /app/analytics/templates/website/faq.mako:32
+#: analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "Porque algumas coleções possuem dados desatualizados?"
 
-#: /app/analytics/templates/website/faq.mako:33
+#: analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
@@ -1316,7 +1316,7 @@ msgstr ""
 "diretamente ligada a condução adequada desses processos por cada uma das "
 "coleções."
 
-#: /app/analytics/templates/website/faq.mako:37
+#: analytics/templates/website/faq.mako:37
 msgid ""
 "Estão sendo contabilizados indicadores de publicação das coleções com "
 "base nos metadados fornecidos durante todo o processo de publicação de um"
@@ -1328,108 +1328,108 @@ msgstr ""
 " documento no SciELO. A qualidade desses indicadores esta diretamente "
 "ligada a qualidade dos processos implementados por cada uma das coleções."
 
-#: /app/analytics/templates/website/faq.mako:41
+#: analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: /app/analytics/templates/website/home_collection.mako:7
-#: /app/analytics/templates/website/home_journal.mako:7
-#: /app/analytics/templates/website/home_network.mako:7
-#: /app/analytics/templates/website/navbar_collection.mako:18
-#: /app/analytics/templates/website/navbar_journal.mako:18
-#: /app/analytics/templates/website/publication_size.mako:5
+#: analytics/templates/website/home_collection.mako:7
+#: analytics/templates/website/home_journal.mako:7
+#: analytics/templates/website/home_network.mako:7
+#: analytics/templates/website/navbar_collection.mako:18
+#: analytics/templates/website/navbar_journal.mako:18
+#: analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composição da coleção"
 
-#: /app/analytics/templates/website/home_collection.mako:24
-#: /app/analytics/templates/website/home_document.mako:21
-#: /app/analytics/templates/website/home_journal.mako:21
-#: /app/analytics/templates/website/home_network.mako:24
-#: /app/analytics/templates/website/navbar_collection.mako:9
-#: /app/analytics/templates/website/navbar_collection.mako:27
-#: /app/analytics/templates/website/navbar_document.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:9
-#: /app/analytics/templates/website/navbar_journal.mako:26
+#: analytics/templates/website/home_collection.mako:24
+#: analytics/templates/website/home_document.mako:21
+#: analytics/templates/website/home_journal.mako:21
+#: analytics/templates/website/home_network.mako:24
+#: analytics/templates/website/navbar_collection.mako:9
+#: analytics/templates/website/navbar_collection.mako:27
+#: analytics/templates/website/navbar_document.mako:9
+#: analytics/templates/website/navbar_journal.mako:9
+#: analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficos"
 
-#: /app/analytics/templates/website/home_document.mako:7
+#: analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores do documento"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:6
+#: analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "fechar"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:11
+#: analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "selecionar um periódico"
 
-#: /app/analytics/templates/website/journal_selector_modal.mako:20
+#: analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "selecionar"
 
-#: /app/analytics/templates/website/navbar_collection.mako:11
-#: /app/analytics/templates/website/navbar_journal.mako:11
+#: analytics/templates/website/navbar_collection.mako:11
+#: analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 Issues"
 
-#: /app/analytics/templates/website/navbar_collection.mako:12
-#: /app/analytics/templates/website/navbar_journal.mako:12
+#: analytics/templates/website/navbar_collection.mako:12
+#: analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 Artigos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:16
-#: /app/analytics/templates/website/navbar_journal.mako:16
+#: analytics/templates/website/navbar_collection.mako:16
+#: analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicação"
 
-#: /app/analytics/templates/website/navbar_collection.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:19
+#: analytics/templates/website/navbar_collection.mako:19
+#: analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficos de documentos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:20
-#: /app/analytics/templates/website/navbar_journal.mako:20
+#: analytics/templates/website/navbar_collection.mako:20
+#: analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficos de documentos por ano de publicação"
 
-#: /app/analytics/templates/website/navbar_collection.mako:21
+#: analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficos de periódicos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:25
-#: /app/analytics/templates/website/navbar_document.mako:13
-#: /app/analytics/templates/website/navbar_journal.mako:24
+#: analytics/templates/website/navbar_collection.mako:25
+#: analytics/templates/website/navbar_document.mako:13
+#: analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometria"
 
-#: /app/analytics/templates/website/navbar_collection.mako:32
-#: /app/analytics/templates/website/navbar_journal.mako:34
+#: analytics/templates/website/navbar_collection.mako:32
+#: analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citações concedidas por periódicos"
 
-#: /app/analytics/templates/website/navbar_collection.mako:34
-#: /app/analytics/templates/website/navbar_journal.mako:36
+#: analytics/templates/website/navbar_collection.mako:34
+#: analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citação do periódico"
 
-#: /app/analytics/templates/website/navbar_collection.mako:35
-#: /app/analytics/templates/website/navbar_journal.mako:37
+#: analytics/templates/website/navbar_collection.mako:35
+#: analytics/templates/website/navbar_journal.mako:37
 msgid "Indicadores Gerais"
 msgstr "Indicadores Gerais"
 
-#: /app/analytics/templates/website/navbar_collection.mako:39
-#: /app/analytics/templates/website/navbar_document.mako:19
-#: /app/analytics/templates/website/navbar_journal.mako:41
+#: analytics/templates/website/navbar_collection.mako:39
+#: analytics/templates/website/navbar_document.mako:19
+#: analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Relatórios"
 
-#: /app/analytics/templates/website/navbar_document.mako:15
+#: analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Received citations"
 
-#: /app/analytics/templates/website/publication_article.mako:17
+#: analytics/templates/website/publication_article.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso. "
 "Os números são relacionados a coleção ou ao periódico quando um periódico"
@@ -1443,12 +1443,12 @@ msgstr ""
 "dependem da adoção da coleção ou periódico selecionado de licenças de uso"
 " creative commons."
 
-#: /app/analytics/templates/website/publication_article.mako:24
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
+#: analytics/templates/website/publication_article.mako:24
+#: analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr "Áreas temáticas"
 
-#: /app/analytics/templates/website/publication_article.mako:36
+#: analytics/templates/website/publication_article.mako:36
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por área de "
 "atuação. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1470,7 +1470,7 @@ msgstr ""
 " parte de mais de uma área de atuação. Este gráfico é recomendado para "
 "extração de indicadores de Coleção."
 
-#: /app/analytics/templates/website/publication_article.mako:55
+#: analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1482,12 +1482,12 @@ msgstr ""
 "selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
 "Citation Index e documentados no SciELO Publishing Schema."
 
-#: /app/analytics/templates/website/publication_article.mako:61
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
+#: analytics/templates/website/publication_article.mako:61
+#: analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr "Idiomas dos documentos"
 
-#: /app/analytics/templates/website/publication_article.mako:73
+#: analytics/templates/website/publication_article.mako:73
 msgid ""
 "Este gráfico apresenta o total de documentos por idioma de publicação. Os"
 " números são relacionados a coleção ou ao periódico quando um periódico é"
@@ -1501,11 +1501,11 @@ msgstr ""
 " considerados como totais de publicações da coleção uma vez que um "
 "documento pode ser publicado em mais de um idioma."
 
-#: /app/analytics/templates/website/publication_article.mako:79
+#: analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr "Anos de publicação"
 
-#: /app/analytics/templates/website/publication_article.mako:91
+#: analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
@@ -1515,12 +1515,12 @@ msgstr ""
 "publicação. Os números são relacionados a coleção ou ao periódico quando "
 "um periódico é selecionado."
 
-#: /app/analytics/templates/website/publication_article.mako:97
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
+#: analytics/templates/website/publication_article.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr "Países de afiliação"
 
-#: /app/analytics/templates/website/publication_article.mako:109
+#: analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
@@ -1532,11 +1532,11 @@ msgstr ""
 "considerados como totais de publicações da coleção uma vez que um "
 "documento pode ter mais um país de afiliação."
 
-#: /app/analytics/templates/website/publication_article.mako:115
+#: analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr "Mapa de países de afiliação"
 
-#: /app/analytics/templates/website/publication_article.mako:127
+#: analytics/templates/website/publication_article.mako:127
 msgid ""
 "Este mapa apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste mapa não podem ser "
@@ -1548,7 +1548,7 @@ msgstr ""
 "considerados como totais de publicações da coleção uma vez que um "
 "documento pode ter mais um país de afiliação."
 
-#: /app/analytics/templates/website/publication_article.mako:145
+#: analytics/templates/website/publication_article.mako:145
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
@@ -1558,11 +1558,11 @@ msgstr ""
 "autores. Os números são relacionados a coleção ou ao periódico quando um "
 "periódico é selecionado."
 
-#: /app/analytics/templates/website/publication_article.mako:151
+#: analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr "Número de referências bibliográficas"
 
-#: /app/analytics/templates/website/publication_article.mako:163
+#: analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
@@ -1572,7 +1572,7 @@ msgstr ""
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
+#: analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
@@ -1586,7 +1586,7 @@ msgstr ""
 "licença de uso dependem da adoção da coleção ou periódico selecionado de "
 "licenças de uso creative commons."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
+#: analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por área de atuação e"
 " ano de publicação. Os números são relacionados a coleção ou ao periódico"
@@ -1604,7 +1604,7 @@ msgstr ""
 "atuação. Este gráfico é recomendado para extração de indicadores de "
 "Coleção."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
+#: analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por tipo de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1614,7 +1614,7 @@ msgstr ""
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
 "ao periódico quando um periódico é selecionado."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
+#: analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por idioma de "
 "publicação e ano de publicação. Os números são relacionados a coleção ou "
@@ -1630,7 +1630,7 @@ msgstr ""
 "publicações da coleção uma vez que um documento pode ser publicado em "
 "mais de um idioma."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+#: analytics/templates/website/publication_article_by_publication_year.mako:91
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por país de afiliação"
 " dos autores e ano de publicação. Os números são relacionados a coleção "
@@ -1646,27 +1646,27 @@ msgstr ""
 "publicações da coleção uma vez que um documento pode ser publicado por "
 "mais de um país de afiliação."
 
-#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
+#: analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr "Citações recebidas, concedidas e auto citações"
 
-#: /app/analytics/templates/website/publication_journal.mako:5
+#: analytics/templates/website/publication_journal.mako:5
 msgid "Licenças de uso dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:10
+#: analytics/templates/website/publication_journal.mako:10
 msgid "Áreas temáticas dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:15
+#: analytics/templates/website/publication_journal.mako:15
 msgid "Ano de inclusão de periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal.mako:19
+#: analytics/templates/website/publication_journal.mako:19
 msgid "Situação de publicação dos periódicos"
 msgstr ""
 
-#: /app/analytics/templates/website/publication_journal_licenses.mako:17
+#: analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por licença de uso adotada."
 " Os valores totais de periódicos deste gráfico não podem ser considerados"
@@ -1680,7 +1680,7 @@ msgstr ""
 " de uma área de atuação. Este gráfico é recomendado para extração de "
 "indicadores de Coleção."
 
-#: /app/analytics/templates/website/publication_journal_status.mako:17
+#: analytics/templates/website/publication_journal_status.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por status da publicação no"
 " SciELO. O status considerado neste grafíco é o status vigente do "
@@ -1694,7 +1694,7 @@ msgstr ""
 "existência do periódico nas bases SciELO. Este gráfico é recomendado para"
 " extração de indicadores de Coleção."
 
-#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
+#: analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
 "gráfico é recomendado para extração de indicadores de Coleção. As áreas "
@@ -1716,7 +1716,7 @@ msgstr ""
 "atuação. Este gráfico é recomendado para extração de indicadores de "
 "Coleção."
 
-#: /app/analytics/templates/website/publication_journal_year.mako:17
+#: analytics/templates/website/publication_journal_year.mako:17
 msgid ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
@@ -1724,14 +1724,14 @@ msgstr ""
 "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
 " Este gráfico é recomendado para extração de indicadores de Coleção."
 
-#: /app/analytics/templates/website/publication_size.mako:11
-#: /app/analytics/templates/website/publication_size.mako:22
-#: /app/analytics/templates/website/publication_size.mako:33
-#: /app/analytics/templates/website/publication_size.mako:44
+#: analytics/templates/website/publication_size.mako:11
+#: analytics/templates/website/publication_size.mako:22
+#: analytics/templates/website/publication_size.mako:33
+#: analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre os números"
 
-#: /app/analytics/templates/website/publication_size.mako:14
+#: analytics/templates/website/publication_size.mako:14
 msgid ""
 "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
@@ -1741,7 +1741,7 @@ msgstr ""
 " artigo publicados. Os números são relacionados a coleção ou ao periódico"
 " quando um periódico é selecionado na barra superior do site."
 
-#: /app/analytics/templates/website/publication_size.mako:25
+#: analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
@@ -1751,7 +1751,7 @@ msgstr ""
 "publicado. Os números são relacionados a coleção ou ao periódico quando "
 "um periódico é selecionado na barra superior do site."
 
-#: /app/analytics/templates/website/publication_size.mako:36
+#: analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
@@ -1761,7 +1761,7 @@ msgstr ""
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
 
-#: /app/analytics/templates/website/publication_size.mako:47
+#: analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
 "citadas nos documentos publicados. Os números são relacionados a coleção "
@@ -1773,27 +1773,27 @@ msgstr ""
 "ou ao periódico quando um periódico é selecionado na barra superior do "
 "site."
 
-#: /app/analytics/templates/website/publication_size_citations.mako:9
+#: analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referências"
 
-#: /app/analytics/templates/website/publication_size_documents.mako:9
+#: analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: /app/analytics/templates/website/publication_size_issues.mako:9
+#: analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: /app/analytics/templates/website/publication_size_journals.mako:10
+#: analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "periódicos"
 
-#: /app/analytics/templates/website/reports.mako:5
+#: analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tabulações"
 
-#: /app/analytics/templates/website/reports.mako:7
+#: analytics/templates/website/reports.mako:7
 msgid ""
 "O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
 "metadados utilizados para produção dos indicadores presentes nesta "
@@ -1805,50 +1805,51 @@ msgstr ""
 "ferramenta. Qualquer interessado pode fazer o download e produzir "
 "análises bibliométricas de acordo com suas necessidade."
 
-#: /app/analytics/templates/website/reports.mako:10
+#: analytics/templates/website/reports.mako:10
 msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 
-#: /app/analytics/templates/website/reports.mako:16
+#: analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nome do arquivo"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidade de atualização"
 
-#: /app/analytics/templates/website/reports.mako:17
+#: analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensal"
 
-#: /app/analytics/templates/website/reports.mako:18
+#: analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamanho do arquivo"
 
-#: /app/analytics/templates/website/reports.mako:19
+#: analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: /app/analytics/templates/website/reports.mako:20
+#: analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última atualização"
 
-#: /app/analytics/templates/website/reports.mako:23
+#: analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "arquivo não disponível para esta coleção"
 
-#: /app/analytics/templates/website/share.mako:8
+#: analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartilhar por email"
 
-#: /app/analytics/templates/website/share.mako:10
+#: analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartilhar no Facebook"
 
-#: /app/analytics/templates/website/share.mako:13
+#: analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartilhar no Twitter"
 
-#: /app/analytics/templates/website/share.mako:16
+#: analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartilhar no LinkedIn"
+

--- a/analytics/locale/pt/LC_MESSAGES/analytics.po
+++ b/analytics/locale/pt/LC_MESSAGES/analytics.po
@@ -1,1541 +1,1854 @@
-# Translations template for analytics.
+# Portuguese translations for analytics.
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the analytics project.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: Analytics\n"
+"Project-Id-Version:  Analytics\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-07-28 11:18-0300\n"
+"POT-Creation-Date: 2019-09-17 18:21+0000\n"
 "PO-Revision-Date: 2017-07-28 14:37+0000\n"
 "Last-Translator: fabiobatalha <fabiobatalha@gmail.com>\n"
-"Language-Team: Portuguese (http://www.transifex.com/scielo/analytics/language/pt/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.0\n"
 "Language: pt\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: Portuguese "
+"(http://www.transifex.com/scielo/analytics/language/pt/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: analytics/charts_config.py:25
+#: /app/analytics/charts_config.py:25
 msgid "Fonte: SciELO.org"
 msgstr "Fonte: SciELO.org"
 
-#: analytics/charts_config.py:58
+#: /app/analytics/charts_config.py:58
 msgid "Ano de acesso aos documentos"
 msgstr "Ano de acesso aos documentos"
 
-#: analytics/charts_config.py:59
+#: /app/analytics/charts_config.py:59
 msgid "Ano de publicação de documentos"
 msgstr "Ano de publicação de documentos"
 
-#: analytics/charts_config.py:91
+#: /app/analytics/charts_config.py:91
 msgid "Ano de publicação de documentos do periódico. (citados)"
 msgstr "Ano de publicação de documentos do periódico. (citados)"
 
-#: analytics/charts_config.py:92
+#: /app/analytics/charts_config.py:92
 msgid "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 msgstr "Ano de publicação dos documentos da Rede ScIELO. (citantes)"
 
-#: analytics/charts_config.py:100 analytics/charts_config.py:103
-#: analytics/charts_config.py:112
-msgid "Fator de impacto JCR"
-msgstr "Fator de impacto JCR"
+#: /app/analytics/charts_config.py:100
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:28
+msgid "Fator de impacto (Média de percentil)"
+msgstr ""
 
-#: analytics/charts_config.py:113 analytics/charts_config.py:136
-#: analytics/charts_config.py:163
+#: /app/analytics/charts_config.py:103 /app/analytics/charts_config.py:112
+msgid "Média de percentil"
+msgstr ""
+
+#: /app/analytics/charts_config.py:113 /app/analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:157 /app/analytics/charts_config.py:179
+#: /app/analytics/charts_config.py:202 /app/analytics/charts_config.py:229
 msgid "Ano base"
 msgstr "Ano base"
 
-#: analytics/charts_config.py:122
+#: /app/analytics/charts_config.py:122 /app/analytics/charts_config.py:125
+#: /app/analytics/charts_config.py:134
+msgid "Eigen Factor JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:144 /app/analytics/charts_config.py:147
+#: /app/analytics/charts_config.py:156
+msgid "Received Citations JCR"
+msgstr ""
+
+#: /app/analytics/charts_config.py:166 /app/analytics/charts_config.py:169
+#: /app/analytics/charts_config.py:178
+msgid "Fator de impacto JCR"
+msgstr "Fator de impacto JCR"
+
+#: /app/analytics/charts_config.py:188
 msgid "Fonte: Google Scholar"
 msgstr "Fonte: Google Scholar"
 
-#: analytics/charts_config.py:123 analytics/charts_config.py:126
-#: analytics/charts_config.py:135
+#: /app/analytics/charts_config.py:189 /app/analytics/charts_config.py:192
+#: /app/analytics/charts_config.py:201
 msgid "Métricas H5M5"
 msgstr "Métricas H5M5"
 
-#: analytics/charts_config.py:145
+#: /app/analytics/charts_config.py:211
 msgid "imediatez"
 msgstr "imediatez"
 
-#: analytics/charts_config.py:146
-#: analytics/templates/website/access_datepicker.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:48
+#: /app/analytics/charts_config.py:212
+#: /app/analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:48
 msgid "1 ano"
 msgstr "1 ano"
 
-#: analytics/charts_config.py:147
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/charts_config.py:213
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "2 anos"
 msgstr "2 anos"
 
-#: analytics/charts_config.py:148
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/charts_config.py:214
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "3 anos"
 msgstr "3 anos"
 
-#: analytics/charts_config.py:149
+#: /app/analytics/charts_config.py:215
 msgid "4 anos"
 msgstr "4 anos"
 
-#: analytics/charts_config.py:150
+#: /app/analytics/charts_config.py:216
 msgid "5 anos"
 msgstr "5 anos"
 
-#: analytics/charts_config.py:157
+#: /app/analytics/charts_config.py:223
 msgid "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 msgstr "Impacto SciELO em 1, 2, 3, 4, 5 anos e Índice de Imediatez"
 
-#: analytics/charts_config.py:160 analytics/charts_config.py:162
-#: analytics/templates/website/bibliometrics_journal.mako:23
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:33
+#: /app/analytics/charts_config.py:226 /app/analytics/charts_config.py:228
+#: /app/analytics/templates/website/bibliometrics_journal.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:33
 msgid "Impacto SciELO"
 msgstr "Impacto SciELO"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Auto citação"
 msgstr "Auto citação"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações concedidas"
 msgstr "Citações concedidas"
 
-#: analytics/charts_config.py:171
+#: /app/analytics/charts_config.py:237
 msgid "Citações recebidas"
 msgstr "Citações recebidas"
 
-#: analytics/charts_config.py:178
+#: /app/analytics/charts_config.py:244
 msgid "Distribuição de citações concedidas, recebidas e auto citações"
 msgstr "Distribuição de citações concedidas, recebidas e auto citações"
 
-#: analytics/charts_config.py:185
+#: /app/analytics/charts_config.py:251
 msgid "Número de citações"
 msgstr "Número de citações"
 
-#: analytics/charts_config.py:190 analytics/charts_config.py:207
-#: analytics/charts_config.py:221 analytics/charts_config.py:348
-#: analytics/charts_config.py:357 analytics/charts_config.py:372
-#: analytics/charts_config.py:380 analytics/charts_config.py:428
-#: analytics/charts_config.py:437 analytics/charts_config.py:516
-#: analytics/charts_config.py:526 analytics/charts_config.py:568
-#: analytics/charts_config.py:577 analytics/charts_config.py:618
-#: analytics/charts_config.py:626 analytics/charts_config.py:742
-#: analytics/templates/website/central_container_for_article_filters.mako:13
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:13
+#: /app/analytics/charts_config.py:256 /app/analytics/charts_config.py:273
+#: /app/analytics/charts_config.py:287 /app/analytics/charts_config.py:414
+#: /app/analytics/charts_config.py:423 /app/analytics/charts_config.py:438
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:494
+#: /app/analytics/charts_config.py:503 /app/analytics/charts_config.py:562
+#: /app/analytics/charts_config.py:572 /app/analytics/charts_config.py:614
+#: /app/analytics/charts_config.py:623 /app/analytics/charts_config.py:664
+#: /app/analytics/charts_config.py:672 /app/analytics/charts_config.py:788
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:13
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:13
 msgid "Ano de publicação"
 msgstr "Ano de publicação"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos citáveis"
 msgstr "Documentos citáveis"
 
-#: analytics/charts_config.py:199
+#: /app/analytics/charts_config.py:265
 msgid "Documentos não citáveis"
 msgstr "Documentos não citáveis"
 
-#: analytics/charts_config.py:206
+#: /app/analytics/charts_config.py:272
 msgid "Distribuição de documentos citáveis e não citáveis"
 msgstr "Distribuição de documentos citáveis e não citáveis"
 
-#: analytics/charts_config.py:215 analytics/charts_config.py:239
-#: analytics/charts_config.py:258 analytics/charts_config.py:275
-#: analytics/charts_config.py:322 analytics/charts_config.py:346
-#: analytics/charts_config.py:375 analytics/charts_config.py:401
-#: analytics/charts_config.py:426 analytics/charts_config.py:494
-#: analytics/charts_config.py:514 analytics/charts_config.py:522
-#: analytics/charts_config.py:545 analytics/charts_config.py:566
-#: analytics/charts_config.py:616 analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:281 /app/analytics/charts_config.py:305
+#: /app/analytics/charts_config.py:324 /app/analytics/charts_config.py:341
+#: /app/analytics/charts_config.py:388 /app/analytics/charts_config.py:412
+#: /app/analytics/charts_config.py:441 /app/analytics/charts_config.py:467
+#: /app/analytics/charts_config.py:492 /app/analytics/charts_config.py:540
+#: /app/analytics/charts_config.py:560 /app/analytics/charts_config.py:568
+#: /app/analytics/charts_config.py:591 /app/analytics/charts_config.py:612
+#: /app/analytics/charts_config.py:662 /app/analytics/charts_config.py:691
 msgid "Número de documentos"
 msgstr "Número de documentos"
 
-#: analytics/charts_config.py:232
+#: /app/analytics/charts_config.py:298
 msgid "Distribuição de número de referências bibliográficas dos documentos"
 msgstr "Distribuição de número de referências bibliográficas dos documentos"
 
-#: analytics/charts_config.py:235
+#: /app/analytics/charts_config.py:301
 msgid "Referências bibliográficas"
 msgstr "Referências bibliográficas"
 
-#: analytics/charts_config.py:242
+#: /app/analytics/charts_config.py:308
 #, python-format
 msgid "%s documentos com %s referências bibliográficas"
 msgstr "%s documentos com %s referências bibliográficas"
 
-#: analytics/charts_config.py:251
+#: /app/analytics/charts_config.py:317
 msgid "Distribuição de número de autores dos documentos"
 msgstr "Distribuição de número de autores dos documentos"
 
-#: analytics/charts_config.py:254
-#: analytics/templates/website/publication_article.mako:133
+#: /app/analytics/charts_config.py:320
+#: /app/analytics/templates/website/publication_article.mako:133
 msgid "Número de autores"
 msgstr "Número de autores"
 
-#: analytics/charts_config.py:261
+#: /app/analytics/charts_config.py:327
 #, python-format
 msgid "%s documentos com %s autores"
 msgstr "%s documentos com %s autores"
 
-#: analytics/charts_config.py:272 analytics/charts_config.py:314
+#: /app/analytics/charts_config.py:338 /app/analytics/charts_config.py:380
 msgid "Distribuição de países de afiliação dos autores"
 msgstr "Distribuição de países de afiliação dos autores"
 
-#: analytics/charts_config.py:293 analytics/charts_config.py:325
-#: analytics/charts_config.py:380 analytics/charts_config.py:404
-#: analytics/charts_config.py:497 analytics/charts_config.py:548
-#: analytics/charts_config.py:648
+#: /app/analytics/charts_config.py:359 /app/analytics/charts_config.py:391
+#: /app/analytics/charts_config.py:446 /app/analytics/charts_config.py:470
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:594
+#: /app/analytics/charts_config.py:694
 msgid "Documentos"
 msgstr "Documentos"
 
-#: analytics/charts_config.py:302 analytics/charts_config.py:317
-#: analytics/charts_config.py:325
+#: /app/analytics/charts_config.py:368 /app/analytics/charts_config.py:383
+#: /app/analytics/charts_config.py:391
 msgid "País de afiliação"
 msgstr "País de afiliação"
 
-#: analytics/charts_config.py:338
+#: /app/analytics/charts_config.py:404
 msgid "Distribuição de países de afiliação dos autores por ano de publicação"
 msgstr "Distribuição de países de afiliação dos autores por ano de publicação"
 
-#: analytics/charts_config.py:371
+#: /app/analytics/charts_config.py:437
 msgid "Distribuição de ano de publicação dos documentos"
 msgstr "Distribuição de ano de publicação dos documentos"
 
-#: analytics/charts_config.py:393
+#: /app/analytics/charts_config.py:459
 msgid "Distribuição de idiomas dos documentos"
 msgstr "Distribuição de idiomas dos documentos"
 
-#: analytics/charts_config.py:396
+#: /app/analytics/charts_config.py:462
 msgid "Idiomas de publicação"
 msgstr "Idiomas de publicação"
 
-#: analytics/charts_config.py:404
+#: /app/analytics/charts_config.py:470
 msgid "Idioma do documento"
 msgstr "Idioma do documento"
 
-#: analytics/charts_config.py:418
+#: /app/analytics/charts_config.py:484
 msgid "Distribuição de idiomas dos documentos por ano de publicação"
 msgstr "Distribuição de idiomas dos documentos por ano de publicação"
 
-#: analytics/charts_config.py:448 analytics/charts_config.py:588
-msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
-msgstr "Distribuição de periódicos por situação atual de publicação no SciELO"
-
-#: analytics/charts_config.py:451 analytics/charts_config.py:459
-#: analytics/charts_config.py:591 analytics/charts_config.py:599
-msgid "Situação da publicação"
-msgstr "Situação da publicação"
-
-#: analytics/charts_config.py:456 analytics/charts_config.py:472
-#: analytics/charts_config.py:596 analytics/charts_config.py:665
-#: analytics/charts_config.py:685
-msgid "Número de periódicos"
-msgstr "Número de periódicos"
-
-#: analytics/charts_config.py:459 analytics/charts_config.py:477
-#: analytics/charts_config.py:599 analytics/charts_config.py:668
-#: analytics/charts_config.py:688
-#: analytics/templates/website/navbar_collection.mako:10
-#: analytics/templates/website/navbar_journal.mako:10
-msgid "Periódicos"
-msgstr "Periódicos"
-
-#: analytics/charts_config.py:468
+#: /app/analytics/charts_config.py:514
 msgid "Distribuição de periódicos por ano de inclusão no SciELO"
 msgstr "Distribuição de periódicos por ano de inclusão no SciELO"
 
-#: analytics/charts_config.py:469 analytics/charts_config.py:477
+#: /app/analytics/charts_config.py:515 /app/analytics/charts_config.py:523
 msgid "Ano de inclusão"
 msgstr "Ano de inclusão"
 
-#: analytics/charts_config.py:486
+#: /app/analytics/charts_config.py:518 /app/analytics/charts_config.py:642
+#: /app/analytics/charts_config.py:711 /app/analytics/charts_config.py:731
+msgid "Número de periódicos"
+msgstr "Número de periódicos"
+
+#: /app/analytics/charts_config.py:523 /app/analytics/charts_config.py:645
+#: /app/analytics/charts_config.py:714 /app/analytics/charts_config.py:734
+#: /app/analytics/templates/website/navbar_collection.mako:10
+#: /app/analytics/templates/website/navbar_journal.mako:10
+msgid "Periódicos"
+msgstr "Periódicos"
+
+#: /app/analytics/charts_config.py:532
 msgid "Distribuição de área temática dos documentos"
 msgstr "Distribuição de área temática dos documentos"
 
-#: analytics/charts_config.py:489 analytics/charts_config.py:660
+#: /app/analytics/charts_config.py:535 /app/analytics/charts_config.py:706
 msgid "Areas temáticas"
 msgstr "Areas temáticas"
 
-#: analytics/charts_config.py:497 analytics/charts_config.py:668
-#: analytics/templates/website/central_container_for_article_filters.mako:30
-#: analytics/templates/website/central_container_for_journal_filters.mako:13
+#: /app/analytics/charts_config.py:543 /app/analytics/charts_config.py:714
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:30
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:13
 msgid "Área temática"
 msgstr "Área temática"
 
-#: analytics/charts_config.py:506
+#: /app/analytics/charts_config.py:552
 msgid "Distribuição de área temática dos documentos por ano de publicação"
 msgstr "Distribuição de área temática dos documentos por ano de publicação"
 
-#: analytics/charts_config.py:537
+#: /app/analytics/charts_config.py:583
 msgid "Distribuição por tipo de documento"
 msgstr "Distribuição por tipo de documento"
 
-#: analytics/charts_config.py:540
-#: analytics/templates/website/publication_article.mako:43
-#: analytics/templates/website/publication_article_by_publication_year.mako:43
+#: /app/analytics/charts_config.py:586
+#: /app/analytics/templates/website/publication_article.mako:43
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:43
 msgid "Tipos de documentos"
 msgstr "Tipos de documentos"
 
-#: analytics/charts_config.py:548
+#: /app/analytics/charts_config.py:594
 msgid "Tipo de documento"
 msgstr "Tipo de documento"
 
-#: analytics/charts_config.py:558
+#: /app/analytics/charts_config.py:604
 msgid "Distribuição de tipos de documentos por ano de publicação"
 msgstr "Distribuição de tipos de documentos por ano de publicação"
 
-#: analytics/charts_config.py:608
+#: /app/analytics/charts_config.py:634
+msgid "Distribuição de periódicos por situação atual de publicação no SciELO"
+msgstr "Distribuição de periódicos por situação atual de publicação no SciELO"
+
+#: /app/analytics/charts_config.py:637 /app/analytics/charts_config.py:645
+msgid "Situação da publicação"
+msgstr "Situação da publicação"
+
+#: /app/analytics/charts_config.py:654
 msgid "Distribuição de licenças de uso por ano de publicação"
 msgstr "Distribuição de licenças de uso por ano de publicação"
 
-#: analytics/charts_config.py:637
+#: /app/analytics/charts_config.py:683
 msgid "Distribuição de licença de uso dos documentos"
 msgstr "Distribuição de licença de uso dos documentos"
 
-#: analytics/charts_config.py:640 analytics/charts_config.py:680
-#: analytics/templates/website/publication_article.mako:5
-#: analytics/templates/website/publication_article_by_publication_year.mako:5
+#: /app/analytics/charts_config.py:686 /app/analytics/charts_config.py:726
+#: /app/analytics/templates/website/publication_article.mako:5
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:5
 msgid "Licenças de uso"
 msgstr "Licenças de uso"
 
-#: analytics/charts_config.py:648 analytics/charts_config.py:688
+#: /app/analytics/charts_config.py:694 /app/analytics/charts_config.py:734
 msgid "Licença"
 msgstr "Licença"
 
-#: analytics/charts_config.py:657
+#: /app/analytics/charts_config.py:703
 msgid "Distribuição de área temática dos periódicos"
 msgstr "Distribuição de área temática dos periódicos"
 
-#: analytics/charts_config.py:677
+#: /app/analytics/charts_config.py:723
 msgid "Distribuição de licença de uso dos periódicos"
 msgstr "Distribuição de licença de uso dos periódicos"
 
-#: analytics/charts_config.py:696
+#: /app/analytics/charts_config.py:742
 msgid "Total de acessos por ano e mês"
 msgstr "Total de acessos por ano e mês"
 
-#: analytics/charts_config.py:704 analytics/charts_config.py:739
-#: analytics/templates/website/navbar_collection.mako:7
-#: analytics/templates/website/navbar_document.mako:7
-#: analytics/templates/website/navbar_journal.mako:7
+#: /app/analytics/charts_config.py:750 /app/analytics/charts_config.py:785
+#: /app/analytics/templates/website/navbar_collection.mako:7
+#: /app/analytics/templates/website/navbar_document.mako:7
+#: /app/analytics/templates/website/navbar_journal.mako:7
 msgid "Acessos"
 msgstr "Acessos"
 
-#: analytics/charts_config.py:710
+#: /app/analytics/charts_config.py:756
 msgid "Acessos em"
 msgstr "Acessos em"
 
-#: analytics/charts_config.py:721
+#: /app/analytics/charts_config.py:767
 msgid "Total de accessos por tipo de documento"
 msgstr "Total de accessos por tipo de documento"
 
-#: analytics/charts_config.py:725
+#: /app/analytics/charts_config.py:771
 #, python-format
 msgid "%s acessos a documentos do tipo %s"
 msgstr "%s acessos a documentos do tipo %s"
 
-#: analytics/charts_config.py:737
+#: /app/analytics/charts_config.py:783
 msgid "Vida útil de artigos por número de acessos em"
 msgstr "Vida útil de artigos por número de acessos em"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 msgid "Ano de referência"
 msgstr "Ano de referência"
 
-#: analytics/charts_config.py:746
+#: /app/analytics/charts_config.py:792
 #, python-format
 msgid "%s acessos aos documentos do ano %s"
 msgstr "%s acessos aos documentos do ano %s"
 
-#: analytics/controller.py:354
-msgid "Fator de impacto 5 anos"
-msgstr "Fator de impacto 5 anos"
-
-#: analytics/controller.py:359
-msgid "Fator de impacto 2 anos"
-msgstr "Fator de impacto 2 anos"
-
-#: analytics/controller.py:364
-msgid "Fator de impacto 2 anos, sem auto citação"
-msgstr "Fator de impacto 2 anos, sem auto citação"
-
-#: analytics/templates/website/access_by_document_type.mako:6
-#: analytics/templates/website/access_by_month_and_year.mako:5
-#: analytics/templates/website/access_lifetime.mako:6
-#: analytics/templates/website/accesses_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:6
-#: analytics/templates/website/bibliometrics_journal_h5m5.mako:5
-#: analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
-#: analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
-#: analytics/templates/website/publication_article_affiliations.mako:5
-#: analytics/templates/website/publication_article_affiliations_map.mako:5
-#: analytics/templates/website/publication_article_affiliations_publication_year.mako:5
-#: analytics/templates/website/publication_article_authors.mako:5
-#: analytics/templates/website/publication_article_citable_documents.mako:5
-#: analytics/templates/website/publication_article_document_type.mako:5
-#: analytics/templates/website/publication_article_document_type_publication_year.mako:5
-#: analytics/templates/website/publication_article_languages.mako:5
-#: analytics/templates/website/publication_article_languages_publication_year.mako:5
-#: analytics/templates/website/publication_article_licenses.mako:5
-#: analytics/templates/website/publication_article_licenses_publication_year.mako:5
-#: analytics/templates/website/publication_article_references.mako:5
-#: analytics/templates/website/publication_article_subject_areas.mako:6
-#: analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
-#: analytics/templates/website/publication_article_year.mako:5
-#: analytics/templates/website/publication_journal_licenses.mako:7
-#: analytics/templates/website/publication_journal_status.mako:7
-#: analytics/templates/website/publication_journal_subject_areas.mako:7
-#: analytics/templates/website/publication_journal_year.mako:7
-#: analytics/templates/website/publication_size_citations.mako:6
-#: analytics/templates/website/publication_size_documents.mako:6
-#: analytics/templates/website/publication_size_issues.mako:6
-#: analytics/templates/website/publication_size_journals.mako:6
+#: /app/analytics/templates/website/access_by_document_type.mako:6
+#: /app/analytics/templates/website/access_by_month_and_year.mako:5
+#: /app/analytics/templates/website/access_lifetime.mako:6
+#: /app/analytics/templates/website/accesses_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_h5m5.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_impact_factor_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_average_impact_factor_percentile.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_eigen_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_impact_factor.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_jcr_received_citations.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:5
+#: /app/analytics/templates/website/bibliometrics_journal_received_self_and_granted_citation_chart.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_map.mako:5
+#: /app/analytics/templates/website/publication_article_affiliations_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_authors.mako:5
+#: /app/analytics/templates/website/publication_article_citable_documents.mako:5
+#: /app/analytics/templates/website/publication_article_document_type.mako:5
+#: /app/analytics/templates/website/publication_article_document_type_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_languages.mako:5
+#: /app/analytics/templates/website/publication_article_languages_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_licenses.mako:5
+#: /app/analytics/templates/website/publication_article_licenses_publication_year.mako:5
+#: /app/analytics/templates/website/publication_article_references.mako:5
+#: /app/analytics/templates/website/publication_article_subject_areas.mako:6
+#: /app/analytics/templates/website/publication_article_subject_areas_publication_year.mako:6
+#: /app/analytics/templates/website/publication_article_year.mako:5
+#: /app/analytics/templates/website/publication_journal_licenses.mako:7
+#: /app/analytics/templates/website/publication_journal_status.mako:7
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:7
+#: /app/analytics/templates/website/publication_journal_year.mako:7
+#: /app/analytics/templates/website/publication_size_citations.mako:6
+#: /app/analytics/templates/website/publication_size_documents.mako:6
+#: /app/analytics/templates/website/publication_size_issues.mako:6
+#: /app/analytics/templates/website/publication_size_journals.mako:6
 msgid "loading"
 msgstr "loading"
 
-#: analytics/templates/website/access_datepicker.mako:5
+#: /app/analytics/templates/website/access_datepicker.mako:5
 msgid "Período"
 msgstr "Período"
 
-#: analytics/templates/website/access_datepicker.mako:9
+#: /app/analytics/templates/website/access_datepicker.mako:9
 msgid "acessos nos últimos 36 meses"
 msgstr "acessos nos últimos 36 meses"
 
-#: analytics/templates/website/access_datepicker.mako:10
+#: /app/analytics/templates/website/access_datepicker.mako:10
 msgid "acessos nos últimos 24 meses"
 msgstr "acessos nos últimos 24 meses"
 
-#: analytics/templates/website/access_datepicker.mako:11
+#: /app/analytics/templates/website/access_datepicker.mako:11
 msgid "acessos nos últimos 12 meses"
 msgstr "acessos nos últimos 12 meses"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "todos acessos disponíveis"
 msgstr "todos acessos disponíveis"
 
-#: analytics/templates/website/access_datepicker.mako:12
+#: /app/analytics/templates/website/access_datepicker.mako:12
 msgid "tudo"
 msgstr "tudo"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid "Seletor de período de acessos"
 msgstr "Seletor de período de acessos"
 
-#: analytics/templates/website/access_datepicker.mako:14
+#: /app/analytics/templates/website/access_datepicker.mako:14
 msgid ""
 "Utilize o campo com datas para selecionar um período customizado para "
-"recuperação dos dados de acesso. Você pode também selecionar o período de 1,"
-" 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis "
-"selecionando tudo."
-msgstr "Utilize o campo com datas para selecionar um período customizado para recuperação dos dados de acesso. Você pode também selecionar o período de 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis selecionando tudo."
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
+msgstr ""
+"Utilize o campo com datas para selecionar um período customizado para "
+"recuperação dos dados de acesso. Você pode também selecionar o período de"
+" 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis"
+" selecionando tudo."
 
-#: analytics/templates/website/access_list_articles.mako:6
+#: /app/analytics/templates/website/access_list_articles.mako:6
 msgid "Top 100 artigos por número de acessos"
 msgstr "Top 100 artigos por número de acessos"
 
-#: analytics/templates/website/access_list_articles.mako:9
+#: /app/analytics/templates/website/access_list_articles.mako:9
 msgid "artigo"
 msgstr "artigo"
 
-#: analytics/templates/website/access_list_articles.mako:13
-#: analytics/templates/website/access_list_issues.mako:13
-#: analytics/templates/website/access_list_journals.mako:13
+#: /app/analytics/templates/website/access_list_articles.mako:13
+#: /app/analytics/templates/website/access_list_issues.mako:13
+#: /app/analytics/templates/website/access_list_journals.mako:13
 msgid "resumo"
 msgstr "resumo"
 
-#: analytics/templates/website/access_list_articles.mako:14
-#: analytics/templates/website/access_list_issues.mako:14
-#: analytics/templates/website/access_list_journals.mako:14
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:26
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:43
-#: analytics/templates/website/bibliometrics_list_granted.mako:19
-#: analytics/templates/website/bibliometrics_list_granted.mako:30
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:41
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:47
-#: analytics/templates/website/bibliometrics_list_received.mako:26
-#: analytics/templates/website/bibliometrics_list_received.mako:37
+#: /app/analytics/templates/website/access_list_articles.mako:14
+#: /app/analytics/templates/website/access_list_issues.mako:14
+#: /app/analytics/templates/website/access_list_journals.mako:14
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:43
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:41
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:47
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:26
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:37
 msgid "total"
 msgstr "total"
 
-#: analytics/templates/website/access_list_issues.mako:6
+#: /app/analytics/templates/website/access_list_issues.mako:6
 msgid "Top 100 fascículos por número de acessos"
 msgstr "Top 100 fascículos por número de acessos"
 
-#: analytics/templates/website/access_list_issues.mako:9
-#: analytics/templates/website/access_list_journals.mako:9
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
+#: /app/analytics/templates/website/access_list_issues.mako:9
+#: /app/analytics/templates/website/access_list_journals.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:10
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:44
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:47
 msgid "periódico"
 msgstr "periódico"
 
-#: analytics/templates/website/access_list_journals.mako:6
+#: /app/analytics/templates/website/access_list_journals.mako:6
 msgid "Acessos aos documentos por periódicos"
 msgstr "Acessos aos documentos por periódicos"
 
-#: analytics/templates/website/accesses.mako:6
+#: /app/analytics/templates/website/accesses.mako:6
 msgid "Gráfico da evolução de acessos aos documentos"
 msgstr "Gráfico da evolução de acessos aos documentos"
 
-#: analytics/templates/website/accesses.mako:12
+#: /app/analytics/templates/website/accesses.mako:12
 msgid "Gráfico de calor de acessos"
 msgstr "Gráfico de calor de acessos"
 
-#: analytics/templates/website/accesses.mako:18
+#: /app/analytics/templates/website/accesses.mako:18
 msgid "Gráfico de tempo de vida de documentos através do número de acessos"
 msgstr "Gráfico de tempo de vida de documentos através do número de acessos"
 
-#: analytics/templates/website/accesses_heat_chart.mako:15
+#: /app/analytics/templates/website/accesses_heat_chart.mako:15
 msgid "Acessos aos documentos"
 msgstr "Acessos aos documentos"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "Documentos publicados em"
 msgstr "Documentos publicados em"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "tiveram"
 msgstr "tiveram"
 
-#: analytics/templates/website/accesses_heat_chart.mako:19
+#: /app/analytics/templates/website/accesses_heat_chart.mako:19
 msgid "acessos em"
 msgstr "acessos em"
 
-#: analytics/templates/website/base.mako:6
+#: /app/analytics/templates/website/base.mako:6
 msgid "SciELO Estatísticas"
 msgstr "SciELO Estatísticas"
 
-#: analytics/templates/website/base.mako:30
+#: /app/analytics/templates/website/base.mako:30
 msgid "Coleções"
 msgstr "Coleções"
 
-#: analytics/templates/website/base.mako:38
-#: analytics/templates/website/journal_selector_modal.mako:7
+#: /app/analytics/templates/website/base.mako:38
+#: /app/analytics/templates/website/journal_selector_modal.mako:7
 msgid "selecionar periódico"
 msgstr "selecionar periódico"
 
-#: analytics/templates/website/base.mako:91
+#: /app/analytics/templates/website/base.mako:91
 msgid "Ferramenta em desenvolvimento disponível em versão Beta Test."
 msgstr "Ferramenta em desenvolvimento disponível em versão Beta Test."
 
-#: analytics/templates/website/base.mako:93
+#: /app/analytics/templates/website/base.mako:93
 msgid ""
-"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de "
-"realizar testes de uso e performance. Todos os indicadores carregados são "
-"reais e estão sendo atualizados e inseridos gradativamente. Problemas de "
-"lentidão e indisponibilidade do serviços são esperados nesta fase."
-msgstr "Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de realizar testes de uso e performance. Todos os indicadores carregados são reais e estão sendo atualizados e inseridos gradativamente. Problemas de lentidão e indisponibilidade do serviços são esperados nesta fase."
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
+msgstr ""
+"Esta ferramenta esta em desenvolvimento e foi publicada com o objetivo de"
+" realizar testes de uso e performance. Todos os indicadores carregados "
+"são reais e estão sendo atualizados e inseridos gradativamente. Problemas"
+" de lentidão e indisponibilidade do serviços são esperados nesta fase."
 
-#: analytics/templates/website/base.mako:114
+#: /app/analytics/templates/website/base.mako:114
 msgid "Ajuda"
 msgstr "Ajuda"
 
-#: analytics/templates/website/base.mako:116
+#: /app/analytics/templates/website/base.mako:116
 msgid "Reportar error"
 msgstr "Reportar error"
 
-#: analytics/templates/website/base.mako:117
+#: /app/analytics/templates/website/base.mako:117
 msgid "Lista de discussão"
 msgstr "Lista de discussão"
 
-#: analytics/templates/website/base.mako:121
+#: /app/analytics/templates/website/base.mako:121
 msgid "Desenvolvimento"
 msgstr "Desenvolvimento"
 
-#: analytics/templates/website/base.mako:124
+#: /app/analytics/templates/website/base.mako:124
 msgid "Lista de desenvolvimento"
 msgstr "Lista de desenvolvimento"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Janeiro"
 msgstr "Janeiro"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Fevereiro"
 msgstr "Fevereiro"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Março"
 msgstr "Março"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Abril"
 msgstr "Abril"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Maio"
 msgstr "Maio"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Junho"
 msgstr "Junho"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Julho"
 msgstr "Julho"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Agosto"
 msgstr "Agosto"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Setembro"
 msgstr "Setembro"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Outubro"
 msgstr "Outubro"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Novembro"
 msgstr "Novembro"
 
-#: analytics/templates/website/base.mako:168
+#: /app/analytics/templates/website/base.mako:168
 msgid "Dezembro"
 msgstr "Dezembro"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jan"
 msgstr "Jan"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Fev"
 msgstr "Fev"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mar"
 msgstr "Mar"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Abr"
 msgstr "Abr"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Mai"
 msgstr "Mai"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jun"
 msgstr "Jun"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Jul"
 msgstr "Jul"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Ago"
 msgstr "Ago"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Set"
 msgstr "Set"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Out"
 msgstr "Out"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Nov"
 msgstr "Nov"
 
-#: analytics/templates/website/base.mako:169
+#: /app/analytics/templates/website/base.mako:169
 msgid "Dez"
 msgstr "Dez"
 
-#: analytics/templates/website/bibliometrics_document_altmetrics.mako:7
+#: /app/analytics/templates/website/bibliometrics_document_altmetrics.mako:7
 msgid "altmetrics"
 msgstr "altmetrics"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:6
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:30
 msgid "Citações Recebidas"
 msgstr "Citações Recebidas"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:45
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:48
 msgid "ano de publicação"
 msgstr "ano de publicação"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:11
 msgid "primeiro autor"
 msgstr "primeiro autor"
 
-#: analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
+#: /app/analytics/templates/website/bibliometrics_document_list_received_citations.mako:12
 msgid "título do documento"
 msgstr "título do documento"
 
-#: analytics/templates/website/bibliometrics_document_received_citations.mako:9
+#: /app/analytics/templates/website/bibliometrics_document_received_citations.mako:9
 msgid "citações recebidas"
 msgstr "citações recebidas"
 
-#: analytics/templates/website/bibliometrics_journal.mako:8
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:8
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:8
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:8
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
-#: analytics/templates/website/bibliometrics_list_granted.mako:8
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:8
-#: analytics/templates/website/bibliometrics_list_received.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:8
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:8
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:8
 msgid "Atenção"
 msgstr "Atenção"
 
-#: analytics/templates/website/bibliometrics_journal.mako:11
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:11
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:11
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:11
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
-#: analytics/templates/website/bibliometrics_list_granted.mako:11
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:11
-#: analytics/templates/website/bibliometrics_list_received.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:11
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:11
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:11
 msgid "É necessário selecionar um periódico para dados bibliométricos."
 msgstr "É necessário selecionar um periódico para dados bibliométricos."
 
-#: analytics/templates/website/bibliometrics_journal.mako:20
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:19
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:19
-#: analytics/templates/website/bibliometrics_list_received.mako:19
-#: analytics/templates/website/central_container_for_article_filters.mako:16
-#: analytics/templates/website/central_container_for_article_filters.mako:33
-#: analytics/templates/website/central_container_for_article_filters.mako:52
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:16
-#: analytics/templates/website/central_container_for_journal_filters.mako:16
+#: /app/analytics/templates/website/bibliometrics_journal.mako:20
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:19
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:19
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:33
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:52
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:16
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:16
 msgid "aplicar"
 msgstr "aplicar"
 
-#: analytics/templates/website/bibliometrics_journal.mako:32
-#: analytics/templates/website/bibliometrics_journal.mako:51
-#: analytics/templates/website/bibliometrics_journal.mako:69
-#: analytics/templates/website/bibliometrics_journal.mako:87
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
-#: analytics/templates/website/publication_article.mako:14
-#: analytics/templates/website/publication_article.mako:33
-#: analytics/templates/website/publication_article.mako:52
-#: analytics/templates/website/publication_article.mako:70
-#: analytics/templates/website/publication_article.mako:88
-#: analytics/templates/website/publication_article.mako:106
-#: analytics/templates/website/publication_article.mako:124
-#: analytics/templates/website/publication_article.mako:142
-#: analytics/templates/website/publication_article.mako:160
-#: analytics/templates/website/publication_article_by_publication_year.mako:14
-#: analytics/templates/website/publication_article_by_publication_year.mako:33
-#: analytics/templates/website/publication_article_by_publication_year.mako:52
-#: analytics/templates/website/publication_article_by_publication_year.mako:70
-#: analytics/templates/website/publication_article_by_publication_year.mako:88
-#: analytics/templates/website/publication_article_by_publication_year.mako:106
-#: analytics/templates/website/publication_journal_licenses.mako:14
-#: analytics/templates/website/publication_journal_status.mako:14
-#: analytics/templates/website/publication_journal_subject_areas.mako:14
-#: analytics/templates/website/publication_journal_year.mako:14
+#: /app/analytics/templates/website/bibliometrics_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_journal.mako:51
+#: /app/analytics/templates/website/bibliometrics_journal.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal.mako:87
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:24
+#: /app/analytics/templates/website/publication_article.mako:14
+#: /app/analytics/templates/website/publication_article.mako:33
+#: /app/analytics/templates/website/publication_article.mako:52
+#: /app/analytics/templates/website/publication_article.mako:70
+#: /app/analytics/templates/website/publication_article.mako:88
+#: /app/analytics/templates/website/publication_article.mako:106
+#: /app/analytics/templates/website/publication_article.mako:124
+#: /app/analytics/templates/website/publication_article.mako:142
+#: /app/analytics/templates/website/publication_article.mako:160
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:14
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:33
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:52
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:70
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:88
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:106
+#: /app/analytics/templates/website/publication_journal_licenses.mako:14
+#: /app/analytics/templates/website/publication_journal_status.mako:14
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:14
+#: /app/analytics/templates/website/publication_journal_year.mako:14
 msgid "Sobre o gráfico"
 msgstr "Sobre o gráfico"
 
-#: analytics/templates/website/bibliometrics_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal.mako:35
 msgid ""
 "Este gráfico apresenta a o fator de impacto do periódico selecionado "
 "considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
 "linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
 "Reuters"
-msgstr "Este gráfico apresenta a o fator de impacto do periódico selecionado considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A linha de 2 anos equivale ao fator de impacto de periódicos da Thomson Reuters"
+msgstr ""
+"Este gráfico apresenta a o fator de impacto do periódico selecionado "
+"considerando os períodos de imediatez, além de períodos de 1 a 5 anos. A "
+"linha de 2 anos equivale ao fator de impacto de periódicos da Thomson "
+"Reuters"
 
-#: analytics/templates/website/bibliometrics_journal.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal.mako:42
 msgid "Documentos citáveis e não citáveis"
 msgstr "Documentos citáveis e não citáveis"
 
-#: analytics/templates/website/bibliometrics_journal.mako:54
-#: analytics/templates/website/publication_article_by_publication_year.mako:109
+#: /app/analytics/templates/website/bibliometrics_journal.mako:54
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:109
 msgid ""
-"Este gráfico apresenta a distribuição de documentos citáveis e não citáveis "
-"relacionados ao periódico selecionado. De acordo com as regras de contagem "
-"do SciELO, documentos citáveis devem ser do tipo \"Research Article\", "
-"\"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid "
-"Communication\" e \"Article Commentary\". Os demais tipos de documentos são "
-"considerados não citáveis."
-msgstr "Este gráfico apresenta a distribuição de documentos citáveis e não citáveis relacionados ao periódico selecionado. De acordo com as regras de contagem do SciELO, documentos citáveis devem ser do tipo \"Research Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid Communication\" e \"Article Commentary\". Os demais tipos de documentos são considerados não citáveis."
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos citáveis e não "
+"citáveis relacionados ao periódico selecionado. De acordo com as regras "
+"de contagem do SciELO, documentos citáveis devem ser do tipo \"Research "
+"Article\", \"Review Article\", \"Case Report\", \"Brief Report\", \"Rapid"
+" Communication\" e \"Article Commentary\". Os demais tipos de documentos "
+"são considerados não citáveis."
 
-#: analytics/templates/website/bibliometrics_journal.mako:60
+#: /app/analytics/templates/website/bibliometrics_journal.mako:60
 msgid "Google H5M5"
 msgstr "Google H5M5"
 
-#: analytics/templates/website/bibliometrics_journal.mako:72
+#: /app/analytics/templates/website/bibliometrics_journal.mako:72
 msgid ""
-"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores "
-"são fornecidos anualmente pelo Google Scholar. A ausência de indicadores "
-"para um periódico ou para um período de um periódico pode ocorrer caso esses"
-" dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, "
-"você será direcionado para o site do Google Scholar."
-msgstr "Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores são fornecidos anualmente pelo Google Scholar. A ausência de indicadores para um periódico ou para um período de um periódico pode ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, você será direcionado para o site do Google Scholar."
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
+msgstr ""
+"Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os "
+"indicadores são fornecidos anualmente pelo Google Scholar. A ausência de "
+"indicadores para um periódico ou para um período de um periódico pode "
+"ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. "
+"Ao clicar na série, você será direcionado para o site do Google Scholar."
 
-#: analytics/templates/website/bibliometrics_journal.mako:78
+#: /app/analytics/templates/website/bibliometrics_journal.mako:78
 msgid "Citações concedidas, recebidas e auto citação"
 msgstr "Citações concedidas, recebidas e auto citação"
 
-#: analytics/templates/website/bibliometrics_journal.mako:90
+#: /app/analytics/templates/website/bibliometrics_journal.mako:90
 msgid ""
 "Este gráfico apresenta o número de citações concedidas, recebidas e auto "
-"citações do periódico selecionado, os dados estão distribuidos por ano de "
-"publicação."
-msgstr "Este gráfico apresenta o número de citações concedidas, recebidas e auto citações do periódico selecionado, os dados estão distribuidos por ano de publicação."
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
+msgstr ""
+"Este gráfico apresenta o número de citações concedidas, recebidas e auto "
+"citações do periódico selecionado, os dados estão distribuidos por ano de"
+" publicação."
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:15
-#: analytics/templates/website/navbar_journal.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:27
 msgid "Indicadores Altmetric"
 msgstr "Indicadores Altmetric"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:20
 msgid "Não há indicadores Altmetric para este periódico"
 msgstr "Não há indicadores Altmetric para este periódico"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:31
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:31
 msgid "Não há indicadores Altmetric para este periódico neste timeframe"
 msgstr "Não há indicadores Altmetric para este periódico neste timeframe"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:41
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:41
 msgid "Posts"
 msgstr "Posts"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:48
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:48
 msgid "Soma de pontuação"
 msgstr "Soma de pontuação"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:55
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:55
 msgid "Mediana de pontuação"
 msgstr "Mediana de pontuação"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:62
 msgid "Soma de pontuação no timeframe"
 msgstr "Soma de pontuação no timeframe"
 
-#: analytics/templates/website/bibliometrics_journal_altmetric.mako:69
+#: /app/analytics/templates/website/bibliometrics_journal_altmetric.mako:69
 msgid "Mediana de pontuação no timeframe"
 msgstr "Mediana de pontuação no timeframe"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:15
-#: analytics/templates/website/navbar_journal.mako:28
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:28
 msgid "Indicadores JCR"
 msgstr "Indicadores JCR"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:20
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:16
+msgid "Dados extraídos em: "
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:21
 msgid "Não há indicadores JCR para este periódico"
 msgstr "Não há indicadores JCR para este periódico"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:25
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:26
 msgid "Fator de impacto"
 msgstr "Fator de impacto"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:32
+msgid "Eigen Factor"
+msgstr ""
+
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:34
 msgid "Dados de todos os anos"
 msgstr "Dados de todos os anos"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:35
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:42
 msgid "Total de citações"
 msgstr "Total de citações"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:42
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:49
 msgid "FI 2 anos"
 msgstr "FI 2 anos"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:49
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:56
 msgid "FI 2 anos sem auto citações"
 msgstr "FI 2 anos sem auto citações"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:56
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:63
 msgid "FI 5 anos"
 msgstr "FI 5 anos"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:63
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:70
 msgid "Indice de imediatez"
 msgstr "Indice de imediatez"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:70
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:77
 msgid "Vida média de citações"
 msgstr "Vida média de citações"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:77
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:84
 msgid "Eigen Factor normalizado"
 msgstr "Eigen Factor normalizado"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:84
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:91
 msgid "Percentíl de média de fator de FI de periódico"
 msgstr "Percentíl de média de fator de FI de periódico"
 
-#: analytics/templates/website/bibliometrics_journal_jcr.mako:91
+#: /app/analytics/templates/website/bibliometrics_journal_jcr.mako:98
 msgid "Porcentagem de artigos em itens citáveis"
 msgstr "Porcentagem de artigos em itens citáveis"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
-#: analytics/templates/website/navbar_journal.mako:29
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:15
+#: /app/analytics/templates/website/navbar_journal.mako:29
 msgid "Gráfico de calor de citações recebidas"
 msgstr "Gráfico de calor de citações recebidas"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:27
 msgid ""
 "Este gráfico apresenta o número de citações recebidas por um determinado "
 "periódico. O corpus de citações corresponde a todas as coleções da Rede "
 "SciELO, coleções Temáticas e Independentes."
-msgstr "Este gráfico apresenta o número de citações recebidas por um determinado periódico. O corpus de citações corresponde a todas as coleções da Rede SciELO, coleções Temáticas e Independentes."
+msgstr ""
+"Este gráfico apresenta o número de citações recebidas por um determinado "
+"periódico. O corpus de citações corresponde a todas as coleções da Rede "
+"SciELO, coleções Temáticas e Independentes."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:33
 msgid "Lista de citações para o eixo selecionado"
 msgstr "Lista de citações para o eixo selecionado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:39
 msgid "Citante"
 msgstr "Citante"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:40
 msgid "Citado"
 msgstr "Citado"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:43
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:46
 msgid "documento"
 msgstr "documento"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat.mako:62
 msgid "Selecione um eixo x/y para obter a lista de citações para o período."
 msgstr "Selecione um eixo x/y para obter a lista de citações para o período."
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:15
 msgid "Citações recebidas pelo periódico"
 msgstr "Citações recebidas pelo periódico"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Documentos da Rede SciELO publicados em"
 msgstr "Documentos da Rede SciELO publicados em"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "citaram"
 msgstr "citaram"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "vezes os documentos do periódico"
 msgstr "vezes os documentos do periódico"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "publicados em"
 msgstr "publicados em"
 
-#: analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
+#: /app/analytics/templates/website/bibliometrics_journal_received_citations_heat_chart.mako:19
 msgid "Clique no ponto para ver a lista de artigos."
 msgstr "Clique no ponto para ver a lista de artigos."
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:22
 msgid "Formas de citação encontrada para o periódico selecionado"
 msgstr "Formas de citação encontrada para o periódico selecionado"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:25
-#: analytics/templates/website/bibliometrics_list_granted.mako:18
-#: analytics/templates/website/bibliometrics_list_received.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:25
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:18
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:25
 msgid "título"
 msgstr "título"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:27
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:27
 msgid "ações"
 msgstr "ações"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:37
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:37
 msgid "reportar erro"
 msgstr "reportar erro"
 
-#: analytics/templates/website/bibliometrics_list_citing_forms.mako:49
-#: analytics/templates/website/bibliometrics_list_granted.mako:35
-#: analytics/templates/website/bibliometrics_list_received.mako:42
+#: /app/analytics/templates/website/bibliometrics_list_citing_forms.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:42
 msgid "sem resultados"
 msgstr "sem resultados"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
-#: analytics/templates/website/navbar_collection.mako:30
-#: analytics/templates/website/navbar_journal.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:30
+#: /app/analytics/templates/website/navbar_journal.mako:32
 msgid "Vida media da citação"
 msgstr "Vida media da citação"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "citações em"
 msgstr "citações em"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:32
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:29
 msgid "para publicações de"
 msgstr "para publicações de"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:33
 msgid "Citação total"
 msgstr "Citação total"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:34
 msgid "Vida media"
 msgstr "Vida media"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:48
 msgid "citações"
 msgstr "citações"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:57
 msgid "percentagem"
 msgstr "percentagem"
 
-#: analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
+#: /app/analytics/templates/website/bibliometrics_list_citing_half_life.mako:66
 msgid "percentagem acumulado"
 msgstr "percentagem acumulado"
 
-#: analytics/templates/website/bibliometrics_list_granted.mako:15
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:5
+msgid "Indicadores Bibliométricos da Rede SciELO"
+msgstr "Indicadores Bibliométricos da Rede SciELO"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid "Periodicidade de atualização:"
+msgstr "Periodicidade de atualização:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:6
+msgid " anual"
+msgstr " anual"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:13
+msgid "Indicadores de Publicação"
+msgstr "Indicadores de Publicação"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:19
+msgid "Numeros da Rede SciELO por:"
+msgstr "Numeros da Rede SciELO por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:21
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:28
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:54
+msgid "Ano de publicação: "
+msgstr "Ano de publicação: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:22
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:29
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:35
+msgid "Periódico: "
+msgstr "Periódico: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:23
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:36
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:55
+msgid "Assunto: "
+msgstr "Assunto: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:24
+msgid "País de afiliação do autor: "
+msgstr "País de afiliação do autor: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:26
+msgid "País de Afiliação do Autor por: "
+msgstr "País de Afiliação do Autor por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:30
+msgid "País de publicação da revista: "
+msgstr "País de publicação da revista: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:33
+msgid "Número de Co-autores por: "
+msgstr "Número de Co-autores por: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:46
+msgid "Indicadores de Coleção"
+msgstr "Indicadores de Coleção"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:52
+msgid "Periódico por:"
+msgstr "Periódico por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:56
+msgid "Indicadores gerais: "
+msgstr "Indicadores gerais: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:66
+msgid "Indicadores de Citação"
+msgstr "Indicadores de Citação"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:72
+msgid "Ano de Citação por:"
+msgstr "Ano de Citação por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:74
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:79
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:84
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:90
+msgid "Idade do documento citado: "
+msgstr "Idade do documento citado: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:75
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:80
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:85
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:91
+msgid "Tipo de documento citado: "
+msgstr "Tipo de documento citado: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:77
+msgid "Periódico Citante por:"
+msgstr "Periódico Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:82
+msgid "Assunto do Periódico Citante por:"
+msgstr "Assunto do Periódico Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:86
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:92
+msgid "Periódico SciELO citado: "
+msgstr "Periódico SciELO citado: "
+
+#: /app/analytics/templates/website/bibliometrics_list_general_indicators.mako:88
+msgid "País de Afiliação do Autor Citante por:"
+msgstr "País de Afiliação do Autor Citante por:"
+
+#: /app/analytics/templates/website/bibliometrics_list_granted.mako:15
 msgid "Citações concedidas por periódico"
 msgstr "Citações concedidas por periódico"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:22
-#: analytics/templates/website/navbar_collection.mako:29
-#: analytics/templates/website/navbar_journal.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:29
+#: /app/analytics/templates/website/navbar_journal.mako:31
 msgid "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 msgstr "Impacto SciELO em 1, 2, 3, 4 e 5 anos"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:30
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:30
 msgid "documentos publicados em"
 msgstr "documentos publicados em"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:31
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:31
 msgid ""
-"Aqui são considerados apenas os documentos citáveis. De acordo com as regras"
-" de contagem do SciELO, documentos citáveis devem ser do tipo Research "
-"Article, Review Article, Case Report, Brief Report, Rapid Communication e "
-"Article Commentary. Os demais tipos de documentos são considerados não "
-"citáveis."
-msgstr "Aqui são considerados apenas os documentos citáveis. De acordo com as regras de contagem do SciELO, documentos citáveis devem ser do tipo Research Article, Review Article, Case Report, Brief Report, Rapid Communication e Article Commentary. Os demais tipos de documentos são considerados não citáveis."
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
+msgstr ""
+"Aqui são considerados apenas os documentos citáveis. De acordo com as "
+"regras de contagem do SciELO, documentos citáveis devem ser do tipo "
+"Research Article, Review Article, Case Report, Brief Report, Rapid "
+"Communication e Article Commentary. Os demais tipos de documentos são "
+"considerados não citáveis."
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:49
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:49
 msgid "2 ano"
 msgstr "2 ano"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:50
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:50
 msgid "3 ano"
 msgstr "3 ano"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:51
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:51
 msgid "4 ano"
 msgstr "4 ano"
 
-#: analytics/templates/website/bibliometrics_list_impact_factor.mako:52
+#: /app/analytics/templates/website/bibliometrics_list_impact_factor.mako:52
 msgid "5 ano"
 msgstr "5 ano"
 
-#: analytics/templates/website/bibliometrics_list_received.mako:22
-#: analytics/templates/website/navbar_collection.mako:33
-#: analytics/templates/website/navbar_journal.mako:35
+#: /app/analytics/templates/website/bibliometrics_list_received.mako:22
+#: /app/analytics/templates/website/navbar_collection.mako:33
+#: /app/analytics/templates/website/navbar_journal.mako:35
 msgid "Citações recebidas por periódicos"
 msgstr "Citações recebidas por periódicos"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:8
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:8
 msgid "Filtros para documentos"
 msgstr "Filtros para documentos"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:22
-#: analytics/templates/website/central_container_for_bibliometric_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:22
+#: /app/analytics/templates/website/central_container_for_bibliometric_filters.mako:22
 msgid "período"
 msgstr "período"
 
-#: analytics/templates/website/central_container_for_article_filters.mako:49
+#: /app/analytics/templates/website/central_container_for_article_filters.mako:49
 msgid "Idioma"
 msgstr "Idioma"
 
-#: analytics/templates/website/central_container_for_journal_filters.mako:8
+#: /app/analytics/templates/website/central_container_for_journal_filters.mako:8
 msgid "Filtros para periódicos"
 msgstr "Filtros para periódicos"
 
-#: analytics/templates/website/faq.mako:5
+#: /app/analytics/templates/website/faq.mako:5
 msgid "Perguntas Frequentes (Acessos)"
 msgstr "Perguntas Frequentes (Acessos)"
 
-#: analytics/templates/website/faq.mako:7
+#: /app/analytics/templates/website/faq.mako:7
 msgid "Por que algumas coleções não possuem estatísticas de acesso?"
 msgstr "Por que algumas coleções não possuem estatísticas de acesso?"
 
-#: analytics/templates/website/faq.mako:8
+#: /app/analytics/templates/website/faq.mako:8
 msgid ""
-"Para que os dados de acessos sejam computados é necessário que os logs de "
-"acessos sejam enviados para processamento. A ausência de estatísticas de "
-"acessos deve ser verificada com a coordenação de cada coleção SciELO."
-msgstr "Para que os dados de acessos sejam computados é necessário que os logs de acessos sejam enviados para processamento. A ausência de estatísticas de acessos deve ser verificada com a coordenação de cada coleção SciELO."
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
+msgstr ""
+"Para que os dados de acessos sejam computados é necessário que os logs de"
+" acessos sejam enviados para processamento. A ausência de estatísticas de"
+" acessos deve ser verificada com a coordenação de cada coleção SciELO."
 
-#: analytics/templates/website/faq.mako:11
-msgid ""
-"Por que algumas coleções possuem acessos computados para um período maior?"
+#: /app/analytics/templates/website/faq.mako:11
+msgid "Por que algumas coleções possuem acessos computados para um período maior?"
 msgstr "Por que algumas coleções possuem acessos computados para um período maior?"
 
-#: analytics/templates/website/faq.mako:12
+#: /app/analytics/templates/website/faq.mako:12
 msgid ""
-"O período disponível de cada uma das coleções depende do período disponível "
-"dos logs de acessos de cada uma das coleções. Este projeto se compromete a "
-"computar os dados de acessos à partir de 2012, desde que os logs sejam "
-"devidamente fornecidos pelas coleções."
-msgstr "O período disponível de cada uma das coleções depende do período disponível dos logs de acessos de cada uma das coleções. Este projeto se compromete a computar os dados de acessos à partir de 2012, desde que os logs sejam devidamente fornecidos pelas coleções."
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
+msgstr ""
+"O período disponível de cada uma das coleções depende do período "
+"disponível dos logs de acessos de cada uma das coleções. Este projeto se "
+"compromete a computar os dados de acessos à partir de 2012, desde que os "
+"logs sejam devidamente fornecidos pelas coleções."
 
-#: analytics/templates/website/faq.mako:15
-#: analytics/templates/website/faq.mako:36
+#: /app/analytics/templates/website/faq.mako:15
+#: /app/analytics/templates/website/faq.mako:36
 msgid "O que esta sendo contabilizado?"
 msgstr "O que esta sendo contabilizado?"
 
-#: analytics/templates/website/faq.mako:16
+#: /app/analytics/templates/website/faq.mako:16
 msgid ""
-"Estão sendo contabilizados e classificados os acessos ao texto completo em "
-"HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
-msgstr "Estão sendo contabilizados e classificados os acessos ao texto completo em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do artigo."
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
+msgstr ""
+"Estão sendo contabilizados e classificados os acessos ao texto completo "
+"em HTML, PDF e EPDF (ReadCube), além dos acessos a páginas de resumo do "
+"artigo."
 
-#: analytics/templates/website/faq.mako:19
+#: /app/analytics/templates/website/faq.mako:19
 msgid ""
 "Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
 "outras ferramentas SciELO?"
-msgstr "Porque os indicadores desta ferramenta são diferentes dos fornecidos em outras ferramentas SciELO?"
+msgstr ""
+"Porque os indicadores desta ferramenta são diferentes dos fornecidos em "
+"outras ferramentas SciELO?"
 
-#: analytics/templates/website/faq.mako:21
+#: /app/analytics/templates/website/faq.mako:21
 msgid ""
-"Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos "
-"de estatísticas de acessos."
-msgstr "Algumas ferramentas SciELO pode ainda estar utilizando os serviços antigos de estatísticas de acessos."
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
+msgstr ""
+"Algumas ferramentas SciELO pode ainda estar utilizando os serviços "
+"antigos de estatísticas de acessos."
 
-#: analytics/templates/website/faq.mako:22
+#: /app/analytics/templates/website/faq.mako:22
 msgid ""
 "A contagem de acessos desta ferramenta difere em diversos aspéctos das "
 "ferramentas antigas."
-msgstr "A contagem de acessos desta ferramenta difere em diversos aspéctos das ferramentas antigas."
+msgstr ""
+"A contagem de acessos desta ferramenta difere em diversos aspéctos das "
+"ferramentas antigas."
 
-#: analytics/templates/website/faq.mako:23
+#: /app/analytics/templates/website/faq.mako:23
 msgid ""
 "Algumas ferramentas possuem um delta de atualização diferenciado dos "
 "indicadores de acessos."
-msgstr "Algumas ferramentas possuem um delta de atualização diferenciado dos indicadores de acessos."
+msgstr ""
+"Algumas ferramentas possuem um delta de atualização diferenciado dos "
+"indicadores de acessos."
 
-#: analytics/templates/website/faq.mako:27
-#: analytics/templates/website/faq.mako:40
+#: /app/analytics/templates/website/faq.mako:27
+#: /app/analytics/templates/website/faq.mako:40
 msgid "Qual a periodicidade de atualização dos indicadores?"
 msgstr "Qual a periodicidade de atualização dos indicadores?"
 
-#: analytics/templates/website/faq.mako:28
+#: /app/analytics/templates/website/faq.mako:28
 msgid "Mensal"
 msgstr "Mensal"
 
-#: analytics/templates/website/faq.mako:30
+#: /app/analytics/templates/website/faq.mako:30
 msgid "Perguntas Frequentes (Publicação)"
 msgstr "Perguntas Frequentes (Publicação)"
 
-#: analytics/templates/website/faq.mako:32
+#: /app/analytics/templates/website/faq.mako:32
 msgid "Porque algumas coleções possuem dados desatualizados?"
 msgstr "Porque algumas coleções possuem dados desatualizados?"
 
-#: analytics/templates/website/faq.mako:33
+#: /app/analytics/templates/website/faq.mako:33
 msgid ""
 "A atualização de dados depende de processos que envolvem cada uma das "
 "coleções certificadas do SciELO. A atualização destes indicadores esta "
 "diretamente ligada a condução adequada desses processos por cada uma das "
 "coleções."
-msgstr "A atualização de dados depende de processos que envolvem cada uma das coleções certificadas do SciELO. A atualização destes indicadores esta diretamente ligada a condução adequada desses processos por cada uma das coleções."
+msgstr ""
+"A atualização de dados depende de processos que envolvem cada uma das "
+"coleções certificadas do SciELO. A atualização destes indicadores esta "
+"diretamente ligada a condução adequada desses processos por cada uma das "
+"coleções."
 
-#: analytics/templates/website/faq.mako:37
+#: /app/analytics/templates/website/faq.mako:37
 msgid ""
-"Estão sendo contabilizados indicadores de publicação das coleções com base "
-"nos metadados fornecidos durante todo o processo de publicação de um "
-"documento no SciELO. A qualidade desses indicadores esta diretamente ligada "
-"a qualidade dos processos implementados por cada uma das coleções."
-msgstr "Estão sendo contabilizados indicadores de publicação das coleções com base nos metadados fornecidos durante todo o processo de publicação de um documento no SciELO. A qualidade desses indicadores esta diretamente ligada a qualidade dos processos implementados por cada uma das coleções."
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
+msgstr ""
+"Estão sendo contabilizados indicadores de publicação das coleções com "
+"base nos metadados fornecidos durante todo o processo de publicação de um"
+" documento no SciELO. A qualidade desses indicadores esta diretamente "
+"ligada a qualidade dos processos implementados por cada uma das coleções."
 
-#: analytics/templates/website/faq.mako:41
+#: /app/analytics/templates/website/faq.mako:41
 msgid "Semanal"
 msgstr "Semanal"
 
-#: analytics/templates/website/home_collection.mako:7
-#: analytics/templates/website/home_journal.mako:7
-#: analytics/templates/website/home_network.mako:7
-#: analytics/templates/website/navbar_collection.mako:18
-#: analytics/templates/website/navbar_journal.mako:18
-#: analytics/templates/website/publication_size.mako:5
+#: /app/analytics/templates/website/home_collection.mako:7
+#: /app/analytics/templates/website/home_journal.mako:7
+#: /app/analytics/templates/website/home_network.mako:7
+#: /app/analytics/templates/website/navbar_collection.mako:18
+#: /app/analytics/templates/website/navbar_journal.mako:18
+#: /app/analytics/templates/website/publication_size.mako:5
 msgid "Composição da coleção"
 msgstr "Composição da coleção"
 
-#: analytics/templates/website/home_collection.mako:24
-#: analytics/templates/website/home_document.mako:21
-#: analytics/templates/website/home_journal.mako:21
-#: analytics/templates/website/home_network.mako:24
-#: analytics/templates/website/navbar_collection.mako:9
-#: analytics/templates/website/navbar_collection.mako:27
-#: analytics/templates/website/navbar_document.mako:9
-#: analytics/templates/website/navbar_journal.mako:9
-#: analytics/templates/website/navbar_journal.mako:26
+#: /app/analytics/templates/website/home_collection.mako:24
+#: /app/analytics/templates/website/home_document.mako:21
+#: /app/analytics/templates/website/home_journal.mako:21
+#: /app/analytics/templates/website/home_network.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:9
+#: /app/analytics/templates/website/navbar_collection.mako:27
+#: /app/analytics/templates/website/navbar_document.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:9
+#: /app/analytics/templates/website/navbar_journal.mako:26
 msgid "Gráficos"
 msgstr "Gráficos"
 
-#: analytics/templates/website/home_document.mako:7
+#: /app/analytics/templates/website/home_document.mako:7
 msgid "Indicadores do documento"
 msgstr "Indicadores do documento"
 
-#: analytics/templates/website/journal_selector_modal.mako:6
+#: /app/analytics/templates/website/journal_selector_modal.mako:6
 msgid "fechar"
 msgstr "fechar"
 
-#: analytics/templates/website/journal_selector_modal.mako:11
+#: /app/analytics/templates/website/journal_selector_modal.mako:11
 msgid "selecionar um periódico"
 msgstr "selecionar um periódico"
 
-#: analytics/templates/website/journal_selector_modal.mako:20
+#: /app/analytics/templates/website/journal_selector_modal.mako:20
 msgid "selecionar"
 msgstr "selecionar"
 
-#: analytics/templates/website/navbar_collection.mako:11
-#: analytics/templates/website/navbar_journal.mako:11
+#: /app/analytics/templates/website/navbar_collection.mako:11
+#: /app/analytics/templates/website/navbar_journal.mako:11
 msgid "Top 100 Issues"
 msgstr "Top 100 Issues"
 
-#: analytics/templates/website/navbar_collection.mako:12
-#: analytics/templates/website/navbar_journal.mako:12
+#: /app/analytics/templates/website/navbar_collection.mako:12
+#: /app/analytics/templates/website/navbar_journal.mako:12
 msgid "Top 100 Artigos"
 msgstr "Top 100 Artigos"
 
-#: analytics/templates/website/navbar_collection.mako:16
-#: analytics/templates/website/navbar_journal.mako:16
+#: /app/analytics/templates/website/navbar_collection.mako:16
+#: /app/analytics/templates/website/navbar_journal.mako:16
 msgid "Publicação"
 msgstr "Publicação"
 
-#: analytics/templates/website/navbar_collection.mako:19
-#: analytics/templates/website/navbar_journal.mako:19
+#: /app/analytics/templates/website/navbar_collection.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:19
 msgid "Gráficos de documentos"
 msgstr "Gráficos de documentos"
 
-#: analytics/templates/website/navbar_collection.mako:20
-#: analytics/templates/website/navbar_journal.mako:20
+#: /app/analytics/templates/website/navbar_collection.mako:20
+#: /app/analytics/templates/website/navbar_journal.mako:20
 msgid "Gráficos de documentos por ano de publicação"
 msgstr "Gráficos de documentos por ano de publicação"
 
-#: analytics/templates/website/navbar_collection.mako:21
+#: /app/analytics/templates/website/navbar_collection.mako:21
 msgid "Gráficos de periódicos"
 msgstr "Gráficos de periódicos"
 
-#: analytics/templates/website/navbar_collection.mako:25
-#: analytics/templates/website/navbar_document.mako:13
-#: analytics/templates/website/navbar_journal.mako:24
+#: /app/analytics/templates/website/navbar_collection.mako:25
+#: /app/analytics/templates/website/navbar_document.mako:13
+#: /app/analytics/templates/website/navbar_journal.mako:24
 msgid "Bibliometria"
 msgstr "Bibliometria"
 
-#: analytics/templates/website/navbar_collection.mako:32
-#: analytics/templates/website/navbar_journal.mako:34
+#: /app/analytics/templates/website/navbar_collection.mako:32
+#: /app/analytics/templates/website/navbar_journal.mako:34
 msgid "Citações concedidas por periódicos"
 msgstr "Citações concedidas por periódicos"
 
-#: analytics/templates/website/navbar_collection.mako:34
-#: analytics/templates/website/navbar_journal.mako:36
+#: /app/analytics/templates/website/navbar_collection.mako:34
+#: /app/analytics/templates/website/navbar_journal.mako:36
 msgid "Formas de citação do periódico"
 msgstr "Formas de citação do periódico"
 
-#: analytics/templates/website/navbar_collection.mako:38
-#: analytics/templates/website/navbar_document.mako:19
-#: analytics/templates/website/navbar_journal.mako:40
+#: /app/analytics/templates/website/navbar_collection.mako:35
+#: /app/analytics/templates/website/navbar_journal.mako:37
+msgid "Indicadores Gerais"
+msgstr "Indicadores Gerais"
+
+#: /app/analytics/templates/website/navbar_collection.mako:39
+#: /app/analytics/templates/website/navbar_document.mako:19
+#: /app/analytics/templates/website/navbar_journal.mako:41
 msgid "Relatórios"
 msgstr "Relatórios"
 
-#: analytics/templates/website/navbar_document.mako:15
+#: /app/analytics/templates/website/navbar_document.mako:15
 msgid "Received citations"
 msgstr "Received citations"
 
-#: analytics/templates/website/publication_article.mako:17
+#: /app/analytics/templates/website/publication_article.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. A disponibilidade de indicadores de licença de uso dependem da "
-"adoção da coleção ou periódico selecionado de licenças de uso creative "
-"commons."
-msgstr "Este gráfico apresenta a distribuição de documentos por licença de uso. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. A disponibilidade de indicadores de licença de uso dependem da adoção da coleção ou periódico selecionado de licenças de uso creative commons."
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por licença de uso. "
+"Os números são relacionados a coleção ou ao periódico quando um periódico"
+" é selecionado. A disponibilidade de indicadores de licença de uso "
+"dependem da adoção da coleção ou periódico selecionado de licenças de uso"
+" creative commons."
 
-#: analytics/templates/website/publication_article.mako:24
-#: analytics/templates/website/publication_article_by_publication_year.mako:24
+#: /app/analytics/templates/website/publication_article.mako:24
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:24
 msgid "Áreas temáticas"
 msgstr "Áreas temáticas"
 
-#: analytics/templates/website/publication_article.mako:36
+#: /app/analytics/templates/website/publication_article.mako:36
 msgid ""
-"Este gráfico apresenta o total de documentos publicados por área de atuação."
-" Os números são relacionados a coleção ou ao periódico quando um periódico é"
-" selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas "
-"são determinadas para cada um dos periódicos SciELO, podendo um periódico "
-"estar relacionado a mais de uma área de atuação. Os valores totais de "
-"documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode fazer parte de mais de "
-"uma área de atuação. Este gráfico é recomendado para extração de indicadores"
-" de Coleção."
-msgstr "Este gráfico apresenta o total de documentos publicados por área de atuação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. As áreas de atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, podendo um periódico estar relacionado a mais de uma área de atuação. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode fazer parte de mais de uma área de atuação. Este gráfico é recomendado para extração de indicadores de Coleção."
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
+msgstr ""
+"Este gráfico apresenta o total de documentos publicados por área de "
+"atuação. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado. As áreas de atuação são as grandes áreas do "
+"CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, "
+"podendo um periódico estar relacionado a mais de uma área de atuação. Os "
+"valores totais de documentos deste gráfico não podem ser considerados "
+"como totais de publicações da coleção uma vez que um documento pode fazer"
+" parte de mais de uma área de atuação. Este gráfico é recomendado para "
+"extração de indicadores de Coleção."
 
-#: analytics/templates/website/publication_article.mako:55
+#: /app/analytics/templates/website/publication_article.mako:55
 msgid ""
 "Este gráfico apresenta o total de documentos por tipo de documento. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
 "Citation Index e documentados no SciELO Publishing Schema."
-msgstr "Este gráfico apresenta o total de documentos por tipo de documento. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. Os tipos de documento são os tipos utilizandos no SciELO Citation Index e documentados no SciELO Publishing Schema."
+msgstr ""
+"Este gráfico apresenta o total de documentos por tipo de documento. Os "
+"números são relacionados a coleção ou ao periódico quando um periódico é "
+"selecionado. Os tipos de documento são os tipos utilizandos no SciELO "
+"Citation Index e documentados no SciELO Publishing Schema."
 
-#: analytics/templates/website/publication_article.mako:61
-#: analytics/templates/website/publication_article_by_publication_year.mako:61
+#: /app/analytics/templates/website/publication_article.mako:61
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:61
 msgid "Idiomas dos documentos"
 msgstr "Idiomas dos documentos"
 
-#: analytics/templates/website/publication_article.mako:73
+#: /app/analytics/templates/website/publication_article.mako:73
 msgid ""
-"Este gráfico apresenta o total de documentos por idioma de publicação. Os "
-"números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ser publicado em mais de um idioma."
-msgstr "Este gráfico apresenta o total de documentos por idioma de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode ser publicado em mais de um idioma."
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
+msgstr ""
+"Este gráfico apresenta o total de documentos por idioma de publicação. Os"
+" números são relacionados a coleção ou ao periódico quando um periódico é"
+" selecionado. Os valores totais de documentos deste gráfico não podem ser"
+" considerados como totais de publicações da coleção uma vez que um "
+"documento pode ser publicado em mais de um idioma."
 
-#: analytics/templates/website/publication_article.mako:79
+#: /app/analytics/templates/website/publication_article.mako:79
 msgid "Anos de publicação"
 msgstr "Anos de publicação"
 
-#: analytics/templates/website/publication_article.mako:91
+#: /app/analytics/templates/website/publication_article.mako:91
 msgid ""
 "Este gráfico apresenta o total de documentos publicados por ano de "
-"publicação. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado."
-msgstr "Este gráfico apresenta o total de documentos publicados por ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado."
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
+msgstr ""
+"Este gráfico apresenta o total de documentos publicados por ano de "
+"publicação. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado."
 
-#: analytics/templates/website/publication_article.mako:97
-#: analytics/templates/website/publication_article_by_publication_year.mako:79
+#: /app/analytics/templates/website/publication_article.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:79
 msgid "Países de afiliação"
 msgstr "Países de afiliação"
 
-#: analytics/templates/website/publication_article.mako:109
+#: /app/analytics/templates/website/publication_article.mako:109
 msgid ""
 "Este gráfico apresenta o total de documentos por país de afiliação dos "
 "autores. Os valores totais de documentos deste gráfico não podem ser "
-"considerados como totais de publicações da coleção uma vez que um documento "
-"pode ter mais um país de afiliação."
-msgstr "Este gráfico apresenta o total de documentos por país de afiliação dos autores. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode ter mais um país de afiliação."
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"Este gráfico apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste gráfico não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
 
-#: analytics/templates/website/publication_article.mako:115
+#: /app/analytics/templates/website/publication_article.mako:115
 msgid "Mapa de países de afiliação"
 msgstr "Mapa de países de afiliação"
 
-#: analytics/templates/website/publication_article.mako:127
+#: /app/analytics/templates/website/publication_article.mako:127
 msgid ""
-"Este mapa apresenta o total de documentos por país de afiliação dos autores."
-" Os valores totais de documentos deste mapa não podem ser considerados como "
-"totais de publicações da coleção uma vez que um documento pode ter mais um "
-"país de afiliação."
-msgstr "Este mapa apresenta o total de documentos por país de afiliação dos autores. Os valores totais de documentos deste mapa não podem ser considerados como totais de publicações da coleção uma vez que um documento pode ter mais um país de afiliação."
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
+msgstr ""
+"Este mapa apresenta o total de documentos por país de afiliação dos "
+"autores. Os valores totais de documentos deste mapa não podem ser "
+"considerados como totais de publicações da coleção uma vez que um "
+"documento pode ter mais um país de afiliação."
 
-#: analytics/templates/website/publication_article.mako:145
+#: /app/analytics/templates/website/publication_article.mako:145
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por número de autores. "
-"Os números são relacionados a coleção ou ao periódico quando um periódico é "
-"selecionado."
-msgstr "Este gráfico apresenta a distribuição de documentos por número de autores. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado."
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por número de "
+"autores. Os números são relacionados a coleção ou ao periódico quando um "
+"periódico é selecionado."
 
-#: analytics/templates/website/publication_article.mako:151
+#: /app/analytics/templates/website/publication_article.mako:151
 msgid "Número de referências bibliográficas"
 msgstr "Número de referências bibliográficas"
 
-#: analytics/templates/website/publication_article.mako:163
+#: /app/analytics/templates/website/publication_article.mako:163
 msgid ""
 "Este gráfico apresenta a distribuição de documentos por número de "
 "referências bibliográficas. Os números são relacionados a coleção ou ao "
 "periódico quando um periódico é selecionado."
-msgstr "Este gráfico apresenta a distribuição de documentos por número de referências bibliográficas. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por número de "
+"referências bibliográficas. Os números são relacionados a coleção ou ao "
+"periódico quando um periódico é selecionado."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:17
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:17
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por licença de uso e ano"
-" de publicação. Os números são relacionados a coleção ou ao periódico quando"
-" um periódico é selecionado. A disponibilidade de indicadores de licença de "
-"uso dependem da adoção da coleção ou periódico selecionado de licenças de "
-"uso creative commons."
-msgstr "Este gráfico apresenta a distribuição de documentos por licença de uso e ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. A disponibilidade de indicadores de licença de uso dependem da adoção da coleção ou periódico selecionado de licenças de uso creative commons."
-
-#: analytics/templates/website/publication_article_by_publication_year.mako:36
-msgid ""
-"Este gráfico apresenta a distribuição de documentos por área de atuação e "
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
 "ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode fazer parte de mais de uma área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Este gráfico apresenta a distribuição de documentos por área de atuação e ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode fazer parte de mais de uma área de atuação. Este gráfico é recomendado para extração de indicadores de Coleção."
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por licença de uso e "
+"ano de publicação. Os números são relacionados a coleção ou ao periódico "
+"quando um periódico é selecionado. A disponibilidade de indicadores de "
+"licença de uso dependem da adoção da coleção ou periódico selecionado de "
+"licenças de uso creative commons."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:55
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:36
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por tipo de publicação e"
-" ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado."
-msgstr "Este gráfico apresenta a distribuição de documentos por tipo de publicação e ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado."
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por área de atuação e"
+" ano de publicação. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado. Os valores totais de documentos deste"
+" gráfico não podem ser considerados como totais de publicações da coleção"
+" uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:73
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:55
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por idioma de publicação"
-" e ano de publicação. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado. Os valores totais de documentos deste "
-"gráfico não podem ser considerados como totais de publicações da coleção uma"
-" vez que um documento pode ser publicado em mais de um idioma."
-msgstr "Este gráfico apresenta a distribuição de documentos por idioma de publicação e ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode ser publicado em mais de um idioma."
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por tipo de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:91
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:73
 msgid ""
-"Este gráfico apresenta a distribuição de documentos por país de afiliação "
-"dos autores e ano de publicação. Os números são relacionados a coleção ou ao"
-" periódico quando um periódico é selecionado. Os valores totais de "
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
 "documentos deste gráfico não podem ser considerados como totais de "
-"publicações da coleção uma vez que um documento pode ser publicado por mais "
-"de um país de afiliação."
-msgstr "Este gráfico apresenta a distribuição de documentos por país de afiliação dos autores e ano de publicação. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado. Os valores totais de documentos deste gráfico não podem ser considerados como totais de publicações da coleção uma vez que um documento pode ser publicado por mais de um país de afiliação."
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por idioma de "
+"publicação e ano de publicação. Os números são relacionados a coleção ou "
+"ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado em "
+"mais de um idioma."
 
-#: analytics/templates/website/publication_article_by_publication_year.mako:97
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:91
+msgid ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+msgstr ""
+"Este gráfico apresenta a distribuição de documentos por país de afiliação"
+" dos autores e ano de publicação. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado. Os valores totais de "
+"documentos deste gráfico não podem ser considerados como totais de "
+"publicações da coleção uma vez que um documento pode ser publicado por "
+"mais de um país de afiliação."
+
+#: /app/analytics/templates/website/publication_article_by_publication_year.mako:97
 msgid "Citações recebidas, concedidas e auto citações"
 msgstr "Citações recebidas, concedidas e auto citações"
 
-#: analytics/templates/website/publication_journal_licenses.mako:17
-msgid ""
-"Este gráfico apresenta o número de periódicos por licença de uso adotada. Os"
-" valores totais de periódicos deste gráfico não podem ser considerados como "
-"totais da coleção uma vez que um documento pode fazer parte de mais de uma "
-"área de atuação. Este gráfico é recomendado para extração de indicadores de "
-"Coleção."
-msgstr "Este gráfico apresenta o número de periódicos por licença de uso adotada. Os valores totais de periódicos deste gráfico não podem ser considerados como totais da coleção uma vez que um documento pode fazer parte de mais de uma área de atuação. Este gráfico é recomendado para extração de indicadores de Coleção."
+#: /app/analytics/templates/website/publication_journal.mako:5
+msgid "Licenças de uso dos periódicos"
+msgstr ""
 
-#: analytics/templates/website/publication_journal_status.mako:17
+#: /app/analytics/templates/website/publication_journal.mako:10
+msgid "Áreas temáticas dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:15
+msgid "Ano de inclusão de periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal.mako:19
+msgid "Situação de publicação dos periódicos"
+msgstr ""
+
+#: /app/analytics/templates/website/publication_journal_licenses.mako:17
 msgid ""
-"Este gráfico apresenta o número de periódicos por status da publicação no "
-"SciELO. O status considerado neste grafíco é o status vigente do periódico, "
-"não são consideradas as mudanças de status a longo da existência do "
-"periódico nas bases SciELO. Este gráfico é recomendado para extração de "
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
 "indicadores de Coleção."
-msgstr "Este gráfico apresenta o número de periódicos por status da publicação no SciELO. O status considerado neste grafíco é o status vigente do periódico, não são consideradas as mudanças de status a longo da existência do periódico nas bases SciELO. Este gráfico é recomendado para extração de indicadores de Coleção."
+msgstr ""
+"Este gráfico apresenta o número de periódicos por licença de uso adotada."
+" Os valores totais de periódicos deste gráfico não podem ser considerados"
+" como totais da coleção uma vez que um documento pode fazer parte de mais"
+" de uma área de atuação. Este gráfico é recomendado para extração de "
+"indicadores de Coleção."
 
-#: analytics/templates/website/publication_journal_subject_areas.mako:17
+#: /app/analytics/templates/website/publication_journal_status.mako:17
+msgid ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+msgstr ""
+"Este gráfico apresenta o número de periódicos por status da publicação no"
+" SciELO. O status considerado neste grafíco é o status vigente do "
+"periódico, não são consideradas as mudanças de status a longo da "
+"existência do periódico nas bases SciELO. Este gráfico é recomendado para"
+" extração de indicadores de Coleção."
+
+#: /app/analytics/templates/website/publication_journal_subject_areas.mako:17
 msgid ""
 "Este gráfico apresenta o número de periódicos por área de atuação. Este "
-"gráfico é recomendado para extração de indicadores de Coleção. As áreas de "
-"atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada"
-" um dos periódicos SciELO, podendo um periódico estar relacionado a mais de "
-"uma área de atuação. Os valores totais de periódicos deste gráfico não podem"
-" ser considerados como totais da coleção uma vez que um documento pode fazer"
-" parte de mais de uma área de atuação. Este gráfico é recomendado para "
-"extração de indicadores de Coleção."
-msgstr "Este gráfico apresenta o número de periódicos por área de atuação. Este gráfico é recomendado para extração de indicadores de Coleção. As áreas de atuação são as grandes áreas do CNPQ, essas áreas são determinadas para cada um dos periódicos SciELO, podendo um periódico estar relacionado a mais de uma área de atuação. Os valores totais de periódicos deste gráfico não podem ser considerados como totais da coleção uma vez que um documento pode fazer parte de mais de uma área de atuação. Este gráfico é recomendado para extração de indicadores de Coleção."
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
+msgstr ""
+"Este gráfico apresenta o número de periódicos por área de atuação. Este "
+"gráfico é recomendado para extração de indicadores de Coleção. As áreas "
+"de atuação são as grandes áreas do CNPQ, essas áreas são determinadas "
+"para cada um dos periódicos SciELO, podendo um periódico estar "
+"relacionado a mais de uma área de atuação. Os valores totais de "
+"periódicos deste gráfico não podem ser considerados como totais da "
+"coleção uma vez que um documento pode fazer parte de mais de uma área de "
+"atuação. Este gráfico é recomendado para extração de indicadores de "
+"Coleção."
 
-#: analytics/templates/website/publication_journal_year.mako:17
+#: /app/analytics/templates/website/publication_journal_year.mako:17
 msgid ""
-"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. "
-"Este gráfico é recomendado para extração de indicadores de Coleção."
-msgstr "Este gráfico apresenta o número periódicos por ano de inclusão no SciELO. Este gráfico é recomendado para extração de indicadores de Coleção."
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
+msgstr ""
+"Este gráfico apresenta o número periódicos por ano de inclusão no SciELO."
+" Este gráfico é recomendado para extração de indicadores de Coleção."
 
-#: analytics/templates/website/publication_size.mako:11
-#: analytics/templates/website/publication_size.mako:22
-#: analytics/templates/website/publication_size.mako:33
-#: analytics/templates/website/publication_size.mako:44
+#: /app/analytics/templates/website/publication_size.mako:11
+#: /app/analytics/templates/website/publication_size.mako:22
+#: /app/analytics/templates/website/publication_size.mako:33
+#: /app/analytics/templates/website/publication_size.mako:44
 msgid "Sobre os números"
 msgstr "Sobre os números"
 
-#: analytics/templates/website/publication_size.mako:14
+#: /app/analytics/templates/website/publication_size.mako:14
 msgid ""
-"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e "
-"artigo publicados. Os números são relacionados a coleção ou ao periódico "
-"quando um periódico é selecionado na barra superior do site."
-msgstr "Os números acima correspondem aos periódicos com pelo menos 1 fascículo e artigo publicados. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado na barra superior do site."
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
+msgstr ""
+"Os números acima correspondem aos periódicos com pelo menos 1 fascículo e"
+" artigo publicados. Os números são relacionados a coleção ou ao periódico"
+" quando um periódico é selecionado na barra superior do site."
 
-#: analytics/templates/website/publication_size.mako:25
+#: /app/analytics/templates/website/publication_size.mako:25
 msgid ""
 "Os números acima correspondem aos fascículos com pelo menos 1 artigo "
-"publicado. Os números são relacionados a coleção ou ao periódico quando um "
-"periódico é selecionado na barra superior do site."
-msgstr "Os números acima correspondem aos fascículos com pelo menos 1 artigo publicado. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado na barra superior do site."
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
+msgstr ""
+"Os números acima correspondem aos fascículos com pelo menos 1 artigo "
+"publicado. Os números são relacionados a coleção ou ao periódico quando "
+"um periódico é selecionado na barra superior do site."
 
-#: analytics/templates/website/publication_size.mako:36
+#: /app/analytics/templates/website/publication_size.mako:36
 msgid ""
 "Os números a cima correspondem ao número de documentos publicados. Os "
 "números são relacionados a coleção ou ao periódico quando um periódico é "
 "selecionado na barra superior do site."
-msgstr "Os números a cima correspondem ao número de documentos publicados. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado na barra superior do site."
+msgstr ""
+"Os números a cima correspondem ao número de documentos publicados. Os "
+"números são relacionados a coleção ou ao periódico quando um periódico é "
+"selecionado na barra superior do site."
 
-#: analytics/templates/website/publication_size.mako:47
+#: /app/analytics/templates/website/publication_size.mako:47
 msgid ""
 "Os números acima correspondem ao número das referências bibliográficas "
-"citadas nos documentos publicados. Os números são relacionados a coleção ou "
-"ao periódico quando um periódico é selecionado na barra superior do site."
-msgstr "Os números acima correspondem ao número das referências bibliográficas citadas nos documentos publicados. Os números são relacionados a coleção ou ao periódico quando um periódico é selecionado na barra superior do site."
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
+msgstr ""
+"Os números acima correspondem ao número das referências bibliográficas "
+"citadas nos documentos publicados. Os números são relacionados a coleção "
+"ou ao periódico quando um periódico é selecionado na barra superior do "
+"site."
 
-#: analytics/templates/website/publication_size_citations.mako:9
+#: /app/analytics/templates/website/publication_size_citations.mako:9
 msgid "referências"
 msgstr "referências"
 
-#: analytics/templates/website/publication_size_documents.mako:9
+#: /app/analytics/templates/website/publication_size_documents.mako:9
 msgid "documentos"
 msgstr "documentos"
 
-#: analytics/templates/website/publication_size_issues.mako:9
+#: /app/analytics/templates/website/publication_size_issues.mako:9
 msgid "fascículos"
 msgstr "fascículos"
 
-#: analytics/templates/website/publication_size_journals.mako:9
+#: /app/analytics/templates/website/publication_size_journals.mako:10
 msgid "periódicos"
 msgstr "periódicos"
 
-#: analytics/templates/website/reports.mako:5
+#: /app/analytics/templates/website/reports.mako:5
 msgid "Tabulações"
 msgstr "Tabulações"
 
-#: analytics/templates/website/reports.mako:7
+#: /app/analytics/templates/website/reports.mako:7
 msgid ""
-"O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados "
-"utilizados para produção dos indicadores presentes nesta ferramenta. "
-"Qualquer interessado pode fazer o download e produzir análises "
-"bibliométricas de acordo com suas necessidade."
-msgstr "O SciELO fornece algumas tabulações pré-formatadas com alguns dos metadados utilizados para produção dos indicadores presentes nesta ferramenta. Qualquer interessado pode fazer o download e produzir análises bibliométricas de acordo com suas necessidade."
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
+msgstr ""
+"O SciELO fornece algumas tabulações pré-formatadas com alguns dos "
+"metadados utilizados para produção dos indicadores presentes nesta "
+"ferramenta. Qualquer interessado pode fazer o download e produzir "
+"análises bibliométricas de acordo com suas necessidade."
 
-#: analytics/templates/website/reports.mako:10
-msgid ""
-"Para mais informações sobre as catacterísticas de cada tabulação, acessar"
+#: /app/analytics/templates/website/reports.mako:10
+msgid "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 msgstr "Para mais informações sobre as catacterísticas de cada tabulação, acessar"
 
-#: analytics/templates/website/reports.mako:16
+#: /app/analytics/templates/website/reports.mako:16
 msgid "nome do arquivo"
 msgstr "nome do arquivo"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "periodicidade de atualização"
 msgstr "periodicidade de atualização"
 
-#: analytics/templates/website/reports.mako:17
+#: /app/analytics/templates/website/reports.mako:17
 msgid "mensal"
 msgstr "mensal"
 
-#: analytics/templates/website/reports.mako:18
+#: /app/analytics/templates/website/reports.mako:18
 msgid "tamanho do arquivo"
 msgstr "tamanho do arquivo"
 
-#: analytics/templates/website/reports.mako:19
+#: /app/analytics/templates/website/reports.mako:19
 msgid "conjunto de caracteres"
 msgstr "conjunto de caracteres"
 
-#: analytics/templates/website/reports.mako:20
+#: /app/analytics/templates/website/reports.mako:20
 msgid "última atualização"
 msgstr "última atualização"
 
-#: analytics/templates/website/reports.mako:23
+#: /app/analytics/templates/website/reports.mako:23
 msgid "arquivo não disponível para esta coleção"
 msgstr "arquivo não disponível para esta coleção"
 
-#: analytics/templates/website/share.mako:8
+#: /app/analytics/templates/website/share.mako:8
 msgid "compartilhar por email"
 msgstr "compartilhar por email"
 
-#: analytics/templates/website/share.mako:10
+#: /app/analytics/templates/website/share.mako:10
 msgid "compartilhar no Facebook"
 msgstr "compartilhar no Facebook"
 
-#: analytics/templates/website/share.mako:13
+#: /app/analytics/templates/website/share.mako:13
 msgid "compartilhar no Twitter"
 msgstr "compartilhar no Twitter"
 
-#: analytics/templates/website/share.mako:16
+#: /app/analytics/templates/website/share.mako:16
 msgid "compartilhar no LinkedIn"
 msgstr "compartilhar no LinkedIn"

--- a/analytics/templates/website/bibliometrics_journal.mako
+++ b/analytics/templates/website/bibliometrics_journal.mako
@@ -69,7 +69,7 @@
                 <h3 class="panel-title">${_(u'Sobre o gráfico')}</h3>
               </div>
               <div class="panel-body">
-                  ${_(u'Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os idicadores são fornecidos anualmente pelo Google Scholar. A ausência de indicadores para um periódico ou para um período de um periódico pode ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, você será direcionado para o site do Google Scholar.')}
+                  ${_(u'Este gráfico apresenta os indices H5 e M5 do Google Scholar. Os indicadores são fornecidos anualmente pelo Google Scholar. A ausência de indicadores para um periódico ou para um período de um periódico pode ocorrer caso esses dados não tenham sido fornecidos pelo Google Scholar. Ao clicar na série, você será direcionado para o site do Google Scholar.')}
               </div>
             </div>
           </div>

--- a/analytics/templates/website/bibliometrics_list_general_indicators.mako
+++ b/analytics/templates/website/bibliometrics_list_general_indicators.mako
@@ -1,0 +1,98 @@
+## coding: utf-8
+<%inherit file="central_container_without_filters.mako"/>
+<%block name="central_container">
+
+  <h3>${_(u'Indicadores Bibliométricos da Rede SciELO')}</h3>
+  <h5><b>${_(u'Periodicidade de atualização:')}</b>${_(u' anual')}</h5>
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <!-- collapseOne -->
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingOne">
+          <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+            ${_(u'Indicadores de Publicação')}
+            </a>
+          </h4>
+        </div>
+        <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+          <div class="panel-body">
+            <b>${_(u'Numeros da Rede SciELO por:')}</b>
+            <ul>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/A01a_${locale}.xls">A01a_${locale}.xls</a></li>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A01b_${locale}.xls">A01b_${locale}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A01c_${locale}.xls">A01c_${locale}.xls</a></li>
+              <li>${_(u'País de afiliação do autor: ')}<a href="https://static.scielo.org/indicators/${locale}/A01d_${locale}.xls">A01d_${locale}.xls</a></li>
+            </ul>
+            <b>${_(u'País de Afiliação do Autor por: ')}</b>
+            <ul>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/A02a_${locale}.xls">A02a_${locale}.xls</a></li>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A02b_${locale}.xls">A02b_${locale}.xls</a></li>
+              <li>${_(u'País de publicação da revista: ')}<a href="https://static.scielo.org/indicators/${locale}/A02c_${locale}.xls">A02c_${locale}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A02d_${locale}.xls">A02d_${locale}.xls</a></li>
+            </ul>
+            <b>${_(u'Número de Co-autores por: ')}</b>
+            <ul>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A03a_${locale}.xls">A03a_${locale}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A03b_${locale}.xls">A03b_${locale}.xls</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <!-- collapseTwo -->
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingTwo">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+              ${_(u'Indicadores de Coleção')}
+            </a>
+          </h4>
+        </div>
+        <div id="collapseTwo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
+          <div class="panel-body">
+            <b>${_(u'Periódico por:')}</b>
+            <ul>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/B01a_${locale}.xls">B01a_${locale}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/B01b_${locale}.xls">B01b_${locale}.xls</a></li>
+              <li>${_(u'Indicadores gerais: ')}<a href="https://static.scielo.org/indicators/${locale}/B01c_${locale}.xls">B01c_${locale}.xls</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <!-- collapseThree -->
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingThree">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+              ${_(u'Indicadores de Citação')}
+            </a>
+          </h4>
+        </div>
+        <div id="collapseThree" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingThree">
+          <div class="panel-body">
+            <b>${_(u'Ano de Citação por:')}</b>
+            <ul>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C01a_${locale}.xls">C01a_${locale}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C01b_${locale}.xls">C01b_${locale}.xls</a></li>
+            </ul>
+            <b>${_(u'Periódico Citante por:')}</b>
+            <ul>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C02a_${locale}.xls">C02a_${locale}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C02b_${locale}.xls">C02b_${locale}.xls</a></li>
+            </ul>
+            <b>${_(u'Assunto do Periódico Citante por:')}</b>
+            <ul>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03a_${locale}.xls">C03a_${locale}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03b_${locale}.xls">C03b_${locale}.xls</a></li>
+              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03c_${locale}.xls">C03c_${locale}.xls</a></li>
+            </ul>
+            <b>${_(u'País de Afiliação do Autor Citante por:')}</b>
+            <ul>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04a_${locale}.xls">C04a_${locale}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04b_${locale}.xls">C04b_${locale}.xls</a></li>
+              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04c_${locale}.xls">C04c_${locale}.xls</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+</%block>

--- a/analytics/templates/website/navbar_collection.mako
+++ b/analytics/templates/website/navbar_collection.mako
@@ -32,6 +32,7 @@
       <li><a href="${request.route_url('bibliometrics_list_granted_web')}">${_(u'Citações concedidas por periódicos')}</a></li>
       <li><a href="${request.route_url('bibliometrics_list_received_web')}">${_(u'Citações recebidas por periódicos')}</a></li>
       <li><a href="${request.route_url('bibliometrics_list_citing_forms_web')}">${_(u'Formas de citação do periódico')}</a></li>
+      <li><a href="${request.route_url('bibliometrics_list_general_indicators_web')}">${_(u'Indicadores Gerais')}</a></li>
     </ul>
   </li>
   <li class="${'active' if page == 'reports' else ''}">

--- a/analytics/templates/website/navbar_journal.mako
+++ b/analytics/templates/website/navbar_journal.mako
@@ -34,6 +34,7 @@
       <li><a href="${request.route_url('bibliometrics_list_granted_web')}">${_(u'Citações concedidas por periódicos')}</a></li>
       <li><a href="${request.route_url('bibliometrics_list_received_web')}">${_(u'Citações recebidas por periódicos')}</a></li>
       <li><a href="${request.route_url('bibliometrics_list_citing_forms_web')}">${_(u'Formas de citação do periódico')}</a></li>
+      <li><a href="${request.route_url('bibliometrics_list_general_indicators_web')}">${_(u'Indicadores Gerais')}</a></li>
     </ul>
   </li>
   <li class="${'active' if page == 'reports' else ''}">

--- a/analytics/views_website.py
+++ b/analytics/views_website.py
@@ -149,6 +149,15 @@ def bibliometrics_list_citing_half_life(request):
     return data
 
 
+@view_config(route_name='bibliometrics_list_general_indicators_web', renderer='templates/website/bibliometrics_list_general_indicators.mako')
+@base_data_manager
+def bibliometrics_list_general_indicators(request):
+    data = request.data_manager
+    data['page'] = 'bibliometrics'
+
+    return data
+
+
 @view_config(route_name='bibliometrics_list_citing_forms_web', renderer='templates/website/bibliometrics_list_citing_forms.mako')
 @base_data_manager
 def bibliometrics_list_citing_forms(request):

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,2 @@
+[python: **.py]
+[mako: **/templates/**.mako]


### PR DESCRIPTION
#### O que esse PR faz?
Implementa o submenu para download de planilhas de indicadores bibliométricos.

#### Onde a revisão poderia começar?

Rota:
https://github.com/ednilson/analytics/blob/tk_132/analytics/__init__.py

View:
https://github.com/ednilson/analytics/blob/tk_132/analytics/views_website.py

Templates:
https://github.com/ednilson/analytics/blob/tk_132/analytics/templates/website/bibliometrics_list_general_indicators.mako
https://github.com/ednilson/analytics/blob/tk_132/analytics/templates/website/navbar_journal.mako
https://github.com/ednilson/analytics/blob/tk_132/analytics/templates/website/navbar_collection.mako

#### Como este poderia ser testado manualmente?
1 - Acesse o menu Bibliometrics >> General Indicators
2 - Abrirá uma página com 3 categorias de idicadores. Clique numa das categorias. Nota: aqui foi utilizado o  componente collapse-accordion do bootstrap - veja fig. abaixo.
3 - Clique num dos links e baixe a planilha. 

#### Algum cenário de contexto que queira dar?
Este template foi criado com base no acesso às planilhas do antigo site scielo org: 
http://old.scielo.org/php/level.php?lang=es&component=44&item=25

Foi adicionado um arquivo de configuração "babel.cfg" usado como arquivo de mapeamento de extração.

### Screenshots
![image](https://user-images.githubusercontent.com/454847/65152898-345e6480-d9ff-11e9-8523-bce985c37351.png)


#### Quais são tickets relevantes?
#132 

### Referências
https://getbootstrap.com/docs/3.3/javascript/#collapse-example-accordion
http://babel.pocoo.org/en/latest/cmdline.html?highlight=MAPPING_FILE#extract
