### PR TITLE
Corrige selecao de idioma para es_MX

### DIFF
--- a/analytics/templates/website/bibliometrics_list_general_indicators.mako
+++ b/analytics/templates/website/bibliometrics_list_general_indicators.mako
@@ -1,6 +1,9 @@
 ## coding: utf-8
 <%inherit file="central_container_without_filters.mako"/>
 <%block name="central_container">
+<!-- 'sheetlang' é um 'slice' de locale.
+Usado para garantir 'es' quando locale for igual a 'es_MX' -->
+<%sheetlang=locale[0:2]%>
 
   <h3>${_(u'Indicadores Bibliométricos da Rede SciELO')}</h3>
   <h5><b>${_(u'Periodicidade de atualização:')}</b>${_(u' anual')}</h5>
@@ -18,22 +21,22 @@
           <div class="panel-body">
             <b>${_(u'Numeros da Rede SciELO por:')}</b>
             <ul>
-              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/A01a_${locale}.xls">A01a_${locale}.xls</a></li>
-              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A01b_${locale}.xls">A01b_${locale}.xls</a></li>
-              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A01c_${locale}.xls">A01c_${locale}.xls</a></li>
-              <li>${_(u'País de afiliação do autor: ')}<a href="https://static.scielo.org/indicators/${locale}/A01d_${locale}.xls">A01d_${locale}.xls</a></li>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A01a_${sheetlang}.xls">A01a_${sheetlang}.xls</a></li>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A01b_${sheetlang}.xls">A01b_${sheetlang}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A01c_${sheetlang}.xls">A01c_${sheetlang}.xls</a></li>
+              <li>${_(u'País de afiliação do autor: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A01d_${sheetlang}.xls">A01d_${sheetlang}.xls</a></li>
             </ul>
             <b>${_(u'País de Afiliação do Autor por: ')}</b>
             <ul>
-              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/A02a_${locale}.xls">A02a_${locale}.xls</a></li>
-              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A02b_${locale}.xls">A02b_${locale}.xls</a></li>
-              <li>${_(u'País de publicação da revista: ')}<a href="https://static.scielo.org/indicators/${locale}/A02c_${locale}.xls">A02c_${locale}.xls</a></li>
-              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A02d_${locale}.xls">A02d_${locale}.xls</a></li>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A02a_${sheetlang}.xls">A02a_${sheetlang}.xls</a></li>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A02b_${sheetlang}.xls">A02b_${sheetlang}.xls</a></li>
+              <li>${_(u'País de publicação da revista: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A02c_${sheetlang}.xls">A02c_${sheetlang}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A02d_${sheetlang}.xls">A02d_${sheetlang}.xls</a></li>
             </ul>
             <b>${_(u'Número de Co-autores por: ')}</b>
             <ul>
-              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${locale}/A03a_${locale}.xls">A03a_${locale}.xls</a></li>
-              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/A03b_${locale}.xls">A03b_${locale}.xls</a></li>
+              <li>${_(u'Periódico: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A03a_${sheetlang}.xls">A03a_${sheetlang}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/A03b_${sheetlang}.xls">A03b_${sheetlang}.xls</a></li>
             </ul>
           </div>
         </div>
@@ -51,9 +54,9 @@
           <div class="panel-body">
             <b>${_(u'Periódico por:')}</b>
             <ul>
-              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${locale}/B01a_${locale}.xls">B01a_${locale}.xls</a></li>
-              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${locale}/B01b_${locale}.xls">B01b_${locale}.xls</a></li>
-              <li>${_(u'Indicadores gerais: ')}<a href="https://static.scielo.org/indicators/${locale}/B01c_${locale}.xls">B01c_${locale}.xls</a></li>
+              <li>${_(u'Ano de publicação: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/B01a_${sheetlang}.xls">B01a_${sheetlang}.xls</a></li>
+              <li>${_(u'Assunto: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/B01b_${sheetlang}.xls">B01b_${sheetlang}.xls</a></li>
+              <li>${_(u'Indicadores gerais: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/B01c_${sheetlang}.xls">B01c_${sheetlang}.xls</a></li>
             </ul>
           </div>
         </div>
@@ -71,25 +74,25 @@
           <div class="panel-body">
             <b>${_(u'Ano de Citação por:')}</b>
             <ul>
-              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C01a_${locale}.xls">C01a_${locale}.xls</a></li>
-              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C01b_${locale}.xls">C01b_${locale}.xls</a></li>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C01a_${sheetlang}.xls">C01a_${sheetlang}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C01b_${sheetlang}.xls">C01b_${sheetlang}.xls</a></li>
             </ul>
             <b>${_(u'Periódico Citante por:')}</b>
             <ul>
-              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C02a_${locale}.xls">C02a_${locale}.xls</a></li>
-              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C02b_${locale}.xls">C02b_${locale}.xls</a></li>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C02a_${sheetlang}.xls">C02a_${sheetlang}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C02b_${sheetlang}.xls">C02b_${sheetlang}.xls</a></li>
             </ul>
             <b>${_(u'Assunto do Periódico Citante por:')}</b>
             <ul>
-              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03a_${locale}.xls">C03a_${locale}.xls</a></li>
-              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03b_${locale}.xls">C03b_${locale}.xls</a></li>
-              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C03c_${locale}.xls">C03c_${locale}.xls</a></li>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C03a_${sheetlang}.xls">C03a_${sheetlang}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C03b_${sheetlang}.xls">C03b_${sheetlang}.xls</a></li>
+              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C03c_${sheetlang}.xls">C03c_${sheetlang}.xls</a></li>
             </ul>
             <b>${_(u'País de Afiliação do Autor Citante por:')}</b>
             <ul>
-              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04a_${locale}.xls">C04a_${locale}.xls</a></li>
-              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04b_${locale}.xls">C04b_${locale}.xls</a></li>
-              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${locale}/C04c_${locale}.xls">C04c_${locale}.xls</a></li>
+              <li>${_(u'Idade do documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C04a_${sheetlang}.xls">C04a_${sheetlang}.xls</a></li>
+              <li>${_(u'Tipo de documento citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C04b_${sheetlang}.xls">C04b_${sheetlang}.xls</a></li>
+              <li>${_(u'Periódico SciELO citado: ')}<a href="https://static.scielo.org/indicators/${sheetlang}/C04c_${sheetlang}.xls">C04c_${sheetlang}.xls</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige um erro no tk_132. Ao selecionar o idioma Español (México) o link para download fica incorreto. Os paths e nomes dos arquivos para download tem que variar de acordo com o idioma selecionado na interface.

#### Onde a revisão poderia começar?
https://github.com/scieloorg/analytics/blob/beta/analytics/templates/website/bibliometrics_list_general_indicators.mako

#### Como este poderia ser testado manualmente?
Selecionar o idioma Español (México) e testar o download de qualquer planilha.

#### Algum cenário de contexto que queira dar?
Nenhum

### Screenshots
![image](https://user-images.githubusercontent.com/454847/65893301-1d642e80-e37e-11e9-9abb-3cd78c31f7bd.png)


#### Quais são tickets relevantes?
#132 

### Referências
https://hplgit.github.io/setup4book-doconce/doc/pub/mako/html/sphinx/._main_mako001.html

