### PR TITLE
Inclui suporte ao novo site de Brasil

### DIFF
--- a/analytics/control_manager.py
+++ b/analytics/control_manager.py
@@ -149,8 +149,9 @@ def base_data_manager(wrapped):
             y2 = today - datetime.timedelta(365*2)
             y1 = today - datetime.timedelta(365*1)
 
+            data['collections'] = collections
+            data = add_old_scielo_br(change_scielo_br_acron(data))
             data.update({
-                'collections': collections,
                 'selected_code': code,
                 'selected_journal': selected_journal,
                 'selected_journal_code': selected_journal_code,
@@ -201,9 +202,18 @@ def base_data_manager(wrapped):
         data['share_this_url'] = current_url(request.url, data)
 
         setattr(request, 'data_manager', data)
-
+        
         return wrapped(request, *arg, **kwargs)
 
     wrapper.__doc__ = wrapped.__doc__
 
     return wrapper
+
+
+def change_scielo_br_acron(data_manager):
+    data_manager['collections']['nbr'] = data_manager['collections'].pop('scl')
+    return data_manager
+
+def add_old_scielo_br(data_manager):
+    data_manager['collections']['scl'] = {'name': 'Brasil (classic site)', 'domain': 'old.scielo.br'}
+    return data_manager

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -98,14 +98,101 @@ class ServerError(Exception):
         return repr(self.message)
 
 
+def _handle_nbr_collection(collection):
+    return 'scl' if collection == 'nbr' else collection
+
+
+class AccessStatsProxy(object):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def access_by_month_and_year(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.access_by_month_and_year(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def access_by_document_type(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.access_by_document_type(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def access_lifetime(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.access_lifetime(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def access_heat(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.access_heat(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def list_journals(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.list_journals(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def list_issues(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.list_issues(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+    def list_articles(self, selected_code, selected_collection_code, py_range, sa_scope, la_scope, range_start, range_end):
+        return self.instance.list_articles(selected_code, _handle_nbr_collection(selected_collection_code), py_range, sa_scope, la_scope, range_start, range_end)
+
+
+class ArticleMetaProxy(object):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def certified_collections(self):
+        return self.instance.certified_collections()
+
+    def collections_journals(self, collection=None):
+        return self.instance.collections_journals(_handle_nbr_collection(collection))
+
+
+class PublicationStatsProxy(object):
+    def __init__(self, instance):
+        self.instance = instance    
+
+    def granted_citations_by_year(self, code, collection, py_range=None, raw=False):
+        return self.instance.granted_citations_by_year(code, _handle_nbr_collection(collection), py_range=None, raw=False)
+
+    def list_subject_areas(self, code, collection):
+        return self.instance.list_subject_areas(code, _handle_nbr_collection(collection))
+
+    def list_languages(self, code, collection):
+        return self.instance.list_languages(code, _handle_nbr_collection(collection))
+
+    def list_publication_years(self, code, collection):
+        return self.instance.list_publication_years(code, _handle_nbr_collection(collection))
+
+    def general(self, index, field, code, collection, py_range=None, sa_scope=None, la_scope=None, size=0, sort_term=None, raw=False):
+        return self.instance.general(index, field, code, _handle_nbr_collection(collection), py_range=None, sa_scope=None, la_scope=None, size=0, sort_term=None, raw=False)
+
+    def journals_status_detailde(self, collection):
+        return self.instance.journals_status_detailde(_handle_nbr_collection(collection))
+
+    def collection_size(self, code, collection, field, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.collection_size(code, _handle_nbr_collection(collection), field, py_range, sa_scope, la_scope, raw=False)
+
+    def citable_documents(self, code, collection, py_range=None, raw=False):
+        return self.instance.citable_documents(code, _handle_nbr_collection(collection), py_range=None, raw=False)
+
+    def affiliations_by_publication_year(self, code, collection, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.affiliations_by_publication_year(code, _handle_nbr_collection(collection), py_range, sa_scope, la_scope, raw=False)
+
+    def subject_areas_by_publication_year(self, code, collection, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.subject_areas_by_publication_year(code, _handle_nbr_collection(collection), py_range, sa_scope, la_scope, raw=False)
+
+    def document_type_by_publication_year(self, code, collection, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.document_type_by_publication_year(code, _handle_nbr_collection(collection), py_range, sa_scope, la_scope, raw=False)
+
+    def languages_by_publication_year(self, code, collection, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.languages_by_publication_year(code, _handle_nbr_collection(collection), py_range, sa_scope, la_scope, raw=False)
+
+    def lincenses_by_publication_year(self, code, collection, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.lincenses_by_publication_year(code, _handle_nbr_collection(collection), py_range, sa_scope, la_scope, raw=False)
+
+    def by_publication_year(self, code, collection, field, py_range, sa_scope, la_scope, raw=False):
+        return self.instance.by_publication_year(code, _handle_nbr_collection(collection), field, py_range, sa_scope, la_scope, raw=False)
+
+
 class Stats(object):
 
     def __init__(self, articlemeta_host, publicationstats_host, accessstats_host, bibliometrics_host):
-        self.articlemeta = ArticleMeta()
-        self.publication = PublicationStats()
-        self.access = AccessStats()
+        self.articlemeta = ArticleMetaProxy(ArticleMeta())
+        self.publication = PublicationStatsProxy(PublicationStats())
+        self.access = AccessStatsProxy(AccessStats())
         self.bibliometrics = BibliometricsStats()
-
 
     @property
     def _(self):


### PR DESCRIPTION
O novo site da coleção Brasil, de acrônimo `nbr`, quebra com o
funcionamento padrão do Analytics pois todos os dados, exceto
estatísticas de acessos, são os mesmos de `scl` e não devem ser
duplicados. Nesta mudança é criada uma indireção de forma a tratar este
caso.

Esta modificação assume que os logs de acessos estejam sendo registrados
no Ratchet sob o acrônimo de coleção _nbr_. Para isso será necessário fazer um
_patch_ no código do github.com/scieloorg/logger, da seguinte forma:

O método https://github.com/scieloorg/Logger/blob/6feb22a95e3f65067bc0ee5905b516d8df7e4677/logger/inspector.py#L70-L77 terá de passar a retornar um item que corresponde ao registro da nova coleção. Sugiro que seja incluído no retorno o registro:

```
{
    "acron": "nbr",
    "code": "nbr",
    "domain": "www.scielo.br",
    "acron2": "nbr",
    "name": {
      "en": "Brazil",
      "pt": "Brasil",
      "es": "Brasil"
    },
    "has_analytics": true,
    "original_name": "Brasil",
    "status": "certified",
    "type": "journals",
    "is_active": true
  }
```

**P:** _Ah, mas não é melhor eu fazer com que o endpoint **collections**, do ArticleMeta, retorne essa nova coleção?_
**R:** O Problema é que se isso for feito, a nova coleção aparecerá em outros lugares como por exemplo no painel de coleções do www.scielo.org, e isso não é desejado.

Outra coisa importante, os logs de acessos do novo site devem ser depositados no diretório `ratchet.scielo.org:/var/www/ftp_ratchet_scielo_org/scielo.nbr`.

#### Onde a revisão poderia começar?
Eu diria que pela classe `controller.Stats`.

#### Como este poderia ser testado manualmente?
Suba uma instância local e observe, no menu seletor de coleções no canto superior direito, a existência das coleções _Brasil_ e _Brasil (site clássico)_. Note também que todas as métricas não relacionadas a acessos são idênticas entre ambas as 2 coleções.