### PR TITLE
Adiciona gráfico com dados de relatório COUNTER R5 TR_J1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ Docker Compose:
 
 ### Integrações
 
-O analytics é um aplicação que faz a integração de 4 serviços:
+O analytics é um aplicação que faz a integração de 5 serviços:
 
 * Article Meta: https://github.com/scieloorg/articles_meta
 * Publication Stats: https://github.com/scieloorg/publication_stats
 * Access Stats: https://github.com/scieloorg/access_stats
 * Bibliometrics: https://github.com/scieloorg/bibliometrics
+* SUSHI API: https://github.com/scieloorg/scielo-sushi-api
 
-Para realizar o uso do analytics é necessário ter as seguintes conexões **Thrift**:
+Para realizar o uso do analytics é necessário ter as conexões **Thrift** dos quatro primeiros serviços listados a seguir e uma conexão com a SUSHI API (que não possui **Thrift**):
 
 * Article Meta: articlemeta.scielo.org:11621
 * Publication Stats: publication.scielo.org:11620
 * Access Stats: ratchet.scielo.org:11660
 * Bibliometric Stats: Utiliza a conexão do Article Meta
+* SUSHI API: usage.apis.scielo.org
 
 É **importante** testar previamente se o host que está utilizando para fazer a instalação da aplicação está com conectividade para esses endereços e portas, para isso utilize o utilitário **telnet**.
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -23,7 +23,7 @@ def main(global_config, **settings):
             settings.get('articlemeta', None),
             settings.get('publicationstats', None),
             settings.get('accessstats', None),
-            settings.get('citedby', None)
+            settings.get('citedby', None),
             settings.get('usage', None),
         )
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -24,6 +24,7 @@ def main(global_config, **settings):
             settings.get('publicationstats', None),
             settings.get('accessstats', None),
             settings.get('citedby', None)
+            settings.get('usage', None),
         )
 
     def add_chartsconfig(request):
@@ -34,6 +35,7 @@ def main(global_config, **settings):
     config.add_route('index_web', '/')
     config.add_route('faq_web', '/w/faq')
     config.add_route('reports', '/w/reports')
+    config.add_route('usage_title_report_chart', '/ajx/usage/title_report_chart')
     config.add_route('accesses_web', '/w/accesses')
     config.add_route('accesses_document_web', '/w/accesses/document')
     config.add_route('accesses_list_journals_web', '/w/accesses/list/journals')

--- a/analytics/charts_config.py
+++ b/analytics/charts_config.py
@@ -181,6 +181,29 @@ class ChartsConfig(object):
 
         return {'options': chart}
 
+    def usage_title_report(self, data):
+        chart = self.highchart
+
+        chart['credits'] = {'href': 'https://usage.apis.scielo.br','text': self._(u'Fonte: SciELO SUSHI API')}
+
+        chart['title'] = {'text': self._(u'Métricas COUNTER Release 5')}
+        chart['series'] = data['series']
+        chart['legend'] = {'enabled': True}
+        chart['yAxis']['title'] = {'text': self._(u'Métricas')}
+        chart['yAxis']['opposite'] = False
+        chart['xAxis'] = {'type': 'datetime'}
+        chart['rangeSelector'] = {'enabled': False}
+
+        chart['tooltip'] = {
+            'shared': True,
+            'useHTML': True,
+            'headerFormat': self._(u'Acessos em') + ' <strong>{point.x:%B %Y}</strong><table style="width: 100%; border-top: 1px solid #CCC;">',
+            'pointFormat': u'<tr><td><span style="color:{point.color}">\u25CF</span> {series.name}: </td><td style="text-align: right"><strong>{point.y}</strong></td></tr>',
+            'footerFormat': '</table>'
+        }
+
+        return {'options': chart}
+
     def bibliometrics_google_h5m5(self, data):
 
         chart = self.highchart

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2921,6 +2921,35 @@ class UsageStats():
         ms_unix_epoch = int(fmt_date.timestamp() * 1000)
 
         return ms_unix_epoch
+
+
+    def _get_tr_j1_chart(self, json_results):
+        serie_total_requests = []
+        serie_unique_requests = []
+
+        for i in json_results.get('Report_Items', []):
+            for p in i.get('Performance', []):
+                p_metric_label = p.get('Instance', {}).get('Metric_Type', '')
+                p_metric_value = p.get('Instance', {}).get('Count', 0)
+                p_period_begin = p.get('Period', {}).get('Begin_Date', '')
+
+                fmt_date = self._format_date(p_period_begin)
+
+                if p_metric_label  == 'Total_Item_Requests':
+                    serie_total_requests.append([fmt_date, int(p_metric_value)])
+                elif p_metric_label == 'Unique_Item_Requests':
+                    serie_unique_requests.append([fmt_date, int(p_metric_value)])
+
+        chart_data = {
+            'series': [
+                {'data': serie_total_requests, 'name': 'Total Item Requests',},
+                {'data': serie_unique_requests, 'name': 'Unique Item Requests',}
+            ],
+        }
+
+        return chart_data
+
+
     def get_title_report(self, issn, collection, begin_date, end_date, granularity='monthly', title_report_code='tr_j1'):
         url_tr = urllib.parse.urljoin(self.base_url, 'reports/%s' % title_report_code)
 

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -103,7 +103,7 @@ class ServerError(Exception):
 
 class Stats(object):
 
-    def __init__(self, articlemeta_host, publicationstats_host, accessstats_host, bibliometrics_host):
+    def __init__(self, articlemeta_host, publicationstats_host, accessstats_host, bibliometrics_host, usage_api_host):
         self.articlemeta = ArticleMeta()
         self.publication = PublicationStats()
         self.access = AccessStats()

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2907,6 +2907,17 @@ class AccessStats(AccessStatsThriftClient):
         computed = self._compute_access_heat(query_result)
 
         return query_result if raw else computed
+
+
 class UsageStats():
     def __init__(self, usage_api_base_url=None):
         self.base_url = usage_api_base_url or 'http://usage.apis.scielo.org/'
+
+
+    def _format_date(self, date):
+        fmt_date = datetime.strptime(date, '%Y-%m-%d')
+        fmt_date = fmt_date.replace(day = 1)
+
+        ms_unix_epoch = int(fmt_date.timestamp() * 1000)
+
+        return ms_unix_epoch

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 import json
-from datetime import datetime, timedelta
+import requests
+import urllib.parse
+
+from datetime import date, datetime, timedelta
 
 from dogpile.cache import make_region
 from scieloh5m5 import h5m5
@@ -105,6 +108,7 @@ class Stats(object):
         self.publication = PublicationStats()
         self.access = AccessStats()
         self.bibliometrics = BibliometricsStats()
+        self.usage = UsageStats(usage_api_host)
 
 
     @property

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2921,3 +2921,22 @@ class UsageStats():
         ms_unix_epoch = int(fmt_date.timestamp() * 1000)
 
         return ms_unix_epoch
+    def get_title_report(self, issn, collection, begin_date, end_date, granularity='monthly', title_report_code='tr_j1'):
+        url_tr = urllib.parse.urljoin(self.base_url, 'reports/%s' % title_report_code)
+
+        params = {
+            'issn': issn,
+            'collection': collection,
+            'begin_date': begin_date,
+            'end_date': end_date,
+            'granularity': granularity,
+        }
+
+        response = requests.get(
+            url=url_tr,
+            params=params
+        )
+
+        if response.status_code == 200:
+            if title_report_code == 'tr_j1':
+                return self._get_tr_j1_chart(response.json())

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2907,3 +2907,6 @@ class AccessStats(AccessStatsThriftClient):
         computed = self._compute_access_heat(query_result)
 
         return query_result if raw else computed
+class UsageStats():
+    def __init__(self, usage_api_base_url=None):
+        self.base_url = usage_api_base_url or 'http://usage.apis.scielo.org/'

--- a/analytics/templates/website/home_journal.mako
+++ b/analytics/templates/website/home_journal.mako
@@ -28,6 +28,11 @@
         </div>
     </div>
     <div class="row container-fluid" style="margin-top: 100px;">
+        <div class="col-md-12">
+            <%include file="usage_tr_j1.mako"/>
+        </div>
+    </div>
+    <div class="row container-fluid" style="margin-top: 100px;">
         <div class="col-md-6">
             <%include file="access_by_month_and_year.mako"/>
         </div>

--- a/analytics/templates/website/usage_tr_j1.mako
+++ b/analytics/templates/website/usage_tr_j1.mako
@@ -1,0 +1,21 @@
+## coding: utf-8
+<div id="usage_tr_j1_chart" style="width:100%; height:400px;">
+  <span id="loading_usage_tr_j1_chart">
+    <img src="/static/images/loading.gif" />
+    <h5>${_(u'loading')}</h5>
+  </span>
+</div>
+<script language="javascript">
+    $("#loading_usage_tr_j1_chart").show();
+    $(document).ready(function() {
+        var url =  "${request.route_url('usage_title_report_chart')}?code=${selected_code}&collection=${selected_collection_code}&range_start=${range_start}&range_end=${range_end}&py_range=${'-'.join(py_range)}&callback=?";
+
+        $.getJSON(url,  function(data) {
+            % if selected_journal:
+                data['options']['subtitle'] = {'text': '${selected_journal}'};
+            % endif
+            $('#usage_tr_j1_chart').highcharts('StockChart', data['options']);
+            $("#loading_usage_tr_j1_chart").hide();
+        });
+    });
+</script>

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -72,6 +72,27 @@ def bibliometrics_journal_google_h5m5_chart(request):
     return request.chartsconfig.bibliometrics_google_h5m5(data)
 
 
+@view_config(route_name='usage_title_report_chart', request_method='GET', renderer='jsonp')
+@base_data_manager
+def usage_title_report_chart(request):
+
+    data = request.data_manager
+
+    range_start = request.GET.get('range_start', None)
+    range_end = request.GET.get('range_end', None)
+    title_report_code = request.GET.get('title_report_code', 'tr_j1')
+
+    data_chart = request.stats.usage.get_title_report(
+        issn = data['selected_code'],
+        collection = data['selected_collection_code'],
+        begin_date = range_start,
+        end_date = range_end,
+        title_report_code = title_report_code,
+    )
+
+    return request.chartsconfig.usage_title_report(data_chart)
+
+
 @view_config(route_name='bibliometrics_journal_cited_and_citing_years_heat', request_method='GET', renderer='jsonp')
 @base_data_manager
 def bibliometrics_journal_cited_and_citing_years_heat(request):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma série de elementos que permitem exibir, na página de um periódico, dados do relatório TR_J1 (COUNTER R5). Os dados são originários da api SUSHI disponível em usage.apis.scielo.org. Um exemplo de como esse relatório é pode ser visualizado em http://usage.apis.scielo.org/reports/tr_j1?begin_date=2021-09-30&end_date=2021-09-30&collection=scl&issn=1517-9702.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Instancie a aplicação usando o README.
2. Conecte-se à VNP
3. Acesse a página de um periódico, por exemplo: https://analytics.scielo.org/?journal=1413-8123
4. Um dos gráficos exibido é o das métricas `Total Item Requests` e `Unique Item Requests` (vide a figura de exemplo neste PR)


#### Algum cenário de contexto que queira dar?
Este PR faz parte de um conjunto de melhorias que visam a adicionar ao site Analytics gráficos e métricas relacionadas ao novo método de contagem de acessos implementado (SciELO Usage COUNTER). Outros gráficos serão propostos, a saber:
1. Gráfico para exibir relatório TR_J4 (dados de acesso por ano de publicação)
2. Gráfico e/ou tabela para exibir contagens de acesso por país de origem
3. Gráfico e/ou tabela para exibir contagens de acesso por idioma do documento acessado.
4. Outros gráficos/tabelas podem ser propostos.

### Screenshots
![image](https://user-images.githubusercontent.com/2096125/145121090-b947d62a-5cda-463e-bf44-88a0bf68625d.png)

#### Quais são tickets relevantes?
N/A

### Referências
- [Nossa documentação do SUSHI](https://docs.google.com/document/d/1eaEcojJ-Fm4zsMMU1KArB8QKpZnxwRVT2E3ZUIyDF4g/edit?usp=sharing)
- [Documentação oficial dos métodos COUNTER](https://www.projectcounter.org/wp-content/uploads/2019/05/Release_5_Librarians_20190509-Revised-Edition.pdf)
- [Site oficial Project COUNTER](https://www.projectcounter.org/) 



