### PR TITLE
Adequa relatório SUSHI para exibir dados por coleção e melhora relatório existente tr_j1

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -35,7 +35,7 @@ def main(global_config, **settings):
     config.add_route('index_web', '/')
     config.add_route('faq_web', '/w/faq')
     config.add_route('reports', '/w/reports')
-    config.add_route('usage_title_report_chart', '/ajx/usage/title_report_chart')
+    config.add_route('usage_report_chart', '/ajx/usage/usage_report_chart')
     config.add_route('accesses_web', '/w/accesses')
     config.add_route('accesses_document_web', '/w/accesses/document')
     config.add_route('accesses_list_journals_web', '/w/accesses/list/journals')

--- a/analytics/charts_config.py
+++ b/analytics/charts_config.py
@@ -181,19 +181,17 @@ class ChartsConfig(object):
 
         return {'options': chart}
 
-    def usage_title_report(self, data):
+    def usage_report(self, data):
         chart = self.highchart
 
         chart['credits'] = {'href': 'https://usage.apis.scielo.br','text': self._(u'Fonte: SciELO SUSHI API')}
-
-        chart['title'] = {'text': self._(u'Métricas COUNTER Release 5')}
+        chart['title'] = {'text': self._(u'Total de acessos por ano e mês (API SUSHI)')}
         chart['series'] = data['series']
         chart['legend'] = {'enabled': True}
         chart['yAxis']['title'] = {'text': self._(u'Métricas')}
         chart['yAxis']['opposite'] = False
         chart['xAxis'] = {'type': 'datetime'}
         chart['rangeSelector'] = {'enabled': False}
-
         chart['tooltip'] = {
             'shared': True,
             'useHTML': True,

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -3,7 +3,7 @@ import json
 import requests
 import urllib.parse
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from dogpile.cache import make_region
 from scieloh5m5 import h5m5
@@ -109,7 +109,6 @@ class Stats(object):
         self.access = AccessStats()
         self.bibliometrics = BibliometricsStats()
         self.usage = UsageStats(usage_api_host)
-
 
     @property
     def _(self):
@@ -2913,7 +2912,6 @@ class UsageStats():
     def __init__(self, usage_api_base_url=None):
         self.base_url = usage_api_base_url or 'http://usage.apis.scielo.org/'
 
-
     def _format_date(self, date):
         fmt_date = datetime.strptime(date, '%Y-%m-%d')
         fmt_date = fmt_date.replace(day = 1)
@@ -2922,8 +2920,21 @@ class UsageStats():
 
         return ms_unix_epoch
 
+    def _clean_params_according_to_report(self, params, report_code):
+        attrs_to_remove = set()
+        
+        if report_code == 'cr_j1':
+            attrs_to_remove = ('issn', 'pid',)
+        elif report_code == 'ir_a1':
+            attrs_to_remove = ('issn',)
+        elif report_code == 'tr_j1':
+            attrs_to_remove = ('pid',)
 
-    def _get_tr_j1_chart(self, json_results):
+        for attr in attrs_to_remove:
+            if attr in params:
+                del params[attr]
+
+    def _get_j1_chart(self, json_results):
         serie_total_requests = []
         serie_unique_requests = []
 

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2960,9 +2960,8 @@ class UsageStats():
 
         return chart_data
 
-
-    def get_title_report(self, issn, collection, begin_date, end_date, granularity='monthly', title_report_code='tr_j1'):
-        url_tr = urllib.parse.urljoin(self.base_url, 'reports/%s' % title_report_code)
+    def get_usage_report(self, issn, collection, begin_date, end_date, granularity='monthly', report_code='tr_j1', api_version='v2'):
+        url_tr = urllib.parse.urljoin(self.base_url, 'reports/%s' % report_code)
 
         params = {
             'issn': issn,
@@ -2970,7 +2969,10 @@ class UsageStats():
             'begin_date': begin_date,
             'end_date': end_date,
             'granularity': granularity,
+            'api': api_version,
         }
+
+        self._clean_params_according_to_report(params, report_code)
 
         response = requests.get(
             url=url_tr,
@@ -2978,5 +2980,5 @@ class UsageStats():
         )
 
         if response.status_code == 200:
-            if title_report_code == 'tr_j1':
-                return self._get_tr_j1_chart(response.json())
+            if report_code in ('cr_j1', 'tr_j1'):
+                return self._get_j1_chart(response.json())

--- a/analytics/templates/website/home_collection.mako
+++ b/analytics/templates/website/home_collection.mako
@@ -23,6 +23,9 @@
         <div class="row">
             <h3>${_(u'Gráficos')}</h3>
         </div>
+        <div class="col-md-12">
+            <%include file="usage_cr_j1.mako"/>
+        </div>
         <div class="col-md-6">
             <%include file="access_by_month_and_year.mako"/>
         </div>

--- a/analytics/templates/website/usage_cr_j1.mako
+++ b/analytics/templates/website/usage_cr_j1.mako
@@ -1,0 +1,18 @@
+## coding: utf-8
+<div id="usage_cr_j1_chart" style="width:100%; height:400px;">
+  <span id="loading_usage_cr_j1_chart">
+    <img src="/static/images/loading.gif" />
+    <h5>${_(u'loading')}</h5>
+  </span>
+</div>
+<script language="javascript">
+    $("#loading_usage_cr_j1_chart").show();
+    $(document).ready(function() {
+        var url =  "${request.route_url('usage_report_chart')}?api_version=v2&report_code=cr_j1&collection=${selected_collection_code}&range_start=${range_start}&range_end=${range_end}&callback=?";
+
+        $.getJSON(url,  function(data) {
+            $('#usage_cr_j1_chart').highcharts('StockChart', data['options']);
+            $("#loading_usage_cr_j1_chart").hide();
+        });
+    });
+</script>

--- a/analytics/templates/website/usage_tr_j1.mako
+++ b/analytics/templates/website/usage_tr_j1.mako
@@ -8,7 +8,7 @@
 <script language="javascript">
     $("#loading_usage_tr_j1_chart").show();
     $(document).ready(function() {
-        var url =  "${request.route_url('usage_title_report_chart')}?code=${selected_code}&collection=${selected_collection_code}&range_start=${range_start}&range_end=${range_end}&py_range=${'-'.join(py_range)}&callback=?";
+        var url =  "${request.route_url('usage_report_chart')}?api_version=v2&report_code=tr_j1&code=${selected_code}&collection=${selected_collection_code}&range_start=${range_start}&range_end=${range_end}&callback=?";
 
         $.getJSON(url,  function(data) {
             % if selected_journal:

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -72,9 +72,9 @@ def bibliometrics_journal_google_h5m5_chart(request):
     return request.chartsconfig.bibliometrics_google_h5m5(data)
 
 
-@view_config(route_name='usage_title_report_chart', request_method='GET', renderer='jsonp')
+@view_config(route_name='usage_report_chart', request_method='GET', renderer='jsonp')
 @base_data_manager
-def usage_title_report_chart(request):
+def usage_report_chart(request):
 
     data = request.data_manager
 

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -78,6 +78,7 @@ def usage_report_chart(request):
 
     data = request.data_manager
 
+    api_version = request.GET.get('api_version', 'v2')
     range_start = request.GET.get('range_start', None)
     range_end = request.GET.get('range_end', None)
     title_report_code = request.GET.get('title_report_code', 'tr_j1')
@@ -88,6 +89,7 @@ def usage_report_chart(request):
         begin_date = range_start,
         end_date = range_end,
         title_report_code = title_report_code,
+        api_version = api_version,
     )
 
     return request.chartsconfig.usage_title_report(data_chart)

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -81,18 +81,20 @@ def usage_report_chart(request):
     api_version = request.GET.get('api_version', 'v2')
     range_start = request.GET.get('range_start', None)
     range_end = request.GET.get('range_end', None)
-    title_report_code = request.GET.get('title_report_code', 'tr_j1')
+    report_code = request.GET.get('report_code', 'tr_j1')
+    selected_code = data['selected_code']
+    selected_collection_code = data['selected_collection_code']
 
-    data_chart = request.stats.usage.get_title_report(
-        issn = data['selected_code'],
-        collection = data['selected_collection_code'],
+    data_chart = request.stats.usage.get_usage_report(
+        issn = selected_code,
+        collection = selected_collection_code,
         begin_date = range_start,
         end_date = range_end,
-        title_report_code = title_report_code,
+        report_code = report_code,
         api_version = api_version,
     )
 
-    return request.chartsconfig.usage_title_report(data_chart)
+    return request.chartsconfig.usage_report(data_chart)
 
 
 @view_config(route_name='bibliometrics_journal_cited_and_citing_years_heat', request_method='GET', renderer='jsonp')


### PR DESCRIPTION
#### O que esse PR faz?
1. Migra o relatório tr_j1 para a versão 2 da API SUSHI (que agrega dados de scl e nbr numa única coleção)
2. Adiciona na página `home_collection` o relatório cr_j1 da versão 2 da API SUSHI. É possível visualizar os dados de acesso (COUNTER R5) para coleções inteiras.

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
1. Instancie a aplicação seguindo as instruções do README.md
2. Conecte-se à VPN (confira se há acesso ao articlemeta/Thrift)
3. Acessa a página principal da aplicação
4. Observe o relatório de acessos `cr_j1` para a coleção selecionada (que por padrão, é Brasil)
5. Acesso a página de um periódico
6. Observe o relatório de acessos `tr_j1`

#### Algum cenário de contexto que queira dar?
Este PR faz parte de um conjunto de alteraçõs que visam a melhorar a apresentação dos dados de acesso (COUNTER) na aplicação SciELO Analytics. Outras melhorias virão (relatórios por documento, relatórios por origem de acesso e por idioma de documento). Esses outros três relatórios dependem de alterações ainda a serem realizadas na aplicação SUSHI e no banco de dados Matomo.

### Screenshots
Por periódico (tr_j1)
![image](https://user-images.githubusercontent.com/2096125/148425784-03aeaf53-266c-4ac0-9dd0-4aea48b36e4e.png)

Por coleção (cr_j1)
![image](https://user-images.githubusercontent.com/2096125/148425883-5d15a538-5750-4933-ab31-b0437a6e57c9.png)

#### Quais são tickets relevantes?
N/A

### Referências
N/A
