### PR TITLE
Garante que seja apresentado o gráfico de Sushi somente para a coleção Brasil

### DIFF
--- a/analytics/templates/website/home_collection.mako
+++ b/analytics/templates/website/home_collection.mako
@@ -23,7 +23,6 @@
         <div class="row">
             <h3>${_(u'Gráficos')}</h3>
         </div>
-
         ## Garante que seja apresentado somente o gráfico do Sushi para a coleção
         ## Brasil
         % if selected_collection_code == 'scl':
@@ -31,13 +30,12 @@
               <%include file="usage_cr_j1.mako"/>
           </div>
         % else:
-          <div class="col-md-6">
+          <div class="col-md-12">
               <%include file="access_by_month_and_year.mako"/>
           </div>
-          <div class="col-md-6">
-              <%include file="publication_article_affiliations_map.mako"/>
-          </div>
         % endif
-
+        <div class="col-md-12">
+            <%include file="publication_article_affiliations_map.mako"/>
+        </div>
     </div>
 </%block>

--- a/analytics/templates/website/home_collection.mako
+++ b/analytics/templates/website/home_collection.mako
@@ -23,9 +23,15 @@
         <div class="row">
             <h3>${_(u'Gráficos')}</h3>
         </div>
-        <div class="col-md-12">
-            <%include file="usage_cr_j1.mako"/>
-        </div>
+
+        ## Garante que seja apresentado somente o gráfico do Sushi para a coleção
+        ## Brasil
+        % if selected_collection_code == 'scl':
+          <div class="col-md-12">
+              <%include file="usage_cr_j1.mako"/>
+          </div>
+        % endif
+
         <div class="col-md-6">
             <%include file="access_by_month_and_year.mako"/>
         </div>

--- a/analytics/templates/website/home_collection.mako
+++ b/analytics/templates/website/home_collection.mako
@@ -30,13 +30,14 @@
           <div class="col-md-12">
               <%include file="usage_cr_j1.mako"/>
           </div>
+        % else:
+          <div class="col-md-6">
+              <%include file="access_by_month_and_year.mako"/>
+          </div>
+          <div class="col-md-6">
+              <%include file="publication_article_affiliations_map.mako"/>
+          </div>
         % endif
 
-        <div class="col-md-6">
-            <%include file="access_by_month_and_year.mako"/>
-        </div>
-        <div class="col-md-6">
-            <%include file="publication_article_affiliations_map.mako"/>
-        </div>
     </div>
 </%block>

--- a/analytics/templates/website/home_journal.mako
+++ b/analytics/templates/website/home_journal.mako
@@ -27,19 +27,28 @@
             <%include file="publication_article_citable_documents.mako"/>
         </div>
     </div>
+
+    ## Garante que seja apresentado somente o gráfico do Sushi para a coleção
+    ## Brasil
+    % if selected_collection_code == 'scl':
+        <div class="row container-fluid" style="margin-top: 100px;">
+            <div class="col-md-12">
+                <%include file="usage_tr_j1.mako"/>
+            </div>
+        </div>
+    % else:
+        <div class="row container-fluid" style="margin-top: 100px;">
+            <div class="col-md-12">
+                <%include file="access_by_month_and_year.mako"/>
+            </div>
+        </div>
+    % endif
     <div class="row container-fluid" style="margin-top: 100px;">
         <div class="col-md-12">
-            <%include file="usage_tr_j1.mako"/>
-        </div>
-    </div>
-    <div class="row container-fluid" style="margin-top: 100px;">
-        <div class="col-md-6">
-            <%include file="access_by_month_and_year.mako"/>
-        </div>
-        <div class="col-md-6">
             <%include file="publication_article_affiliations_map.mako"/>
         </div>
     </div>
+
     <div class="row container-fluid" style="margin-top: 100px;">
         <div class="col-md-12">
             <%include file="bibliometrics_journal_received_citations_heat_chart.mako"/>


### PR DESCRIPTION
#### O que esse PR faz?
Garanti que seja apresentado o gráfico de Sushi somente para a coleção Brasil

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Acessando uma instância local com o ajuste.

#### Algum cenário de contexto que queira dar?

Por hora não temos os dados do Sushi no nível da rede.

### Screenshots

Sem Sushi
![Captura de Tela 2022-03-10 às 11 09 05](https://user-images.githubusercontent.com/86991526/157678919-139779ad-cbbc-4056-b704-f4580907fd46.png)

Coleção Brasil com Sushi

![Captura de Tela 2022-03-10 às 11 09 57](https://user-images.githubusercontent.com/86991526/157679018-45283228-3b47-45e1-b8f4-7fa21b869f1e.png)


#### Quais são tickets relevantes?
N/A

### Referências
N/A

