### PR TITLE
Adiciona página com links para relatórios SUSHI de periódico

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -45,6 +45,7 @@ def main(global_config, **settings):
     config.add_route('accesses_bymonthandyear', '/ajx/accesses/bymonthandyear')
     config.add_route('accesses_lifetime', '/ajx/accesses/lifetime')
     config.add_route('accesses_heat', '/ajx/accesses/heat')
+    config.add_route('accesses_journal_usage_data_web', '/w/accesses/journal/usage_data')
     config.add_route('publication_size_web', '/w/publication/size')
     config.add_route('publication_size', '/ajx/publication/size')
     config.add_route('publication_journal_web', '/w/publication/journal')

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -2938,8 +2938,8 @@ class UsageStats():
         serie_total_requests = []
         serie_unique_requests = []
 
-        for i in json_results.get('Report_Items', []):
-            for p in i.get('Performance', []):
+        for i in json_results.get('Report_Items', {}):
+            for p in i.get('Performance', {}):
                 p_metric_label = p.get('Instance', {}).get('Metric_Type', '')
                 p_metric_value = p.get('Instance', {}).get('Count', 0)
                 p_period_begin = p.get('Period', {}).get('Begin_Date', '')
@@ -2979,6 +2979,12 @@ class UsageStats():
             params=params
         )
 
-        if response.status_code == 200:
-            if report_code in ('cr_j1', 'tr_j1'):
-                return self._get_j1_chart(response.json())
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            ...
+
+        if response.status_code == 200 and report_code in ('cr_j1', 'tr_j1'):
+            return self._get_j1_chart(response.json())
+
+        return {}

--- a/analytics/templates/website/access_datepicker.mako
+++ b/analytics/templates/website/access_datepicker.mako
@@ -1,5 +1,5 @@
 ## coding: utf-8
-<div class="row container-fluid" style="padding-left: 30px;">
+<div class="row container-fluid">
   <form class="form-inline">
     <div class="form-group">
       <label class="sr-only" for="exampleInputAmount">${_(u'Período')}</label>
@@ -9,7 +9,7 @@
         <div class="input-group-addon"><a href="?range_start=${y3}&amp;range_end=${today}" data-toggle="tooltip" data-placement="bottom" title="${_(u'acessos nos últimos 36 meses')}">${_(u'3 anos')}</a></div>
         <div class="input-group-addon"><a href="?range_start=${y2}&amp;range_end=${today}" data-toggle="tooltip" data-placement="bottom" title="${_(u'acessos nos últimos 24 meses')}">${_(u'2 anos')}</a></div>
         <div class="input-group-addon"><a href="?range_start=${y1}&amp;range_end=${today}" data-toggle="tooltip" data-placement="bottom" title="${_(u'acessos nos últimos 12 meses')}">${_(u'1 ano')}</a></div>
-        <div class="input-group-addon"><a href="?range_start=0&amp;range_end=${today}" data-toggle="tooltip" data-placement="bottom" title="${_(u'todos acessos disponíveis')}">${_(u'tudo')}</a></div>
+        <div class="input-group-addon"><a href="?range_start=1998-01-01&amp;range_end=${today}" data-toggle="tooltip" data-placement="bottom" title="${_(u'todos acessos disponíveis')}">${_(u'tudo')}</a></div>
         <div class="input-group-addon">
           <span class="glyphicon glyphicon-question-sign" data-toggle="popover" data-container="body" data-placement="bottom" title="${_(u'Seletor de período de acessos')}" data-content="${_(u'Utilize o campo com datas para selecionar um período customizado para recuperação dos dados de acesso. Você pode também selecionar o período de 1, 2 e 3 anos, através dos links rápidos ou todos os acessos disponíveis selecionando tudo.')}"></span>
         </div>

--- a/analytics/templates/website/accesses.mako
+++ b/analytics/templates/website/accesses.mako
@@ -6,7 +6,11 @@
   <h3>${_(u'Gráfico da evolução de acessos aos documentos')}</h3>
   <center>
     <div class="chart">
-      <%include file="access_by_month_and_year.mako"/>
+      % if selected_journal_code:  
+        <%include file="usage_tr_j1.mako"/>
+      % else:
+        <%include file="usage_cr_j1.mako"/>
+      % endif
     </div>
   </center>
   <h3>${_(u'Gráfico de calor de acessos')}</h3>

--- a/analytics/templates/website/accesses_journal_usage_data.mako
+++ b/analytics/templates/website/accesses_journal_usage_data.mako
@@ -1,0 +1,81 @@
+## coding: utf-8
+<%inherit file="central_container_without_filters.mako"/>
+
+<%block name="central_container">
+  % if not selected_journal_code:
+    <div class="col-md-8">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">${_(u'Atenção')}</h3>
+        </div>
+        <div class="panel-body">
+          ${_(u'É necessário selecionar um periódico para visualizar os relatórios de acesso disponíveis.')}
+        </div>
+      </div>
+    </div>
+
+  % else:
+    <div class="col-md-8">
+      <h1>${_(u'Dados de acessos')}</h1>
+
+      <p>${_(u'O módulo Analytics do SciELO fornece para cada periódico um conjunto de tabelas em formato TSV ou JSON com métricas de acesso.')}</p>
+
+      <p>${_(u'Essas tabelas são resultado de um processo computacional baseado no método COUNTER Release 5 e são disponibilizadas por meio da SciELO SUSHI API.')}</p>
+
+      <p>${_(u'Para mais informações acerca desse método, acesse')} <a href="https://github.com/scieloorg/scielo-sushi-api/blob/master/docs/guide.md" target="_blank"> ${_(u'a documentação oficial da SciELO SUSHI API')}</a>.</p>
+
+      <p>${_(u'Ao todo são disponibilizadas seis tabelas (arquivos em formato tabular).')}</p>
+        
+      <p>${_(u'Escolha um período e acesse os endereços indicados na coluna "Links" da tabela seguinte para obter os relatórios de acesso.')}</p>
+
+      <%include file="access_datepicker.mako"/>
+
+      <table class="table table-striped table-bordered" style="margin-top:20px;">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Descrição</th>
+            <th>Links</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Title Report J1</td>
+            <td>Acessos mensais</td>
+            <td>
+              <a target="_blank" href="http://usage.apis.scielo.org/reports/tr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=tsv&api=v2&collection=${selected_collection_code}">Tabular</a> | <a target="_blank" href="http://usage.apis.scielo.org/reports/tr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=json&api=v2&collection=${selected_collection_code}">JSON</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Language Report J1</td>
+            <td>Acessos mensais agregados por idioma de documento</td>
+            <td>
+              <a target="_blank" href="http://usage.apis.scielo.org/reports/lr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=tsv&api=v2&collection=${selected_collection_code}">Tabular</a> | <a target="_blank" href="http://usage.apis.scielo.org/reports/lr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=json&api=v2&collection=${selected_collection_code}">JSON</a>
+              </td>
+          </tr>
+          <tr>
+            <td>Language Report J4</td>
+            <td>Acessos mensais agregados por ano de publicação e idioma de documento</td>
+            <td>
+              <a target="_blank" href="http://usage.apis.scielo.org/reports/lr_j4?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=tsv&api=v2&collection=${selected_collection_code}">Tabular</a> | <a target="_blank" href="http://usage.apis.scielo.org/reports/lr_j4?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=json&api=v2&collection=${selected_collection_code}">JSON</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Geolocation Report J1</td>
+            <td>Acessos mensais agregados por país de origem de acesso</td>
+            <td>
+              <a target="_blank" href="http://usage.apis.scielo.org/reports/gr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=tsv&api=v2&collection=${selected_collection_code}">Tabular</a> | <a target="_blank" href="http://usage.apis.scielo.org/reports/gr_j1?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=json&api=v2&collection=${selected_collection_code}">JSON</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Geolocation Report J4</td>
+            <td>Acessos mensais agregados por país de origem de acesso e ano de publicação de documento</td>
+            <td>
+              <a target="_blank" href="http://usage.apis.scielo.org/reports/gr_j4?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=tsv&api=v2&collection=${selected_collection_code}">Tabular</a> | <a target="_blank" href="http://usage.apis.scielo.org/reports/gr_j4?begin_date=${range_start}&end_date=${range_end}&issn=${selected_journal_code}&fmt=json&api=v2&collection=${selected_collection_code}">JSON</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  % endif
+</%block>

--- a/analytics/templates/website/home_collection.mako
+++ b/analytics/templates/website/home_collection.mako
@@ -23,17 +23,8 @@
         <div class="row">
             <h3>${_(u'Gráficos')}</h3>
         </div>
-        ## Garante que seja apresentado somente o gráfico do Sushi para a coleção
-        ## Brasil
-        % if selected_collection_code == 'scl':
-          <div class="col-md-12">
-              <%include file="usage_cr_j1.mako"/>
-          </div>
-        % else:
-          <div class="col-md-12">
-              <%include file="access_by_month_and_year.mako"/>
-          </div>
-        % endif
+            <%include file="usage_cr_j1.mako"/>
+        </div>
         <div class="col-md-12">
             <%include file="publication_article_affiliations_map.mako"/>
         </div>

--- a/analytics/templates/website/home_journal.mako
+++ b/analytics/templates/website/home_journal.mako
@@ -28,21 +28,12 @@
         </div>
     </div>
 
-    ## Garante que seja apresentado somente o gráfico do Sushi para a coleção
-    ## Brasil
-    % if selected_collection_code == 'scl':
-        <div class="row container-fluid" style="margin-top: 100px;">
-            <div class="col-md-12">
-                <%include file="usage_tr_j1.mako"/>
-            </div>
+    <div class="row container-fluid" style="margin-top: 100px;">
+        <div class="col-md-12">
+            <%include file="usage_tr_j1.mako"/>
         </div>
-    % else:
-        <div class="row container-fluid" style="margin-top: 100px;">
-            <div class="col-md-12">
-                <%include file="access_by_month_and_year.mako"/>
-            </div>
-        </div>
-    % endif
+    </div>
+    
     <div class="row container-fluid" style="margin-top: 100px;">
         <div class="col-md-12">
             <%include file="publication_article_affiliations_map.mako"/>

--- a/analytics/templates/website/navbar_journal.mako
+++ b/analytics/templates/website/navbar_journal.mako
@@ -6,6 +6,7 @@
   <li class="${'active' if page == 'accesses' else ''}">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">${_(u'Acessos')} <span class="caret"></span></a>
     <ul class="dropdown-menu">
+      <li><a href="${request.route_url('accesses_journal_usage_data_web')}">${_(u'Dados de acessos')}</a></li>
       <li><a href="${request.route_url('accesses_web')}">${_(u'Gráficos')}</a></li>
       <li><a href="${request.route_url('accesses_list_journals_web')}">${_(u'Periódicos')}</a></li>
       <li><a href="${request.route_url('accesses_list_issues_web')}">${_(u'Top 100 Issues')}</a></li>

--- a/analytics/views_website.py
+++ b/analytics/views_website.py
@@ -379,6 +379,16 @@ def accesses(request):
 
     return data
 
+
+@view_config(route_name='accesses_journal_usage_data_web', renderer='templates/website/accesses_journal_usage_data.mako')
+@base_data_manager
+def accesses_journal_usage_data_web(request):
+    data = request.data_manager
+    data['page'] = 'accesses_journal_usage_data'
+
+    return data
+
+
 @view_config(route_name='bibliometrics_journal_citation_data_web', renderer='templates/website/bibliometrics_journal_citation_data.mako')
 @base_data_manager
 def bibliometrics_journal_citation_data_web(request):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ test_requires = ["nose>=1.0", "coverage"]
 
 setup(
     name="analytics",
-    version='1.35.0',
+    version='1.36.0',
     description="A analytics frontend for SciELO usage and publication statistics",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR:
1. Adiciona uma nova página de periódico que lista os relatórios SUSHI disponíveis: lr_j1, lr_j4, gr_j1, gr_j4 e tr_j1.
2. Remove a condição de ser coleção Brasil para exibir gráficos SUSHI

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Acesse a página principal da aplicação, seleciona uma coleção e veja o gráfico SUSHI
2. Selecione um periódico, clique no menu "periódico" e depois em "Dados de acessos"

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

#### Quais são tickets relevantes?
N/A

### Referências
N/A