### PR TITLE
Remove link https://visual.scielo.org/v1/ de barra de navegação

### DIFF
--- a/analytics/templates/website/navbar_common_links.mako
+++ b/analytics/templates/website/navbar_common_links.mako
@@ -1,7 +1,4 @@
 ## coding: utf-8
-<li>
-    <a href="http://visual.scielo.org/v1" target="_blank">${_(u'Visualização')}</a>
-</li>
 <li class="${'active' if page == 'reports' else ''}">
     <a href="${request.route_url('reports')}">${_(u'Relatórios')}</a>
 </li>

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ test_requires = ["nose>=1.0", "coverage"]
 
 setup(
     name="analytics",
-    version='1.36.4',
+    version='2.1.0',
     description="A analytics frontend for SciELO usage and publication statistics",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR remove o item Visualization da barra de navegação, que é um link https://visual.scielo.org/v1/ para acessar a aplicação Analytics Vizualization. O PR também mantém as últimas remoções realizadas em momento anterior.

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
Implantar a aplicação em máquina local por meio de: 
1. Construir a imagem e ligar a aplicação
```bash
cp development-TEMPLATE.ini development.ini
docker compose -f dockerfile-dev.yml build
docker-compose -f dockerfile-dev.yml up
```

2. Conectar-se à VPN
3. Acessar a página principal e observar que não existe mais o link (entre bibliometrics e FAQ).

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![pr-remocao-link-ivz](https://github.com/scieloorg/analytics/assets/158627036/427caf94-2b01-4cbe-8f1a-34de55c70534)


#### Quais são tickets relevantes?
N/A.

### Referências
N/A