### PR TITLE
Atualiza informações de data de atualização de citações

### DIFF
--- a/analytics/templates/website/bibliometrics_datepicker.mako
+++ b/analytics/templates/website/bibliometrics_datepicker.mako
@@ -7,7 +7,7 @@
         <div class="input-group-addon">
           <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
         </div>
-        <input class="input-group-addon" id="selected-year" type="number" name="selected-year" min="1941" max="2030" value="2021"/>
+        <input class="input-group-addon" id="selected-year" type="number" name="selected-year" min="1941" max="2030" value="${selected_year}"/>
         <div class="input-group-addon">
           <a href="#" onclick="updateData();" data-toggle="tooltip" data-placement="bottom" title="${_(u'Citações realizadas no ano selecionado')}">${_(u'aplicar')}</a>
         </div>

--- a/analytics/templates/website/bibliometrics_journal_citation_data.mako
+++ b/analytics/templates/website/bibliometrics_journal_citation_data.mako
@@ -52,7 +52,7 @@
     <ul>
       <li><b>${_(u'Nome do arquivo')}:</b> <a id="link_citations_granted_count" href="https://static.scielo.org/bibliometrics/${selected_journal_code}/${selected_journal_code}_citations_granted_count_${selected_year}.csv">${selected_journal_code}_citations_granted_count_${selected_year}.csv</a></li>
       <li><b>${_(u'Periodicidade de atualização')}:</b> ${_(u'Trimestral')}</li>
-      <li><b>${_(u'Última atualização')}:</b> 24/06/2022</li>
+      <li><b>${_(u'Última atualização')}:</b> 02/03/2026</li>
       <li><b>${_(u'Separador de colunas')}:</b> ${_(u'Vírgula')}</li>
     </ul>
 
@@ -60,7 +60,7 @@
     <ul>
       <li><b>${_(u'Nome do arquivo')}:</b> <a id="link_citations_received_count" href="https://static.scielo.org/bibliometrics/${selected_journal_code}/${selected_journal_code}_citations_received_count_${selected_year}.csv">${selected_journal_code}_citations_received_count_${selected_year}.csv</a></li>
       <li><b>${_(u'Periodicidade de atualização')}:</b> ${_(u'Trimestral')}</li>
-      <li><b>${_(u'Última atualização')}:</b> 24/06/2022</li>
+      <li><b>${_(u'Última atualização')}:</b> 02/03/2026</li>
       <li><b>${_(u'Separador de colunas')}:</b> ${_(u'Vírgula')}</li>
     </ul>
 
@@ -68,7 +68,7 @@
     <ul>
       <li><b>${_(u'Nome do arquivo')}:</b> <a id="link_citations_received_cited_forms" href="https://static.scielo.org/bibliometrics/${selected_journal_code}/${selected_journal_code}_citations_received_cited_forms_${selected_year}.csv">${selected_journal_code}_citations_received_cited_forms_${selected_year}.csv</a></li>
       <li><b>${_(u'Periodicidade de atualização')}:</b> ${_(u'Trimestral')}</li>
-      <li><b>${_(u'Última atualização')}:</b> 24/06/2022</li>
+      <li><b>${_(u'Última atualização')}:</b> 02/03/2026</li>
       <li><b>${_(u'Separador de colunas')}:</b> ${_(u'Vírgula')}</li>
     </ul>
 
@@ -76,7 +76,7 @@
     <ul>
       <li><b>${_(u'Nome do arquivo')}:</b> <a id="link_citations_received_citing_pids" href="https://static.scielo.org/bibliometrics/${selected_journal_code}/${selected_journal_code}_citations_received_citing_pids_${selected_year}.csv">${selected_journal_code}_citations_received_citing_pids_${selected_year}.csv</a></li>
       <li><b>${_(u'Periodicidade de atualização')}:</b> ${_(u'Trimestral')}</li>
-      <li><b>${_(u'Última atualização')}:</b> 24/06/2022</li>
+      <li><b>${_(u'Última atualização')}:</b> 02/03/2026</li>
       <li><b>${_(u'Separador de colunas')}:</b> ${_(u'Vírgula')}</li>
     </ul>
 
@@ -84,7 +84,7 @@
     <ul>
       <li><b>${_(u'Nome do arquivo')}:</b> <a id="link_citations_received_standardized" href="https://static.scielo.org/bibliometrics/${selected_journal_code}/${selected_journal_code}_citations_received_standardized_${selected_year}.csv">${selected_journal_code}_citations_received_standardized_${selected_year}.csv</a></li>
       <li><b>${_(u'Periodicidade de atualização')}:</b> ${_(u'Trimestral')}</li>
-      <li><b>${_(u'Última atualização')}:</b> 24/06/2022</li>
+      <li><b>${_(u'Última atualização')}:</b> 02/03/2026</li>
       <li><b>${_(u'Separador de colunas')}:</b> ${_(u'Vírgula')}</li>
     </ul>
 


### PR DESCRIPTION
This pull request updates the bibliometrics date picker and citation data templates to improve year selection and ensure the displayed metadata reflects the latest data updates.

Improvements to year selection:

* The default value for the year input in `bibliometrics_datepicker.mako` now dynamically uses the `selected_year` variable, allowing the selected year to be reflected in the input field.

Updates to citation data metadata:

* The "Última atualização" (last update) date for all five data sections in `bibliometrics_journal_citation_data.mako` has been updated from "24/06/2022" to "02/03/2026" to indicate the most recent data refresh.