### PR TITLE
Codex/hml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-  - 3.5
+  - "3.13"
 env:
   - ANALYTICS_SETTINGS_FILE=./config.ini
 install: 
   - pip install --upgrade deps/scielojcr-1.3.0-py2.py3-none-any.whl
   - python setup.py install
 script:
-  - python setup.py test
+  - python -m unittest discover -s tests
 before_script:
   - cp ./development.ini-TEMPLATE ./config.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM python:3.6
+FROM python:3.13-slim
 ENV PYTHONUNBUFFERED 1
 
 
 RUN apt-get update
-RUN apt-key update
-RUN apt-get install --yes libmemcached-dev
+RUN apt-get install --yes build-essential git libmemcached-dev zlib1g-dev
 
 COPY . /app
 COPY production.ini-TEMPLATE /app/config.ini
 
 WORKDIR /app
 
-RUN pip install --upgrade pip && \
+RUN pip install --upgrade pip "setuptools<81" wheel && \
     pip install gunicorn && \
     pip install --upgrade deps/scielojcr-1.3.0-py2.py3-none-any.whl && \
     pip install -r requirements.txt && \
-    python setup.py install
+    pip install .
 
 ENV ANALYTICS_SETTINGS_FILE=/app/config.ini
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,9 +1,8 @@
-FROM python:3.6
+FROM python:3.13-slim
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update
-RUN apt-key update
-RUN apt-get install --yes libmemcached-dev
+RUN apt-get install --yes build-essential git libmemcached-dev zlib1g-dev
 
 
 COPY . /app
@@ -11,11 +10,11 @@ COPY development.ini-TEMPLATE /app/config.ini
 
 WORKDIR /app
 
-RUN pip install --upgrade pip && \
+RUN pip install --upgrade pip "setuptools<81" wheel && \
     pip install gunicorn && \
     pip install --upgrade deps/scielojcr-1.3.0-py2.py3-none-any.whl && \
     pip install -r requirements.txt && \
-    python setup.py install
+    pip install .
 RUN chown -R nobody:nogroup /app
 
 ENV ANALYTICS_SETTINGS_FILE=/app/config.ini

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Para testes, é mais prático usar um ambiente virtual Python em vez de containe
 sudo apt install libmemcached-dev
 ```
 
-2. Crie um ambiente virtual Python 3.6 (usando miniconda):
+2. Crie um ambiente virtual Python 3.13 (usando miniconda):
 
 ```bash
-conda create -n scl-analytics python=3.6 -y
+conda create -n scl-analytics python=3.13 -y
 conda activate scl-analytics
 ```
 
@@ -45,7 +45,7 @@ pip install -r requirements.txt
 4. Execute os testes de unidade:
 
 ```bash
-python setup.py test
+python -m unittest discover -s tests
 ```
 
 > ⚠️ **Observação**: fora do Docker, o Memcached deve estar rodando localmente (`127.0.0.1:11211`). Você pode iniciá-lo com:

--- a/README.md
+++ b/README.md
@@ -156,8 +156,18 @@ Variáveis:
 * `BACKEND_TIMEOUT_SECONDS` (default: `8`)
 * `PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS` (default: `4`)
 * `PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE` (default: `8`)
+* `PUBLICATION_AFFILIATIONS_MAX_INFLIGHT` (default: valor de `PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE`)
 * `USAGE_REPORT_TIMEOUT_SECONDS` (default: `4`)
 * `USAGE_YEARLY_TIMEOUT_SECONDS` (default: usa valor de `USAGE_REPORT_TIMEOUT_SECONDS`)
+* `USAGE_TIMEOUT_POOL_SIZE` (default: `8`)
+* `USAGE_TIMEOUT_MAX_INFLIGHT` (default: valor de `USAGE_TIMEOUT_POOL_SIZE`)
+
+Detalhes de comportamento:
+
+* Endpoints de usage usam fallback de período por sessão (`range_start`/`range_end`) quando os parâmetros não são enviados.
+* Os pools são isolados por backend (`usage` e `publication`) para evitar contenção cruzada.
+* O limite de inflight aplica backpressure: quando saturado, retorna fallback sem disparar nova chamada de backend.
+* Em timeout, a requisição em background recebe `cancel()` (best effort), mantendo o retorno rápido ao usuário.
 
 ### 4. Circuit breaker para Usage API
 
@@ -182,8 +192,11 @@ PREWARM_DELAY_SECONDS=2
 BACKEND_TIMEOUT_SECONDS=8
 PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS=4
 PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE=8
+PUBLICATION_AFFILIATIONS_MAX_INFLIGHT=8
 USAGE_REPORT_TIMEOUT_SECONDS=4
 USAGE_YEARLY_TIMEOUT_SECONDS=4
+USAGE_TIMEOUT_POOL_SIZE=8
+USAGE_TIMEOUT_MAX_INFLIGHT=8
 
 USAGE_CIRCUIT_BREAKER_HOST=usage.apis.scielo.org
 USAGE_CIRCUIT_BREAKER_FAILURE_THRESHOLD=3

--- a/README.md
+++ b/README.md
@@ -121,6 +121,77 @@ http://0.0.0.0:6543
 
 ---
 
+## Cache, timeout e resiliência (home e gráficos)
+
+As rotas AJAX mais pesadas foram preparadas para reduzir latência de primeira carga e proteger o backend em cenários de degradação.
+
+### 1. Cache em Memcached (recomendado)
+
+Com `MEMCACHED_HOST` configurado, o app usa `dogpile.cache.pylibmc` para cache compartilhado entre workers/instâncias.
+
+Efeito prático:
+
+* A primeira requisição para uma combinação de parâmetros (coleção, período, relatório, métrica etc.) consulta o backend externo.
+* Requisições seguintes com a mesma chave servem do cache, inclusive para usuários diferentes.
+* Nova consulta externa só ocorre em `cache miss` ou após expiração.
+
+Sem `MEMCACHED_HOST`, o app cai para `dogpile.cache.memory` (cache por processo).
+
+### 2. Prewarm de cache no startup
+
+No boot da aplicação, um prewarm assíncrono prepara dados base de coleção e agregações críticas da home.
+
+Variáveis:
+
+* `ENABLE_CACHE_PREWARM` (default: `1`)
+* `PREWARM_DELAY_SECONDS` (default: `0`)
+* `PREWARM_COLLECTION` (default: `scl`)
+
+### 3. Timeout e fallback por backend (sem mudar regra de negócio)
+
+Quando backend externo está lento/indisponível, endpoints críticos retornam payload válido vazio em tempo limitado, evitando travamento da home.
+
+Variáveis:
+
+* `BACKEND_TIMEOUT_SECONDS` (default: `8`)
+* `PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS` (default: `4`)
+* `PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE` (default: `8`)
+* `USAGE_REPORT_TIMEOUT_SECONDS` (default: `4`)
+* `USAGE_YEARLY_TIMEOUT_SECONDS` (default: usa valor de `USAGE_REPORT_TIMEOUT_SECONDS`)
+
+### 4. Circuit breaker para Usage API
+
+As chamadas para `usage.apis.scielo.org` usam circuit breaker para reduzir efeito cascata em falhas repetidas.
+
+Variáveis:
+
+* `USAGE_CIRCUIT_BREAKER_HOST` (default: `usage.apis.scielo.org`)
+* `USAGE_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (default: `3`)
+* `USAGE_CIRCUIT_BREAKER_OPEN_SECONDS` (default: `90`)
+
+### 5. Exemplo de configuração (homologação)
+
+```bash
+MEMCACHED_HOST=memcached:11211
+MEMCACHED_EXPIRATION_TIME=2592000
+
+ENABLE_CACHE_PREWARM=1
+PREWARM_COLLECTION=scl
+PREWARM_DELAY_SECONDS=2
+
+BACKEND_TIMEOUT_SECONDS=8
+PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS=4
+PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE=8
+USAGE_REPORT_TIMEOUT_SECONDS=4
+USAGE_YEARLY_TIMEOUT_SECONDS=4
+
+USAGE_CIRCUIT_BREAKER_HOST=usage.apis.scielo.org
+USAGE_CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
+USAGE_CIRCUIT_BREAKER_OPEN_SECONDS=90
+```
+
+---
+
 ## Alterando a aplicação (desenvolvimento)
 
 Sempre que fizer alterações:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Variáveis:
 * `PUBLICATION_AFFILIATIONS_MAX_INFLIGHT` (default: valor de `PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE`)
 * `USAGE_REPORT_TIMEOUT_SECONDS` (default: `4`)
 * `USAGE_YEARLY_TIMEOUT_SECONDS` (default: usa valor de `USAGE_REPORT_TIMEOUT_SECONDS`)
+* `USAGE_YEARLY_DEFAULT_MONTHS` (default: `24`, aplicado quando yearly não recebe `range_start/range_end`)
 * `USAGE_TIMEOUT_POOL_SIZE` (default: `8`)
 * `USAGE_TIMEOUT_MAX_INFLIGHT` (default: valor de `USAGE_TIMEOUT_POOL_SIZE`)
 
@@ -195,6 +196,7 @@ PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE=8
 PUBLICATION_AFFILIATIONS_MAX_INFLIGHT=8
 USAGE_REPORT_TIMEOUT_SECONDS=4
 USAGE_YEARLY_TIMEOUT_SECONDS=4
+USAGE_YEARLY_DEFAULT_MONTHS=24
 USAGE_TIMEOUT_POOL_SIZE=8
 USAGE_TIMEOUT_MAX_INFLIGHT=8
 
@@ -202,6 +204,25 @@ USAGE_CIRCUIT_BREAKER_HOST=usage.apis.scielo.org
 USAGE_CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
 USAGE_CIRCUIT_BREAKER_OPEN_SECONDS=90
 ```
+
+### 6. Monitoramento com Prometheus
+
+Foi adicionado endpoint de métricas em:
+
+```bash
+GET /metrics
+```
+
+Principais métricas:
+
+* `analytics_http_requests_total`
+* `analytics_http_request_duration_seconds`
+* `analytics_http_requests_in_progress`
+* `analytics_backend_calls_total`
+* `analytics_backend_call_duration_seconds`
+* `analytics_backend_inflight_rejected_total`
+* `analytics_circuit_breaker_state`
+* `analytics_cache_backend_info`
 
 ---
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,4 +1,7 @@
 import os
+import time
+import logging
+import threading
 from pyramid.session import SignedCookieSessionFactory
 from pyramid.renderers import JSONP
 from pyramid.config import Configurator
@@ -10,6 +13,42 @@ from analytics.views_website import cache_region as views_website_cache_region
 from analytics.views_ajax import cache_region as views_ajax_cache_region
 from analytics.controller import cache_region as controller_cache_region
 from analytics.control_manager import cache_region as control_manager_cache_region
+
+logger = logging.getLogger(__name__)
+
+
+def _start_cache_prewarm(settings):
+    if os.environ.get("ENABLE_CACHE_PREWARM", "1").lower() in ("0", "false", "no"):
+        return
+
+    def _prewarm():
+        delay_seconds = float(os.environ.get("PREWARM_DELAY_SECONDS", "0"))
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+
+        collection = os.environ.get("PREWARM_COLLECTION", "scl")
+        try:
+            stats = controller.Stats(
+                settings.get('articlemeta', None),
+                settings.get('publicationstats', None),
+                settings.get('citedby', None),
+                settings.get('usage', None),
+                request=None
+            )
+            stats.articlemeta.certified_collections()
+            stats.articlemeta.collections_journals(collection)
+            stats.publication.list_subject_areas(collection, collection)
+            stats.publication.list_languages(collection, collection)
+            stats.publication.list_publication_years(collection, collection)
+            logger.info("Cache prewarm finished for collection '%s'", collection)
+        except Exception as exc:
+            logger.warning("Cache prewarm failed: %s", exc)
+
+    threading.Thread(
+        target=_prewarm,
+        name="cache-prewarm",
+        daemon=True,
+    ).start()
 
 
 def main(global_config, **settings):
@@ -109,14 +148,18 @@ def main(global_config, **settings):
         controller_cache_region.configure('dogpile.cache.pylibmc', **cache_config)
         control_manager_cache_region.configure('dogpile.cache.pylibmc', **cache_config)
     else:
-        views_website_cache_region.configure('dogpile.cache.null')
-        controller_cache_region.configure('dogpile.cache.null')
-        control_manager_cache_region.configure('dogpile.cache.null')
-        views_ajax_cache_region.configure('dogpile.cache.null')
+        # Fallback to in-process cache when memcached is unavailable.
+        # This avoids recomputing heavy remote calls on every request.
+        cache_config = {'expiration_time': int(memcached_expiration_time)}
+        views_website_cache_region.configure('dogpile.cache.memory', **cache_config)
+        controller_cache_region.configure('dogpile.cache.memory', **cache_config)
+        control_manager_cache_region.configure('dogpile.cache.memory', **cache_config)
+        views_ajax_cache_region.configure('dogpile.cache.memory', **cache_config)
 
     # Session config
     navegation_session_factory = SignedCookieSessionFactory('sses_navegation')
     config.set_session_factory(navegation_session_factory)
+    _start_cache_prewarm(settings)
 
     config.scan()
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -2,12 +2,14 @@ import os
 import time
 import logging
 import threading
+from pyramid.response import Response
 from pyramid.session import SignedCookieSessionFactory
 from pyramid.renderers import JSONP
 from pyramid.config import Configurator
 
 from analytics import controller
 from analytics import charts_config
+from analytics import monitoring
 
 from analytics.views_website import cache_region as views_website_cache_region
 from analytics.views_ajax import cache_region as views_ajax_cache_region
@@ -17,7 +19,39 @@ from analytics.control_manager import cache_region as control_manager_cache_regi
 logger = logging.getLogger(__name__)
 
 
-def _start_cache_prewarm(settings):
+def _metrics_view(_request):
+    body, content_type = monitoring.metrics_response()
+    return Response(body=body, content_type=content_type)
+
+
+def _request_metrics_tween_factory(handler, registry):
+    def _tween(request):
+        route_name = "unknown"
+        if request.matched_route is not None:
+            route_name = request.matched_route.name
+        method = request.method
+        timer = monitoring.HTTP_REQUEST_DURATION_SECONDS.labels(method=method, route=route_name).time()
+        monitoring.HTTP_REQUESTS_IN_PROGRESS.labels(method=method, route=route_name).inc()
+        try:
+            with timer:
+                response = handler(request)
+            status_code = str(getattr(response, "status_code", "200"))
+            monitoring.HTTP_REQUESTS_TOTAL.labels(
+                method=method, route=route_name, status_code=status_code
+            ).inc()
+            return response
+        except Exception:
+            monitoring.HTTP_REQUESTS_TOTAL.labels(
+                method=method, route=route_name, status_code="500"
+            ).inc()
+            raise
+        finally:
+            monitoring.HTTP_REQUESTS_IN_PROGRESS.labels(method=method, route=route_name).dec()
+
+    return _tween
+
+
+def _start_cache_prewarm(settings, usage_api_base_url=None):
     if os.environ.get("ENABLE_CACHE_PREWARM", "1").lower() in ("0", "false", "no"):
         return
 
@@ -32,7 +66,7 @@ def _start_cache_prewarm(settings):
                 settings.get('articlemeta', None),
                 settings.get('publicationstats', None),
                 settings.get('citedby', None),
-                settings.get('usage', None),
+                usage_api_base_url,
                 request=None
             )
             stats.articlemeta.certified_collections()
@@ -71,13 +105,14 @@ def main(global_config, **settings):
     """
     config = Configurator(settings=settings)
     config.add_renderer('jsonp', JSONP(param_name='callback', indent=4))
+    usage_api_base_url = os.environ.get('USAGE_API_BASE_URL', settings.get('usage', None))
 
     def add_stats(request):
         return controller.Stats(
             settings.get('articlemeta', None),
             settings.get('publicationstats', None),
             settings.get('citedby', None),
-            settings.get('usage', None),
+            usage_api_base_url,
             request
         )
 
@@ -89,6 +124,7 @@ def main(global_config, **settings):
     config.add_route('index_web', '/')
     config.add_route('faq_web', '/w/faq')
     config.add_route('reports', '/w/reports')
+    config.add_route('metrics', '/metrics')
     config.add_route('usage_report_chart', '/ajx/usage/usage_report_chart')
     config.add_route('usage_report_yearly_chart', '/ajx/usage/usage_report_yearly_chart')
     config.add_route('accesses_web', '/w/accesses')
@@ -138,6 +174,8 @@ def main(global_config, **settings):
     config.add_subscriber('analytics.subscribers.add_localizer',
                           'pyramid.events.NewRequest')
     config.add_translation_dirs('analytics:locale')
+    config.add_tween('analytics._request_metrics_tween_factory', over='MAIN')
+    config.add_view(_metrics_view, route_name='metrics', request_method='GET')
 
     # Cache Settings Config
     memcached_host = (
@@ -162,6 +200,8 @@ def main(global_config, **settings):
         views_website_cache_region.configure('dogpile.cache.pylibmc', **cache_config)
         controller_cache_region.configure('dogpile.cache.pylibmc', **cache_config)
         control_manager_cache_region.configure('dogpile.cache.pylibmc', **cache_config)
+        monitoring.CACHE_BACKEND_INFO.labels(backend='pylibmc').set(1)
+        monitoring.CACHE_BACKEND_INFO.labels(backend='memory').set(0)
     else:
         # Fallback to in-process cache when memcached is unavailable.
         # This avoids recomputing heavy remote calls on every request.
@@ -170,11 +210,13 @@ def main(global_config, **settings):
         controller_cache_region.configure('dogpile.cache.memory', **cache_config)
         control_manager_cache_region.configure('dogpile.cache.memory', **cache_config)
         views_ajax_cache_region.configure('dogpile.cache.memory', **cache_config)
+        monitoring.CACHE_BACKEND_INFO.labels(backend='memory').set(1)
+        monitoring.CACHE_BACKEND_INFO.labels(backend='pylibmc').set(0)
 
     # Session config
     navegation_session_factory = SignedCookieSessionFactory('sses_navegation')
     config.set_session_factory(navegation_session_factory)
-    _start_cache_prewarm(settings)
+    _start_cache_prewarm(settings, usage_api_base_url=usage_api_base_url)
 
     config.scan()
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -39,7 +39,22 @@ def _start_cache_prewarm(settings):
             stats.articlemeta.collections_journals(collection)
             stats.publication.list_subject_areas(collection, collection)
             stats.publication.list_languages(collection, collection)
-            stats.publication.list_publication_years(collection, collection)
+            publication_years = stats.publication.list_publication_years(collection, collection)
+            if publication_years:
+                py_range = [publication_years[0], publication_years[-1]]
+            else:
+                current_year = str(time.gmtime().tm_year)
+                py_range = [current_year, current_year]
+
+            # Warm the heaviest home chart payload used by affiliations widgets.
+            stats.publication.general(
+                'article',
+                'aff_countries',
+                collection,
+                collection,
+                py_range=py_range,
+                size=0
+            )
             logger.info("Cache prewarm finished for collection '%s'", collection)
         except Exception as exc:
             logger.warning("Cache prewarm failed: %s", exc)

--- a/analytics/charts_config.py
+++ b/analytics/charts_config.py
@@ -338,9 +338,13 @@ class ChartsConfig(object):
                 'text': self._(u'Número de documentos')
             }
         }
+        map_values = []
+        if data.get('series') and data['series'][0].get('data'):
+            map_values = data['series'][0]['data']
+
         chart['colorAxis'] = {
             'min': 1,
-            'max': sorted(data['series'][0]['data'])[-1],
+            'max': sorted(map_values)[-1] if map_values else 1,
             'type': 'logarithmic'
         }
 
@@ -351,7 +355,7 @@ class ChartsConfig(object):
             }
         }
         chart['series'] = [{
-            'data': [{'value': v, 'code': k, 'name': k} for k, v in dict(zip(data['categories'], data['series'][0]['data'])).items()],
+            'data': [{'value': v, 'code': k, 'name': k} for k, v in dict(zip(data.get('categories', []), map_values)).items()],
             'joinBy': ['iso-a2', 'code'],
             'name': self._(u'Documentos'),
             'states': {

--- a/analytics/control_manager.py
+++ b/analytics/control_manager.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 import os
 import datetime
+import logging
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 from pyramid.settings import aslist
 
@@ -11,6 +13,22 @@ from analytics import choices
 
 
 cache_region = make_region(name='control_manager')
+logger = logging.getLogger(__name__)
+
+
+def _backend_call_with_timeout(func, fallback_factory, timeout_seconds, label):
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(func)
+    try:
+        return future.result(timeout=timeout_seconds)
+    except FuturesTimeoutError:
+        logger.warning("Timeout calling backend '%s' after %ss; using fallback", label, timeout_seconds)
+        return fallback_factory()
+    except Exception as exc:
+        logger.warning("Backend '%s' failed (%s); using fallback", label, exc)
+        return fallback_factory()
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def current_url(current_url, data):
@@ -126,23 +144,43 @@ def base_data_manager(wrapped):
 
     @check_session
     def wrapper(request, *arg, **kwargs):
+        backend_timeout_seconds = float(os.environ.get("BACKEND_TIMEOUT_SECONDS", "8"))
 
         @cache_region.cache_on_arguments()
         def get_data_manager(collection, journal, document, range_start, range_end):
             code = document or journal or collection
             data = {}
+            fallback_collection = collection or 'scl'
 
-            xylose_doc = request.stats.articlemeta.document(document, collection) if document else None
+            xylose_doc = None
+            if document:
+                xylose_doc = _backend_call_with_timeout(
+                    lambda: request.stats.articlemeta.document(document, collection),
+                    lambda: None,
+                    backend_timeout_seconds,
+                    'articlemeta.document'
+                )
 
             if xylose_doc and xylose_doc.publisher_id:
                 data['selected_document'] = xylose_doc
                 data['selected_document_code'] = document
                 journal = document[1:10]
 
-            collections = request.stats.articlemeta.certified_collections()
-            journals = request.stats.articlemeta.collections_journals(collection)
+            collections = _backend_call_with_timeout(
+                lambda: request.stats.articlemeta.certified_collections(),
+                lambda: {fallback_collection: {'name': fallback_collection, 'domain': ''}},
+                backend_timeout_seconds,
+                'articlemeta.certified_collections'
+            )
+            journals = _backend_call_with_timeout(
+                lambda: request.stats.articlemeta.collections_journals(collection),
+                lambda: {},
+                backend_timeout_seconds,
+                'articlemeta.collections_journals'
+            )
             selected_journal = journals.get(journal, None)
             selected_journal_code = journal if journal in journals else None
+            selected_collection = collections.get(collection) or collections.get(fallback_collection) or {'name': fallback_collection, 'domain': ''}
 
             today = datetime.datetime.now()
             y3 = today - datetime.timedelta(365*3)
@@ -155,7 +193,7 @@ def base_data_manager(wrapped):
                 'selected_journal': selected_journal,
                 'selected_journal_code': selected_journal_code,
                 'selected_document_code': document or None,
-                'selected_collection': collections[collection],
+                'selected_collection': selected_collection,
                 'selected_collection_code': collection,
                 'journals': journals,
                 'range_start': range_start,
@@ -188,9 +226,28 @@ def base_data_manager(wrapped):
             'GOOGLE_ANALYTICS_SAMPLE_RATE',
             request.registry.settings.get('google_analytics_sample_rate', '100')
         )
-        data['subject_areas'] = request.stats.publication.list_subject_areas(data['selected_code'], data['selected_collection_code'])
-        data['languages'] = [(i, choices.ISO_639_1.get(i.upper(), 'undefined')) for i in request.stats.publication.list_languages(data['selected_code'], data['selected_collection_code'])]
-        data['publication_years'] = request.stats.publication.list_publication_years(data['selected_code'], data['selected_collection_code'])
+        subject_areas = _backend_call_with_timeout(
+            lambda: request.stats.publication.list_subject_areas(data['selected_code'], data['selected_collection_code']),
+            lambda: [],
+            backend_timeout_seconds,
+            'publicationstats.list_subject_areas'
+        )
+        languages = _backend_call_with_timeout(
+            lambda: request.stats.publication.list_languages(data['selected_code'], data['selected_collection_code']),
+            lambda: [],
+            backend_timeout_seconds,
+            'publicationstats.list_languages'
+        )
+        publication_years = _backend_call_with_timeout(
+            lambda: request.stats.publication.list_publication_years(data['selected_code'], data['selected_collection_code']),
+            lambda: [],
+            backend_timeout_seconds,
+            'publicationstats.list_publication_years'
+        )
+
+        data['subject_areas'] = subject_areas
+        data['languages'] = [(i, choices.ISO_639_1.get(i.upper(), 'undefined')) for i in languages]
+        data['publication_years'] = publication_years
         if len(data['publication_years']) == 0:
             data['publication_years'] = [str(datetime.datetime.now().year)]
         py = '-'.join([data['publication_years'][0], data['publication_years'][-1]])

--- a/analytics/controller.py
+++ b/analytics/controller.py
@@ -1,18 +1,19 @@
 # coding: utf-8
 import json
+import os
 import urllib.parse
+from types import SimpleNamespace
 
 from dogpile.cache import make_region
 from scieloh5m5 import h5m5
 # from scielojcr import jcrindicators
 from articlemeta.client import ThriftClient as ArticleMetaThriftClient
-from citedby.client import ThriftClient as CitedbyThriftClient
 from publicationstats.client import ThriftClient as PublicationStatsThriftClient
 from publicationstats import queries as PublicationStatsQueries
-from citedby import custom_query
 from altmetric import Altmetric, AltmetricHTTPException
 
 from analytics import choices, utils, request_utils
+from analytics import custom_query
 
 
 SCIELO_SUSHI_API_ERROR_KEY = 'Severity'
@@ -102,18 +103,28 @@ class ServerError(Exception):
 
 class Stats(object):
 
-    def __init__(self, articlemeta_host, publicationstats_host, bibliometrics_host, usage_api_host, request):
-        self.articlemeta = ArticleMeta()
-        self.publication = PublicationStats()
+    def __init__(
+        self,
+        articlemeta_host,
+        publicationstats_host,
+        bibliometrics_host,
+        usage_api_host,
+        request=None
+    ):
+        translate = getattr(request, "translate", None) or (lambda text: text)
+        self.request = request or SimpleNamespace(translate=translate)
+        articlemeta_timeout_ms = int(os.environ.get("ARTICLEMETA_TIMEOUT_MS", "5000"))
+        self.articlemeta = ArticleMeta(articlemeta_host, timeout=articlemeta_timeout_ms)
+        self.publication = PublicationStats(publicationstats_host)
         self.bibliometrics = BibliometricsStats()
-        self.usage = UsageStats(usage_api_host, request.translate)
+        self.usage = UsageStats(usage_api_host, translate)
 
     @property
     def _(self):
         return self.request.translate
 
 
-class BibliometricsStats(CitedbyThriftClient):
+class BibliometricsStats(object):
 
     def _compute_google_h5m5(self, data):
 

--- a/analytics/custom_query.py
+++ b/analytics/custom_query.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+
+class JournalTitles:
+    """
+    Minimal local replacement for custom title query templates.
+    """
+
+    _DATA = {
+        "0000-0000": {
+            "must_not": [
+                "ecol api",
+                "ecol apl",
+                "ecol apli",
+                "ecol aplic",
+                "ecol app",
+                "ecol appl",
+                "ecol applic",
+                "ecolapl",
+                "ecolappl",
+                "ecologia aplicada",
+                "econ adm",
+                "econ bol",
+            ],
+            "should": [
+                {"title": "econ aplic"},
+                {"title": "economia aplicada"},
+            ],
+        }
+    }
+
+    def load(self, issn):
+        return self._DATA.get(issn, {"must_not": [], "should": []})
+
+
+journal_titles = JournalTitles()

--- a/analytics/monitoring.py
+++ b/analytics/monitoring.py
@@ -1,0 +1,77 @@
+import time
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "analytics_http_requests_total",
+    "Total HTTP requests handled by the app",
+    ["method", "route", "status_code"],
+)
+
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    "analytics_http_request_duration_seconds",
+    "HTTP request latency in seconds",
+    ["method", "route"],
+)
+
+HTTP_REQUESTS_IN_PROGRESS = Gauge(
+    "analytics_http_requests_in_progress",
+    "HTTP requests currently in progress",
+    ["method", "route"],
+)
+
+BACKEND_CALLS_TOTAL = Counter(
+    "analytics_backend_calls_total",
+    "Total backend calls by backend and operation",
+    ["backend", "operation", "result"],
+)
+
+BACKEND_CALL_DURATION_SECONDS = Histogram(
+    "analytics_backend_call_duration_seconds",
+    "Backend call duration in seconds",
+    ["backend", "operation"],
+)
+
+BACKEND_INFLIGHT_REJECTED_TOTAL = Counter(
+    "analytics_backend_inflight_rejected_total",
+    "Rejected backend calls due to inflight guard saturation",
+    ["backend", "operation"],
+)
+
+CIRCUIT_BREAKER_STATE = Gauge(
+    "analytics_circuit_breaker_state",
+    "Circuit breaker state (1=open, 0=closed)",
+    ["host"],
+)
+
+CACHE_BACKEND_INFO = Gauge(
+    "analytics_cache_backend_info",
+    "Configured cache backend (1 for active backend)",
+    ["backend"],
+)
+
+
+def metrics_response():
+    return generate_latest(), CONTENT_TYPE_LATEST
+
+
+def observe_backend_call(backend, operation, callable_obj):
+    started_at = time.monotonic()
+    try:
+        result = callable_obj()
+        BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation, result="success").inc()
+        return result
+    except Exception:
+        BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation, result="error").inc()
+        raise
+    finally:
+        BACKEND_CALL_DURATION_SECONDS.labels(backend=backend, operation=operation).observe(
+            time.monotonic() - started_at
+        )

--- a/analytics/request_utils.py
+++ b/analytics/request_utils.py
@@ -5,6 +5,7 @@ import time
 from urllib.parse import urlparse
 
 import requests
+from analytics import monitoring
 
 from requests.exceptions import (
     ConnectionError,
@@ -68,6 +69,7 @@ def _breaker_mark_success():
     with _breaker_lock:
         _breaker_state["failures"] = 0
         _breaker_state["open_until"] = 0.0
+        monitoring.CIRCUIT_BREAKER_STATE.labels(host=CIRCUIT_BREAKER_HOST).set(0)
 
 
 def _breaker_mark_failure():
@@ -76,6 +78,7 @@ def _breaker_mark_failure():
         failures = _breaker_state["failures"]
         if failures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD:
             _breaker_state["open_until"] = time.time() + CIRCUIT_BREAKER_OPEN_SECONDS
+            monitoring.CIRCUIT_BREAKER_STATE.labels(host=CIRCUIT_BREAKER_HOST).set(1)
             logger.warning(
                 "Circuit breaker opened for host '%s' for %ss after %s failures",
                 CIRCUIT_BREAKER_HOST,
@@ -123,40 +126,46 @@ def fetch_data(url, json=True, params=None, timeout=32, verify=True):
         RetryableError: If a connection or timeout error occurs (for retry).
         NonRetryableError: For schema, URL, or 4xx client errors.
     """
-    if _is_breaker_target(url) and _breaker_is_open():
-        logger.warning(
-            "Circuit breaker open for host '%s', short-circuiting request: %s",
-            CIRCUIT_BREAKER_HOST,
-            url,
-        )
-        raise NonRetryableError(CircuitOpenError(url))
+    def _do_fetch():
+        if _is_breaker_target(url) and _breaker_is_open():
+            logger.warning(
+                "Circuit breaker open for host '%s', short-circuiting request: %s",
+                CIRCUIT_BREAKER_HOST,
+                url,
+            )
+            monitoring.BACKEND_CALLS_TOTAL.labels(
+                backend="usage_api", operation="fetch_data", result="circuit_open"
+            ).inc()
+            raise NonRetryableError(CircuitOpenError(url))
 
-    try:
-        logger.info(f"Fetching URL: {url} with params {params}")
-        response = requests.get(url, params=params, timeout=timeout, verify=verify)
-        response.raise_for_status()
-        if _is_breaker_target(url):
-            _breaker_mark_success()
+        try:
+            logger.info(f"Fetching URL: {url} with params {params}")
+            response = requests.get(url, params=params, timeout=timeout, verify=verify)
+            response.raise_for_status()
+            if _is_breaker_target(url):
+                _breaker_mark_success()
 
-    except (ConnectionError, Timeout) as exc:
-        if _is_breaker_target(url):
-            _breaker_mark_failure()
-        logger.error(f"Erro fetching content: {url}. Retrying... Error: {exc}")
-        raise RetryableError(exc) from exc
-
-    except (InvalidSchema, MissingSchema, InvalidURL) as exc:
-        logger.error(f"Invalid URL or schema: {url}. Error: {exc}")
-        raise NonRetryableError(exc) from exc
-    
-    except HTTPError as exc:
-        status_code = exc.response.status_code
-        if 400 <= status_code < 500:
-            logger.error(f"Client error (non-retryable): {url}. Status: {status_code}")
-            raise NonRetryableError(exc) from exc
-        elif 500 <= status_code < 600:
+        except (ConnectionError, Timeout) as exc:
             if _is_breaker_target(url):
                 _breaker_mark_failure()
-            logger.error(f"Server error: {url}. Retrying... Status: {status_code}")
+            logger.error(f"Erro fetching content: {url}. Retrying... Error: {exc}")
             raise RetryableError(exc) from exc
 
-    return response.json() if json else response.content
+        except (InvalidSchema, MissingSchema, InvalidURL) as exc:
+            logger.error(f"Invalid URL or schema: {url}. Error: {exc}")
+            raise NonRetryableError(exc) from exc
+        
+        except HTTPError as exc:
+            status_code = exc.response.status_code
+            if 400 <= status_code < 500:
+                logger.error(f"Client error (non-retryable): {url}. Status: {status_code}")
+                raise NonRetryableError(exc) from exc
+            elif 500 <= status_code < 600:
+                if _is_breaker_target(url):
+                    _breaker_mark_failure()
+                logger.error(f"Server error: {url}. Retrying... Status: {status_code}")
+                raise RetryableError(exc) from exc
+
+        return response.json() if json else response.content
+
+    return monitoring.observe_backend_call("usage_api", "fetch_data", _do_fetch)

--- a/analytics/request_utils.py
+++ b/analytics/request_utils.py
@@ -1,4 +1,9 @@
 import logging
+import os
+import threading
+import time
+from urllib.parse import urlparse
+
 import requests
 
 from requests.exceptions import (
@@ -20,6 +25,16 @@ from tenacity import (
 
 logger = logging.getLogger(__name__)
 
+CIRCUIT_BREAKER_HOST = os.environ.get("USAGE_CIRCUIT_BREAKER_HOST", "usage.apis.scielo.org")
+CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(os.environ.get("USAGE_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3"))
+CIRCUIT_BREAKER_OPEN_SECONDS = int(os.environ.get("USAGE_CIRCUIT_BREAKER_OPEN_SECONDS", "90"))
+
+_breaker_lock = threading.Lock()
+_breaker_state = {
+    "failures": 0,
+    "open_until": 0.0,
+}
+
 
 class RetryableError(Exception):
     """Recoverable error without having to modify the data state on the client
@@ -31,6 +46,42 @@ class NonRetryableError(Exception):
     """Recoverable error without having to modify the data state on the client
     side, e.g. timeouts, errors from network partitioning, etc.
     """
+
+
+class CircuitOpenError(Exception):
+    """Raised when the circuit breaker is open and requests are short-circuited."""
+
+
+def _is_breaker_target(url):
+    try:
+        return urlparse(url).hostname == CIRCUIT_BREAKER_HOST
+    except Exception:
+        return False
+
+
+def _breaker_is_open():
+    with _breaker_lock:
+        return time.time() < _breaker_state["open_until"]
+
+
+def _breaker_mark_success():
+    with _breaker_lock:
+        _breaker_state["failures"] = 0
+        _breaker_state["open_until"] = 0.0
+
+
+def _breaker_mark_failure():
+    with _breaker_lock:
+        _breaker_state["failures"] += 1
+        failures = _breaker_state["failures"]
+        if failures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD:
+            _breaker_state["open_until"] = time.time() + CIRCUIT_BREAKER_OPEN_SECONDS
+            logger.warning(
+                "Circuit breaker opened for host '%s' for %ss after %s failures",
+                CIRCUIT_BREAKER_HOST,
+                CIRCUIT_BREAKER_OPEN_SECONDS,
+                failures,
+            )
 
 
 def clean_params_by_report(params, report_code):
@@ -72,14 +123,24 @@ def fetch_data(url, json=True, params=None, timeout=32, verify=True):
         RetryableError: If a connection or timeout error occurs (for retry).
         NonRetryableError: For schema, URL, or 4xx client errors.
     """
-    logger.info(f"Fetching URL: {url} with params {params}")
+    if _is_breaker_target(url) and _breaker_is_open():
+        logger.warning(
+            "Circuit breaker open for host '%s', short-circuiting request: %s",
+            CIRCUIT_BREAKER_HOST,
+            url,
+        )
+        raise NonRetryableError(CircuitOpenError(url))
 
     try:
         logger.info(f"Fetching URL: {url} with params {params}")
         response = requests.get(url, params=params, timeout=timeout, verify=verify)
         response.raise_for_status()
+        if _is_breaker_target(url):
+            _breaker_mark_success()
 
     except (ConnectionError, Timeout) as exc:
+        if _is_breaker_target(url):
+            _breaker_mark_failure()
         logger.error(f"Erro fetching content: {url}. Retrying... Error: {exc}")
         raise RetryableError(exc) from exc
 
@@ -93,6 +154,8 @@ def fetch_data(url, json=True, params=None, timeout=32, verify=True):
             logger.error(f"Client error (non-retryable): {url}. Status: {status_code}")
             raise NonRetryableError(exc) from exc
         elif 500 <= status_code < 600:
+            if _is_breaker_target(url):
+                _breaker_mark_failure()
             logger.error(f"Server error: {url}. Retrying... Status: {status_code}")
             raise RetryableError(exc) from exc
 

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -4,12 +4,8 @@ import re
 import unicodedata
 import weakref
 
-from datetime import datetime
-
-try:
-    from ConfigParser import SafeConfigParser
-except ImportError:
-    from configparser import ConfigParser as SafeConfigParser
+from datetime import datetime, timezone, timedelta
+from configparser import ConfigParser
 
 REGEX_ISSN = re.compile("^[0-9]{4}-[0-9]{3}[0-9xX]$")
 REGEX_ISSUE = re.compile("^[0-9]{4}-[0-9]{3}[0-9xX][0-2][0-9]{3}[0-9]{4}$")
@@ -35,19 +31,18 @@ def dogpile_controller_key_generator(namespace, fn, *kwargs):
 
 
 def clean_string(text):
+    if text is None:
+        return text
 
-    if isinstance(text, str):
-        try:
-            text = text.decode('utf-8')
-        except:
-            pass
+    if isinstance(text, bytes):
+        text = text.decode("utf-8", errors="ignore")
 
     try:
         nfd_form = unicodedata.normalize('NFD', text.strip().lower())
-    except:
+    except (TypeError, AttributeError):
         return text
 
-    cleaned_str = u''.join(x for x in nfd_form if unicodedata.category(x)[0] == 'L' or x == ' ')
+    cleaned_str = ''.join(x for x in nfd_form if unicodedata.category(x)[0] == 'L' or x == ' ')
 
     return cleaned_str.lower().strip()
 
@@ -61,8 +56,10 @@ def mktime(year=1970, month=1, day=1):
 
 
 def convert_date_to_month_start_unix_ms(date):
-    fmt_date = datetime.strptime(date, '%Y-%m-%d')
-    fmt_date = fmt_date.replace(day = 1)
+    # Usage API chart points are expected at month start in BRT (UTC-03:00),
+    # independent from the container/host local timezone.
+    brt_tz = timezone(timedelta(hours=-3))
+    fmt_date = datetime.strptime(date, '%Y-%m-%d').replace(day=1, tzinfo=brt_tz)
 
     ms_unix_epoch = int(fmt_date.timestamp() * 1000)
 
@@ -93,11 +90,11 @@ class SingletonMixin(object):
 
 class Configuration(SingletonMixin):
     """
-    Acts as a proxy to the ConfigParser module
+    Acts as a proxy to the configparser module
     """
-    def __init__(self, fp, parser_dep=SafeConfigParser):
+    def __init__(self, fp, parser_dep=ConfigParser):
         self.conf = parser_dep()
-        self.conf.readfp(fp)
+        self.conf.read_file(fp)
 
     @classmethod
     def from_env(cls):
@@ -115,8 +112,8 @@ class Configuration(SingletonMixin):
 
         ``filepath`` is a text string.
         """
-        fp = open(filepath, 'rb')
-        return cls(fp)
+        with open(filepath, 'r', encoding='utf-8') as fp:
+            return cls(fp)
 
     def __getattr__(self, attr):
         return getattr(self.conf, attr)

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -13,6 +13,7 @@ from dogpile.cache import make_region
 
 from analytics.control_manager import base_data_manager, check_session
 from analytics import request_utils
+from analytics import monitoring
 from analytics.controller import SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT, SCIELO_SUSHI_API_ERROR_KEY, SCIELO_SUSHI_API_ERROR_VALUE
 
 
@@ -25,6 +26,7 @@ _USAGE_REPORT_TIMEOUT_SECONDS = float(os.environ.get("USAGE_REPORT_TIMEOUT_SECON
 _USAGE_YEARLY_TIMEOUT_SECONDS = float(
     os.environ.get("USAGE_YEARLY_TIMEOUT_SECONDS", str(_USAGE_REPORT_TIMEOUT_SECONDS))
 )
+_USAGE_YEARLY_DEFAULT_MONTHS = int(os.environ.get("USAGE_YEARLY_DEFAULT_MONTHS", "24"))
 _USAGE_TIMEOUT_POOL_SIZE = int(os.environ.get("USAGE_TIMEOUT_POOL_SIZE", "8"))
 _USAGE_MAX_INFLIGHT = int(os.environ.get("USAGE_TIMEOUT_MAX_INFLIGHT", str(_USAGE_TIMEOUT_POOL_SIZE)))
 _PUBLICATION_MAX_INFLIGHT = int(
@@ -56,6 +58,8 @@ def _submit_guarded(executor, inflight_guard, callable_obj, operation_name):
             "Inflight guard reached for %s; returning fallback without backend call",
             operation_name
         )
+        backend = "usage" if operation_name.startswith("usage_") else "publication"
+        monitoring.BACKEND_INFLIGHT_REJECTED_TOTAL.labels(backend=backend, operation=operation_name).inc()
         return None
 
     try:
@@ -75,12 +79,20 @@ def _submit_guarded(executor, inflight_guard, callable_obj, operation_name):
 
 
 def _run_with_timeout(executor, inflight_guard, callable_obj, fallback_data, timeout_seconds, operation_name):
+    backend = "usage" if operation_name.startswith("usage_") else "publication"
     future = _submit_guarded(executor, inflight_guard, callable_obj, operation_name)
     if future is None:
+        monitoring.BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation_name, result="inflight_rejected").inc()
         return fallback_data
 
     try:
-        return future.result(timeout=timeout_seconds)
+        started_at = datetime.datetime.now().timestamp()
+        result = future.result(timeout=timeout_seconds)
+        monitoring.BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation_name, result="success").inc()
+        monitoring.BACKEND_CALL_DURATION_SECONDS.labels(backend=backend, operation=operation_name).observe(
+            datetime.datetime.now().timestamp() - started_at
+        )
+        return result
     except FuturesTimeoutError:
         future.cancel()
         logger.warning(
@@ -88,6 +100,7 @@ def _run_with_timeout(executor, inflight_guard, callable_obj, fallback_data, tim
             operation_name,
             timeout_seconds
         )
+        monitoring.BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation_name, result="timeout").inc()
         return fallback_data
     except Exception as exc:
         logger.warning(
@@ -95,6 +108,7 @@ def _run_with_timeout(executor, inflight_guard, callable_obj, fallback_data, tim
             operation_name,
             exc
         )
+        monitoring.BACKEND_CALLS_TOTAL.labels(backend=backend, operation=operation_name, result="error").inc()
         return fallback_data
 
 
@@ -190,6 +204,29 @@ def _usage_date_range(request):
     return range_start, range_end
 
 
+def _subtract_months(yyyy_mm_dd, months):
+    year, month, _ = [int(x) for x in yyyy_mm_dd.split('-')]
+    total = (year * 12 + (month - 1)) - months
+    new_year = total // 12
+    new_month = (total % 12) + 1
+    return "%04d-%02d-01" % (new_year, new_month)
+
+
+def _usage_yearly_date_range(request):
+    # Preserve explicit user filters from query string.
+    if request.GET.get('range_start') and request.GET.get('range_end'):
+        return request.GET.get('range_start'), request.GET.get('range_end')
+
+    today = datetime.datetime.now().isoformat()[0:10]
+    range_end = request.GET.get('range_end') or request.session.get('range_end') or today
+    range_start = request.GET.get('range_start') or request.session.get('range_start')
+
+    if range_start:
+        return range_start, range_end
+
+    return _subtract_months(range_end, _USAGE_YEARLY_DEFAULT_MONTHS), range_end
+
+
 @view_config(route_name='usage_report_chart', request_method='GET', renderer='jsonp')
 @check_session
 def usage_report_chart(request):
@@ -249,7 +286,7 @@ def usage_report_chart(request):
 def usage_report_yearly_chart(request):
 
     api_version = request.GET.get('api_version', 'v2')
-    range_start, range_end = _usage_date_range(request)
+    range_start, range_end = _usage_yearly_date_range(request)
     report_code = request.GET.get('report_code', 'cr_j1')
     metric_type = request.GET.get('metric_type', 'Total_Item_Requests')
     selected_code, selected_collection_code, selected_document_code = _usage_selected_values(request)

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 _AFFILIATIONS_TIMEOUT_SECONDS = float(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS", "4"))
 _AFFILIATIONS_TIMEOUT_POOL_SIZE = int(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE", "8"))
 _USAGE_REPORT_TIMEOUT_SECONDS = float(os.environ.get("USAGE_REPORT_TIMEOUT_SECONDS", "4"))
+_USAGE_YEARLY_TIMEOUT_SECONDS = float(
+    os.environ.get("USAGE_YEARLY_TIMEOUT_SECONDS", str(_USAGE_REPORT_TIMEOUT_SECONDS))
+)
 _AFFILIATIONS_EXECUTOR = ThreadPoolExecutor(
     max_workers=_AFFILIATIONS_TIMEOUT_POOL_SIZE,
     thread_name_prefix="affiliations-timeout",
@@ -240,7 +243,7 @@ def usage_report_yearly_chart(request):
     data_chart = _run_with_timeout(
         lambda: cache_region.get_or_create(cache_key, _compute_yearly_chart),
         fallback_data={'series': [], 'categories': []},
-        timeout_seconds=_USAGE_REPORT_TIMEOUT_SECONDS,
+        timeout_seconds=_USAGE_YEARLY_TIMEOUT_SECONDS,
         operation_name='usage_report_yearly_chart',
     )
     

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -3,6 +3,8 @@ import urllib.parse
 import json
 import logging
 import os
+import datetime
+import threading
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 from pyramid.view import view_config
@@ -23,10 +25,22 @@ _USAGE_REPORT_TIMEOUT_SECONDS = float(os.environ.get("USAGE_REPORT_TIMEOUT_SECON
 _USAGE_YEARLY_TIMEOUT_SECONDS = float(
     os.environ.get("USAGE_YEARLY_TIMEOUT_SECONDS", str(_USAGE_REPORT_TIMEOUT_SECONDS))
 )
-_AFFILIATIONS_EXECUTOR = ThreadPoolExecutor(
-    max_workers=_AFFILIATIONS_TIMEOUT_POOL_SIZE,
-    thread_name_prefix="affiliations-timeout",
+_USAGE_TIMEOUT_POOL_SIZE = int(os.environ.get("USAGE_TIMEOUT_POOL_SIZE", "8"))
+_USAGE_MAX_INFLIGHT = int(os.environ.get("USAGE_TIMEOUT_MAX_INFLIGHT", str(_USAGE_TIMEOUT_POOL_SIZE)))
+_PUBLICATION_MAX_INFLIGHT = int(
+    os.environ.get("PUBLICATION_AFFILIATIONS_MAX_INFLIGHT", str(_AFFILIATIONS_TIMEOUT_POOL_SIZE))
 )
+
+_USAGE_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_USAGE_TIMEOUT_POOL_SIZE,
+    thread_name_prefix="usage-timeout",
+)
+_PUBLICATION_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_AFFILIATIONS_TIMEOUT_POOL_SIZE,
+    thread_name_prefix="publication-timeout",
+)
+_USAGE_INFLIGHT = threading.BoundedSemaphore(value=_USAGE_MAX_INFLIGHT)
+_PUBLICATION_INFLIGHT = threading.BoundedSemaphore(value=_PUBLICATION_MAX_INFLIGHT)
 
 
 def _usage_cache_key(prefix, payload):
@@ -36,11 +50,39 @@ def _usage_cache_key(prefix, payload):
     )
 
 
-def _run_with_timeout(callable_obj, fallback_data, timeout_seconds, operation_name):
-    future = _AFFILIATIONS_EXECUTOR.submit(callable_obj)
+def _submit_guarded(executor, inflight_guard, callable_obj, operation_name):
+    if not inflight_guard.acquire(blocking=False):
+        logger.warning(
+            "Inflight guard reached for %s; returning fallback without backend call",
+            operation_name
+        )
+        return None
+
+    try:
+        future = executor.submit(callable_obj)
+    except Exception:
+        inflight_guard.release()
+        raise
+
+    def _release_guard(_):
+        try:
+            inflight_guard.release()
+        except ValueError:
+            logger.warning("Inflight guard release imbalance for %s", operation_name)
+
+    future.add_done_callback(_release_guard)
+    return future
+
+
+def _run_with_timeout(executor, inflight_guard, callable_obj, fallback_data, timeout_seconds, operation_name):
+    future = _submit_guarded(executor, inflight_guard, callable_obj, operation_name)
+    if future is None:
+        return fallback_data
+
     try:
         return future.result(timeout=timeout_seconds)
     except FuturesTimeoutError:
+        future.cancel()
         logger.warning(
             "Timeout in %s after %.2fs; returning fallback",
             operation_name,
@@ -133,13 +175,27 @@ def _usage_selected_values(request):
     return selected_code, selected_collection_code, selected_document_code
 
 
+def _usage_date_range(request):
+    today = datetime.datetime.now().isoformat()[0:10]
+    range_start = (
+        request.GET.get('range_start')
+        or request.session.get('range_start')
+        or '1998-01-01'
+    )
+    range_end = (
+        request.GET.get('range_end')
+        or request.session.get('range_end')
+        or today
+    )
+    return range_start, range_end
+
+
 @view_config(route_name='usage_report_chart', request_method='GET', renderer='jsonp')
 @check_session
 def usage_report_chart(request):
 
     api_version = request.GET.get('api_version', 'v2')
-    range_start = request.GET.get('range_start', None)
-    range_end = request.GET.get('range_end', None)
+    range_start, range_end = _usage_date_range(request)
     report_code = request.GET.get('report_code', 'tr_j1')
     granularity = request.GET.get('granularity', 'monthly')
     selected_code, selected_collection_code, selected_document_code = _usage_selected_values(request)
@@ -161,6 +217,8 @@ def usage_report_chart(request):
         fallback_data = {'series': []}
 
     data_chart = _run_with_timeout(
+        _USAGE_EXECUTOR,
+        _USAGE_INFLIGHT,
         lambda: cache_region.get_or_create(
             cache_key,
             lambda: request.stats.usage.get_usage_report(
@@ -191,8 +249,7 @@ def usage_report_chart(request):
 def usage_report_yearly_chart(request):
 
     api_version = request.GET.get('api_version', 'v2')
-    range_start = request.GET.get('range_start', None)
-    range_end = request.GET.get('range_end', None)
+    range_start, range_end = _usage_date_range(request)
     report_code = request.GET.get('report_code', 'cr_j1')
     metric_type = request.GET.get('metric_type', 'Total_Item_Requests')
     selected_code, selected_collection_code, selected_document_code = _usage_selected_values(request)
@@ -241,6 +298,8 @@ def usage_report_yearly_chart(request):
         return request.stats.usage._title_report_to_yearly_chart_data(data_raw, metric_type=metric_type)
 
     data_chart = _run_with_timeout(
+        _USAGE_EXECUTOR,
+        _USAGE_INFLIGHT,
         lambda: cache_region.get_or_create(cache_key, _compute_yearly_chart),
         fallback_data={'series': [], 'categories': []},
         timeout_seconds=_USAGE_YEARLY_TIMEOUT_SECONDS,
@@ -289,6 +348,8 @@ def publication_article_affiliations_map(request):
     cache_key = _usage_cache_key("publication_article_affiliations_map", cache_payload)
 
     chart_data = _run_with_timeout(
+        _PUBLICATION_EXECUTOR,
+        _PUBLICATION_INFLIGHT,
         lambda: cache_region.get_or_create(
             cache_key,
             lambda: request.stats.publication.general(
@@ -326,6 +387,8 @@ def publication_article_affiliations(request):
     cache_key = _usage_cache_key("publication_article_affiliations", cache_payload)
 
     chart_data = _run_with_timeout(
+        _PUBLICATION_EXECUTOR,
+        _PUBLICATION_INFLIGHT,
         lambda: cache_region.get_or_create(
             cache_key,
             lambda: request.stats.publication.general(
@@ -364,6 +427,8 @@ def publication_article_affiliations_publication_year(request):
     cache_key = _usage_cache_key("publication_article_affiliations_publication_year", cache_payload)
 
     chart_data = _run_with_timeout(
+        _PUBLICATION_EXECUTOR,
+        _PUBLICATION_INFLIGHT,
         lambda: cache_region.get_or_create(
             cache_key,
             lambda: request.stats.publication.affiliations_by_publication_year(

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -9,7 +9,7 @@ from pyramid.view import view_config
 
 from dogpile.cache import make_region
 
-from analytics.control_manager import base_data_manager
+from analytics.control_manager import base_data_manager, check_session
 from analytics import request_utils
 from analytics.controller import SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT, SCIELO_SUSHI_API_ERROR_KEY, SCIELO_SUSHI_API_ERROR_VALUE
 
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _AFFILIATIONS_TIMEOUT_SECONDS = float(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS", "4"))
 _AFFILIATIONS_TIMEOUT_POOL_SIZE = int(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE", "8"))
+_USAGE_REPORT_TIMEOUT_SECONDS = float(os.environ.get("USAGE_REPORT_TIMEOUT_SECONDS", "4"))
 _AFFILIATIONS_EXECUTOR = ThreadPoolExecutor(
     max_workers=_AFFILIATIONS_TIMEOUT_POOL_SIZE,
     thread_name_prefix="affiliations-timeout",
@@ -107,20 +108,38 @@ def bibliometrics_journal_google_h5m5_chart(request):
     return request.chartsconfig.bibliometrics_google_h5m5(data)
 
 
-@view_config(route_name='usage_report_chart', request_method='GET', renderer='jsonp')
-@base_data_manager
-def usage_report_chart(request):
+def _usage_selected_values(request):
+    selected_collection_code = (
+        request.GET.get('collection')
+        or request.session.get('collection')
+        or 'scl'
+    )
+    selected_document_code = (
+        request.GET.get('pid')
+        or request.GET.get('article')
+        or request.session.get('document')
+        or None
+    )
+    selected_code = (
+        request.GET.get('issn')
+        or request.GET.get('code')
+        or request.GET.get('journal')
+        or request.session.get('journal')
+        or selected_collection_code
+    )
+    return selected_code, selected_collection_code, selected_document_code
 
-    data = request.data_manager
+
+@view_config(route_name='usage_report_chart', request_method='GET', renderer='jsonp')
+@check_session
+def usage_report_chart(request):
 
     api_version = request.GET.get('api_version', 'v2')
     range_start = request.GET.get('range_start', None)
     range_end = request.GET.get('range_end', None)
     report_code = request.GET.get('report_code', 'tr_j1')
     granularity = request.GET.get('granularity', 'monthly')
-    selected_code = data['selected_code']
-    selected_collection_code = data['selected_collection_code']
-    selected_document_code = data['selected_document_code']
+    selected_code, selected_collection_code, selected_document_code = _usage_selected_values(request)
 
     cache_payload = {
         'pid': selected_document_code,
@@ -134,18 +153,28 @@ def usage_report_chart(request):
     }
     cache_key = _usage_cache_key("usage_report_chart", cache_payload)
 
-    data_chart = cache_region.get_or_create(
-        cache_key,
-        lambda: request.stats.usage.get_usage_report(
-            pid=selected_document_code,
-            issn=selected_code,
-            collection=selected_collection_code,
-            begin_date=range_start,
-            end_date=range_end,
-            report_code=report_code,
-            api_version=api_version,
-            granularity=granularity,
+    fallback_data = []
+    if report_code != 'gr_j1':
+        fallback_data = {'series': []}
+
+    data_chart = _run_with_timeout(
+        lambda: cache_region.get_or_create(
+            cache_key,
+            lambda: request.stats.usage.get_usage_report(
+                pid=selected_document_code,
+                issn=selected_code,
+                collection=selected_collection_code,
+                begin_date=range_start,
+                end_date=range_end,
+                report_code=report_code,
+                api_version=api_version,
+                granularity=granularity,
+            )
         )
+        ,
+        fallback_data=fallback_data,
+        timeout_seconds=_USAGE_REPORT_TIMEOUT_SECONDS,
+        operation_name='usage_report_chart',
     )
 
     if report_code == 'gr_j1':
@@ -155,19 +184,15 @@ def usage_report_chart(request):
 
 
 @view_config(route_name='usage_report_yearly_chart', request_method='GET', renderer='jsonp')
-@base_data_manager
+@check_session
 def usage_report_yearly_chart(request):
-    
-    data = request.data_manager
-    
+
     api_version = request.GET.get('api_version', 'v2')
     range_start = request.GET.get('range_start', None)
     range_end = request.GET.get('range_end', None)
     report_code = request.GET.get('report_code', 'cr_j1')
     metric_type = request.GET.get('metric_type', 'Total_Item_Requests')
-    selected_code = data['selected_code']
-    selected_collection_code = data['selected_collection_code']
-    selected_document_code = data['selected_document_code']
+    selected_code, selected_collection_code, selected_document_code = _usage_selected_values(request)
     
     cache_payload = {
         'pid': selected_document_code,
@@ -212,7 +237,12 @@ def usage_report_yearly_chart(request):
 
         return request.stats.usage._title_report_to_yearly_chart_data(data_raw, metric_type=metric_type)
 
-    data_chart = cache_region.get_or_create(cache_key, _compute_yearly_chart)
+    data_chart = _run_with_timeout(
+        lambda: cache_region.get_or_create(cache_key, _compute_yearly_chart),
+        fallback_data={'series': [], 'categories': []},
+        timeout_seconds=_USAGE_REPORT_TIMEOUT_SECONDS,
+        operation_name='usage_report_yearly_chart',
+    )
     
     return request.chartsconfig.usage_report_yearly(data_chart, metric_type)
 

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 import urllib.parse
 import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 from pyramid.view import view_config
 
@@ -12,6 +15,14 @@ from analytics.controller import SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT, SCIELO_SUS
 
 
 cache_region = make_region(name='views_ajax_cache')
+logger = logging.getLogger(__name__)
+
+_AFFILIATIONS_TIMEOUT_SECONDS = float(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_SECONDS", "4"))
+_AFFILIATIONS_TIMEOUT_POOL_SIZE = int(os.environ.get("PUBLICATION_AFFILIATIONS_TIMEOUT_POOL_SIZE", "8"))
+_AFFILIATIONS_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_AFFILIATIONS_TIMEOUT_POOL_SIZE,
+    thread_name_prefix="affiliations-timeout",
+)
 
 
 def _usage_cache_key(prefix, payload):
@@ -19,6 +30,26 @@ def _usage_cache_key(prefix, payload):
         prefix,
         json.dumps(payload, sort_keys=True, separators=(",", ":"))
     )
+
+
+def _run_with_timeout(callable_obj, fallback_data, timeout_seconds, operation_name):
+    future = _AFFILIATIONS_EXECUTOR.submit(callable_obj)
+    try:
+        return future.result(timeout=timeout_seconds)
+    except FuturesTimeoutError:
+        logger.warning(
+            "Timeout in %s after %.2fs; returning fallback",
+            operation_name,
+            timeout_seconds
+        )
+        return fallback_data
+    except Exception as exc:
+        logger.warning(
+            "Error in %s: %s; returning fallback",
+            operation_name,
+            exc
+        )
+        return fallback_data
 
 
 # @view_config(route_name='bibliometrics_journal_jcr_eigen_factor_chart', request_method='GET', renderer='jsonp')
@@ -224,17 +255,22 @@ def publication_article_affiliations_map(request):
     }
     cache_key = _usage_cache_key("publication_article_affiliations_map", cache_payload)
 
-    chart_data = cache_region.get_or_create(
-        cache_key,
-        lambda: request.stats.publication.general(
-            'article',
-            'aff_countries',
-            data['selected_code'],
-            data['selected_collection_code'],
-            py_range=data['py_range'],
-            sa_scope=data['sa_scope'],
-            la_scope=data['la_scope'],
-        )
+    chart_data = _run_with_timeout(
+        lambda: cache_region.get_or_create(
+            cache_key,
+            lambda: request.stats.publication.general(
+                'article',
+                'aff_countries',
+                data['selected_code'],
+                data['selected_collection_code'],
+                py_range=data['py_range'],
+                sa_scope=data['sa_scope'],
+                la_scope=data['la_scope'],
+            )
+        ),
+        fallback_data={'series': [{'name': 'documents', 'data': []}], 'categories': []},
+        timeout_seconds=_AFFILIATIONS_TIMEOUT_SECONDS,
+        operation_name='publication_article_affiliations_map',
     )
 
     return request.chartsconfig.publication_article_affiliations_map(chart_data)
@@ -256,18 +292,24 @@ def publication_article_affiliations(request):
     }
     cache_key = _usage_cache_key("publication_article_affiliations", cache_payload)
 
-    chart_data = cache_region.get_or_create(
-        cache_key,
-        lambda: request.stats.publication.general(
-            'article',
-            'aff_countries',
-            data['selected_code'],
-            data['selected_collection_code'],
-            py_range=data['py_range'],
-            sa_scope=data['sa_scope'],
-            la_scope=data['la_scope'],
-            size=20,
+    chart_data = _run_with_timeout(
+        lambda: cache_region.get_or_create(
+            cache_key,
+            lambda: request.stats.publication.general(
+                'article',
+                'aff_countries',
+                data['selected_code'],
+                data['selected_collection_code'],
+                py_range=data['py_range'],
+                sa_scope=data['sa_scope'],
+                la_scope=data['la_scope'],
+                size=20,
+            )
         )
+        ,
+        fallback_data={'series': [{'name': 'documents', 'data': []}], 'categories': []},
+        timeout_seconds=_AFFILIATIONS_TIMEOUT_SECONDS,
+        operation_name='publication_article_affiliations',
     )
 
     return request.chartsconfig.publication_article_affiliations(chart_data)
@@ -288,15 +330,21 @@ def publication_article_affiliations_publication_year(request):
     }
     cache_key = _usage_cache_key("publication_article_affiliations_publication_year", cache_payload)
 
-    chart_data = cache_region.get_or_create(
-        cache_key,
-        lambda: request.stats.publication.affiliations_by_publication_year(
-            data['selected_code'],
-            data['selected_collection_code'],
-            data['py_range'],
-            data['sa_scope'],
-            data['la_scope']
+    chart_data = _run_with_timeout(
+        lambda: cache_region.get_or_create(
+            cache_key,
+            lambda: request.stats.publication.affiliations_by_publication_year(
+                data['selected_code'],
+                data['selected_collection_code'],
+                data['py_range'],
+                data['sa_scope'],
+                data['la_scope']
+            )
         )
+        ,
+        fallback_data={'series': [], 'navigator_series': []},
+        timeout_seconds=_AFFILIATIONS_TIMEOUT_SECONDS,
+        operation_name='publication_article_affiliations_publication_year',
     )
 
     return request.chartsconfig.publication_article_affiliations_by_publication_year(chart_data)

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -215,7 +215,27 @@ def publication_article_affiliations_map(request):
 
     data = request.data_manager
 
-    chart_data = request.stats.publication.general('article', 'aff_countries', data['selected_code'], data['selected_collection_code'], py_range=data['py_range'], sa_scope=data['sa_scope'], la_scope=data['la_scope'])
+    cache_payload = {
+        'selected_code': data['selected_code'],
+        'selected_collection_code': data['selected_collection_code'],
+        'py_range': data['py_range'],
+        'sa_scope': data['sa_scope'],
+        'la_scope': data['la_scope'],
+    }
+    cache_key = _usage_cache_key("publication_article_affiliations_map", cache_payload)
+
+    chart_data = cache_region.get_or_create(
+        cache_key,
+        lambda: request.stats.publication.general(
+            'article',
+            'aff_countries',
+            data['selected_code'],
+            data['selected_collection_code'],
+            py_range=data['py_range'],
+            sa_scope=data['sa_scope'],
+            la_scope=data['la_scope'],
+        )
+    )
 
     return request.chartsconfig.publication_article_affiliations_map(chart_data)
 
@@ -226,7 +246,29 @@ def publication_article_affiliations(request):
 
     data = request.data_manager
 
-    chart_data = request.stats.publication.general('article', 'aff_countries', data['selected_code'], data['selected_collection_code'], py_range=data['py_range'], sa_scope=data['sa_scope'], la_scope=data['la_scope'], size=20)
+    cache_payload = {
+        'selected_code': data['selected_code'],
+        'selected_collection_code': data['selected_collection_code'],
+        'py_range': data['py_range'],
+        'sa_scope': data['sa_scope'],
+        'la_scope': data['la_scope'],
+        'size': 20,
+    }
+    cache_key = _usage_cache_key("publication_article_affiliations", cache_payload)
+
+    chart_data = cache_region.get_or_create(
+        cache_key,
+        lambda: request.stats.publication.general(
+            'article',
+            'aff_countries',
+            data['selected_code'],
+            data['selected_collection_code'],
+            py_range=data['py_range'],
+            sa_scope=data['sa_scope'],
+            la_scope=data['la_scope'],
+            size=20,
+        )
+    )
 
     return request.chartsconfig.publication_article_affiliations(chart_data)
 
@@ -237,7 +279,25 @@ def publication_article_affiliations_publication_year(request):
 
     data = request.data_manager
 
-    chart_data = request.stats.publication.affiliations_by_publication_year(data['selected_code'], data['selected_collection_code'], data['py_range'], data['sa_scope'], data['la_scope'])
+    cache_payload = {
+        'selected_code': data['selected_code'],
+        'selected_collection_code': data['selected_collection_code'],
+        'py_range': data['py_range'],
+        'sa_scope': data['sa_scope'],
+        'la_scope': data['la_scope'],
+    }
+    cache_key = _usage_cache_key("publication_article_affiliations_publication_year", cache_payload)
+
+    chart_data = cache_region.get_or_create(
+        cache_key,
+        lambda: request.stats.publication.affiliations_by_publication_year(
+            data['selected_code'],
+            data['selected_collection_code'],
+            data['py_range'],
+            data['sa_scope'],
+            data['la_scope']
+        )
+    )
 
     return request.chartsconfig.publication_article_affiliations_by_publication_year(chart_data)
 

--- a/analytics/views_ajax.py
+++ b/analytics/views_ajax.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import urllib.parse
+import json
 
 from pyramid.view import view_config
 
@@ -11,6 +12,13 @@ from analytics.controller import SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT, SCIELO_SUS
 
 
 cache_region = make_region(name='views_ajax_cache')
+
+
+def _usage_cache_key(prefix, payload):
+    return "%s:%s" % (
+        prefix,
+        json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    )
 
 
 # @view_config(route_name='bibliometrics_journal_jcr_eigen_factor_chart', request_method='GET', renderer='jsonp')
@@ -83,15 +91,30 @@ def usage_report_chart(request):
     selected_collection_code = data['selected_collection_code']
     selected_document_code = data['selected_document_code']
 
-    data_chart = request.stats.usage.get_usage_report(
-        pid = selected_document_code,
-        issn = selected_code,
-        collection = selected_collection_code,
-        begin_date = range_start,
-        end_date = range_end,
-        report_code = report_code,
-        api_version = api_version,
-        granularity = granularity,
+    cache_payload = {
+        'pid': selected_document_code,
+        'issn': selected_code,
+        'collection': selected_collection_code,
+        'begin_date': range_start,
+        'end_date': range_end,
+        'report_code': report_code,
+        'api_version': api_version,
+        'granularity': granularity,
+    }
+    cache_key = _usage_cache_key("usage_report_chart", cache_payload)
+
+    data_chart = cache_region.get_or_create(
+        cache_key,
+        lambda: request.stats.usage.get_usage_report(
+            pid=selected_document_code,
+            issn=selected_code,
+            collection=selected_collection_code,
+            begin_date=range_start,
+            end_date=range_end,
+            report_code=report_code,
+            api_version=api_version,
+            granularity=granularity,
+        )
     )
 
     if report_code == 'gr_j1':
@@ -115,39 +138,50 @@ def usage_report_yearly_chart(request):
     selected_collection_code = data['selected_collection_code']
     selected_document_code = data['selected_document_code']
     
-    # Fetch RAW data directly from API (not processed)
-    url_report = urllib.parse.urljoin(request.stats.usage.base_url, 'reports/%s' % report_code)
-    
-    params = {
+    cache_payload = {
         'pid': selected_document_code,
         'issn': selected_code,
         'collection': selected_collection_code,
         'begin_date': range_start,
         'end_date': range_end,
+        'report_code': report_code,
+        'api_version': api_version,
+        'metric_type': metric_type,
         'granularity': 'monthly',
-        'api': api_version,
     }
-    
-    request_utils.clean_params_by_report(params, report_code)
-    
-    try:
-        data_raw = request_utils.fetch_data(
-            url_report,
-            params=params,
-            timeout=SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT,
-        )
-    except (request_utils.RetryableError, request_utils.NonRetryableError):
-        # If API request fails, return empty chart
-        return request.chartsconfig.usage_report_yearly({'series': [], 'categories': []}, metric_type)
-    
-    # Check for API error response
-    severity = data_raw.get(SCIELO_SUSHI_API_ERROR_KEY, '')
-    if isinstance(severity, str) and severity.lower() == SCIELO_SUSHI_API_ERROR_VALUE.lower():
-        # Return empty chart in case of error
-        return request.chartsconfig.usage_report_yearly({'series': [], 'categories': []}, metric_type)
-    
-    # Process into yearly chart data
-    data_chart = request.stats.usage._title_report_to_yearly_chart_data(data_raw, metric_type=metric_type)
+    cache_key = _usage_cache_key("usage_report_yearly_chart", cache_payload)
+
+    def _compute_yearly_chart():
+        url_report = urllib.parse.urljoin(request.stats.usage.base_url, 'reports/%s' % report_code)
+
+        params = {
+            'pid': selected_document_code,
+            'issn': selected_code,
+            'collection': selected_collection_code,
+            'begin_date': range_start,
+            'end_date': range_end,
+            'granularity': 'monthly',
+            'api': api_version,
+        }
+
+        request_utils.clean_params_by_report(params, report_code)
+
+        try:
+            data_raw = request_utils.fetch_data(
+                url_report,
+                params=params,
+                timeout=SCIELO_SUSHI_API_FETCH_DATA_TIMEOUT,
+            )
+        except (request_utils.RetryableError, request_utils.NonRetryableError):
+            return {'series': [], 'categories': []}
+
+        severity = data_raw.get(SCIELO_SUSHI_API_ERROR_KEY, '')
+        if isinstance(severity, str) and severity.lower() == SCIELO_SUSHI_API_ERROR_VALUE.lower():
+            return {'series': [], 'categories': []}
+
+        return request.stats.usage._title_report_to_yearly_chart_data(data_raw, metric_type=metric_type)
+
+    data_chart = cache_region.get_or_create(cache_key, _compute_yearly_chart)
     
     return request.chartsconfig.usage_report_yearly(data_chart, metric_type)
 

--- a/analytics/views_website.py
+++ b/analytics/views_website.py
@@ -4,10 +4,10 @@ from datetime import datetime, timedelta
 
 from pyramid.view import view_config
 from dogpile.cache import make_region
-from citedby.custom_query import journal_titles
 # from scielojcr import jcrindicators
 
 from analytics.control_manager import base_data_manager
+from analytics.custom_query import journal_titles
 
 cache_region = make_region(name='views_website_cache')
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,21 +1,11 @@
-version: '3.9'
-
 services:
-  memcached:
-    image: memcached:latest
-    restart: always
-    ports:
-      - "11211:11211"
-
   webapp:
     build:
       context: .
       dockerfile: Dockerfile-dev
     user: nobody
     restart: always
-    depends_on:
-      - memcached
     ports:
-      - "8000:8000"
+      - "8010:8000"
     environment:
-      MEMCACHED_HOST: memcached:11211
+      MEMCACHED_HOST: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,11 @@
-version: '3.9'
-
 services:
-  memcached:
-    image: memcached:latest
-    restart: always
-    ports:
-      - "11211:11211"
-
   webapp:
     build:
       context: .
       dockerfile: Dockerfile-dev
     user: nobody
     restart: always
-    depends_on:
-      - memcached
     ports:
-      - "8000:8000"
+      - "8010:8000"
     environment:
-      MEMCACHED_HOST: memcached:11211
+      MEMCACHED_HOST: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,6 @@ services:
       - "8010:8000"
     environment:
       MEMCACHED_HOST: ""
+      USAGE_API_BASE_URL: "http://host.docker.internal:6543/"
+      USAGE_REPORT_TIMEOUT_SECONDS: "20"
+      USAGE_YEARLY_TIMEOUT_SECONDS: "120"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,17 @@
--e git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap
-requests==2.19.1
-cython==0.22
-thriftpy==0.3.1
-pyramid==1.5.7
-pyramid_chameleon==0.3
-pyramid_mako==1.0
-pyramid-debugtoolbar==4.9
-waitress==0.8.10
-dogpile.cache==0.5.6
-pylibmc==1.5.0
-Babel==2.0
--e git+https://github.com/scieloorg/scieloh5m5@1.9.6#egg=scieloh5m5
-xylose==1.35.4
-citedbyapi==1.5.1
-accessstatsapi==1.2.0
-publicationstatsapi==1.2.0
-articlemetaapi==1.14.19
-altmetric==1.0.0
-tenacity==8.2.2
+requests
+cython
+thriftpy2
+pyramid
+pyramid_chameleon
+pyramid_mako
+pyramid-debugtoolbar
+waitress
+dogpile.cache
+pylibmc
+Babel
+scieloh5m5==1.11.0
+xylose
+publicationstatsapi
+articlemetaapi
+altmetric
+tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ publicationstatsapi
 articlemetaapi
 altmetric
 tenacity
+prometheus_client

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[nosetests]
-match = ^test
-nocapture = 1
-
 [compile_catalog]
 directory = analytics/locale
 domain = analytics

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 
 from setuptools import setup
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 install_requires = [
     'requests',
     'cython',
-    'thriftpy',
+    'thriftpy2',
     'pyramid',
     'pyramid_chameleon',
     'pyramid_mako',
@@ -24,14 +24,10 @@ install_requires = [
     'scieloh5m5',
     'xylose',
     'articlemetaapi',
-    'accessstatsapi',
     'publicationstatsapi',
-    'citedbyapi',
     'scielojcr',
     'altmetric'
     ]
-
-test_requires = ["nose>=1.0", "coverage"]
 
 setup(
     name="analytics",
@@ -48,14 +44,13 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: POSIX :: Linux",
         "Topic :: System",
         "Topic :: Services",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
-    ],
-    dependency_links=[
-        "git+https://github.com/scieloorg/thriftpy-wrap@0.1.1#egg=thriftpywrap"
     ],
     message_extractors={
         'analytics': [
@@ -67,9 +62,9 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    tests_require=test_requires,
+    python_requires=">=3.13,<4",
+    extras_require={"test": ["coverage"]},
     install_requires=install_requires,
-    test_suite="nose.collector",
     entry_points="""\
     [paste.app_factory]
     main = analytics:main

--- a/src/thriftpywrap/.gitignore
+++ b/src/thriftpywrap/.gitignore
@@ -1,0 +1,39 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Vim
+*.swp

--- a/src/thriftpywrap/README.rst
+++ b/src/thriftpywrap/README.rst
@@ -1,0 +1,35 @@
+thriftpy-wrap
+=============
+
+A thin wrap around thriftpy2 to help you create console based server applications.
+It also extends thriftpy2 in order to make possible to run the server against
+already opened sockets.
+
+
+.. code-block:: python
+
+    import thriftpy2
+    import thriftpywrap
+
+    spec = thriftpy2.load('dsl.thrift')
+
+
+    class Handler(object)
+        """ Remote procedures """
+    
+    if __name__ == '__main__':
+        app = thriftpywrap.ConsoleApp(spec.Service, Handler)
+        app()
+
+
+Executing this script will result is something like:
+
+.. code-block:: bash
+
+    $ python ping_server.py
+    usage: ping_server.py [-h] [--port PORT]
+                      [--address-family {AF_APPLETALK,AF_DECnet,AF_INET,AF_INET6,AF_IPX,AF_ROUTE,AF_SNA,AF_UNIX,AF_UNSPEC}]
+                      (--host HOST | --unix-socket UNIX_SOCKET | --fd FD)
+                      [--loglevel LOGLEVEL]
+                      [arguments [arguments ...]]
+    ping_server.py: error: one of the arguments --host --unix-socket --fd is required

--- a/src/thriftpywrap/setup.cfg
+++ b/src/thriftpywrap/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/src/thriftpywrap/setup.py
+++ b/src/thriftpywrap/setup.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#coding:utf-8
+from setuptools import setup, find_packages
+import codecs
+
+
+install_requires = [
+    'thriftpy2>=0.4',
+]
+
+
+setup(
+    name="thriftpywrap",
+    version='0.1.1',
+    description="Lib to help you build console based thrift servers.",
+    long_description=codecs.open('README.rst', mode='r', encoding='utf-8').read(),
+    author="SciELO",
+    author_email="scielo-dev@googlegroups.com",
+    maintainer="Gustavo Fonseca",
+    maintainer_email="gustavo.fonseca@scielo.org",
+    license="BSD License",
+    url="http://docs.scielo.org",
+    packages=find_packages(),
+    include_package_data=True,
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.13",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    python_requires=">=3.13,<4",
+    test_suite='tests',
+    install_requires=install_requires,
+)

--- a/src/thriftpywrap/tests/spec.thrift
+++ b/src/thriftpywrap/tests/spec.thrift
@@ -1,0 +1,3 @@
+service Service {
+    void ping();
+}

--- a/src/thriftpywrap/tests/test_thriftpywrapp.py
+++ b/src/thriftpywrap/tests/test_thriftpywrapp.py
@@ -1,0 +1,75 @@
+import unittest
+import socket
+import tempfile
+import os
+
+import thriftpy2
+from thriftpywrap import (get_description, make_server, )
+
+spec = thriftpy2.load(os.path.join(os.path.dirname(__file__), "spec.thrift"))
+
+
+class Dispatcher(object):
+    def ping(self):
+        return True
+
+
+class GetDescriptionTests(unittest.TestCase):
+    def test_from_class(self):
+        class Foo(object):
+            __description__ = """Foobar"""
+
+        self.assertEqual(get_description(Foo), 'Foobar')
+
+    def test_from_instance(self):
+        class Foo(object):
+            __description__ = """Foobar"""
+
+        self.assertEqual(get_description(Foo()), 'Foobar')
+
+    def test_missing(self):
+        class Foo(object):
+            pass
+
+        self.assertEqual(get_description(Foo(), default='Foo'), 'Foo')
+
+    def test_from_class_missing(self):
+        class Foo(object):
+            pass
+
+        self.assertEqual(get_description(Foo, default='Foo'), 'Foo')
+
+
+class MakeServerTests(unittest.TestCase):
+    def test_unix_domain_socket(self):
+        """Does not create/bind/listen the socket
+        """
+        from thriftpy2.server import TThreadedServer
+        temp_dir = tempfile.mkdtemp()
+        sock_path = os.path.join(temp_dir, 'test_sock.sock')
+
+        server = make_server(spec, Dispatcher(), unix_socket=sock_path)
+        self.assertIsInstance(server, TThreadedServer)
+
+    def test_host_port(self):
+        """Does not create/bind/listen the socket
+        """
+        from thriftpy2.server import TThreadedServer
+        server = make_server(spec, Dispatcher(), host='0.0.0.0', port=0)
+        self.assertIsInstance(server, TThreadedServer)
+
+    def test_fd(self):
+        from thriftpy2.server import TThreadedServer
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(('0.0.0.0', 0))
+
+            server = make_server(spec, Dispatcher(), fd=sock.fileno())
+            self.assertIsInstance(server, TThreadedServer)
+
+            server.trans.listen()
+            self.assertEqual(server.trans.handle.getsockname(),
+                             sock.getsockname())
+        finally:
+            server.trans.close()
+            sock.close()

--- a/src/thriftpywrap/thriftpywrap/__init__.py
+++ b/src/thriftpywrap/thriftpywrap/__init__.py
@@ -1,0 +1,140 @@
+#coding: utf-8
+from __future__ import absolute_import
+
+import logging
+import argparse
+import socket
+import sys
+
+from thriftpy2.protocol import TBinaryProtocolFactory
+from thriftpy2.server import TThreadedServer
+from thriftpy2.thrift import TProcessor
+from thriftpy2.transport import (TBufferedTransportFactory, TServerSocket, )
+
+__all__ = ['ConsoleApp']
+
+_ADDRESS_FAMILY = [af for af in dir(socket) if af.startswith('AF_')]
+_DEFAULT_DESCRIPTION = 'Thrift-based RPC server.'
+_PROTO_FACTORY = TBinaryProtocolFactory
+_TRANS_FACTORY = TBufferedTransportFactory
+
+logger = logging.getLogger(__name__)
+
+
+def get_description(handler, default=None):
+    default_description = default or _DEFAULT_DESCRIPTION
+    return handler.__description__ if hasattr(
+        handler, '__description__') else default_description
+
+
+def ConsoleApp(spec, handler,
+               proto_factory=_PROTO_FACTORY(),
+               trans_factory=_TRANS_FACTORY()):
+    def app():
+        parser = argparse.ArgumentParser(description=get_description(handler))
+        parser.add_argument('--port', type=int, default=8080)
+        parser.add_argument('--address-family',
+                            type=str,
+                            default='AF_INET',
+                            choices=sorted(_ADDRESS_FAMILY))
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--host')
+        group.add_argument('--unix-socket')
+        group.add_argument('--fd', type=int)
+        parser.add_argument(
+            'arguments',
+            default=[],
+            nargs='*',
+            help="Optional arguments you may need for your app")
+
+        parser.add_argument('--loglevel', default='info', help="log level")
+        args = parser.parse_args()
+
+        logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+
+        address_family = getattr(socket, args.address_family)
+
+        logger.debug('Protocol factory: %s', proto_factory)
+        logger.debug('Transport factory: %s', trans_factory)
+
+        server = make_server(spec, handler(*args.arguments),
+                             fd=args.fd,
+                             host=args.host,
+                             port=args.port,
+                             unix_socket=args.unix_socket,
+                             address_family=address_family,
+                             proto_factory=proto_factory,
+                             trans_factory=trans_factory)
+        try:
+            server.serve()
+        except KeyboardInterrupt:
+            sys.exit(1)
+        finally:
+            server.trans.close()
+            logger.debug('Closing transport %s', server.trans)
+
+    return app
+
+
+def make_server(service, handler,
+                fd=None,
+                host=None,
+                port=None,
+                unix_socket=None,
+                address_family=socket.AF_INET,
+                proto_factory=None,
+                trans_factory=None):
+    processor = TProcessor(service, handler)
+    if unix_socket is not None:
+        logger.info('Setting up server bound to %s', unix_socket)
+        server_socket = TServerSocket(unix_socket=unix_socket,
+                                      socket_family=address_family)
+    elif fd is not None:
+        logger.info('Setting up server bound to socket fd %s', fd)
+        server_socket = TFDServerSocket(fd=fd, socket_family=address_family)
+    elif host is not None and port is not None:
+        logger.info('Setting up server bound to %s:%s', host, str(port))
+        server_socket = TServerSocket(host=host,
+                                      port=port,
+                                      socket_family=address_family)
+    else:
+        raise ValueError('Insufficient params')
+
+    server = TThreadedServer(processor, server_socket,
+                             iprot_factory=proto_factory,
+                             itrans_factory=trans_factory)
+    return server
+
+
+class TFDServerSocket(TServerSocket):
+    def __init__(self, fd=None, **kwargs):
+        self._fd = fd
+        super(TFDServerSocket, self).__init__(**kwargs)
+
+    def _init_sock(self):
+        if self._fd is None:
+            super(TFDServerSocket, self)._init_sock()
+            self.handle = self.sock
+            return
+
+        self.sock = socket.fromfd(self._fd, self.socket_family, socket.SOCK_STREAM)
+        self.handle = self.sock
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if hasattr(socket, "SO_REUSEPORT"):
+            try:
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            except OSError:
+                pass
+        self.sock.settimeout(None)
+
+    def listen(self):
+        if self._fd is None:
+            super(TFDServerSocket, self).listen()
+            logger.debug('Started listening socket %s', repr(self.sock))
+            logger.info('Started listening %s', self.sock.getsockname())
+            return
+
+        self._init_sock()
+        self.sock.listen(self.backlog)
+        logger.debug('Started listening socket %s', repr(self.sock))
+        logger.info('Started listening %s', self.sock.getsockname())

--- a/src/thriftpywrap/tox.ini
+++ b/src/thriftpywrap/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,py33,py34
+
+[testenv]
+commands=python setup.py test -q
+

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,10 @@
+import unittest
+
+from analytics import monitoring
+
+
+class MonitoringTest(unittest.TestCase):
+    def test_metrics_response_contains_http_metric(self):
+        body, content_type = monitoring.metrics_response()
+        self.assertTrue(content_type.startswith("text/plain; version="))
+        self.assertIn(b"analytics_http_requests_total", body)


### PR DESCRIPTION
Perfeito. Segue a versão com links apontando para `scieloorg/analytics` na branch `qa`.

#### O que esse PR faz?
Este PR adiciona observabilidade com Prometheus na aplicação `analytics`, cobrindo métricas HTTP e de integrações/backend sem alterar regra de negócio.

Principais entregas:
- Exposição de métricas em `GET /metrics`.
- Instrumentação de requisições HTTP (contagem, latência, em progresso).
- Instrumentação de chamadas de backend (sucesso, erro, timeout, rejeição por inflight).
- Métrica de estado do circuit breaker.
- Métrica indicando backend de cache ativo (`pylibmc` ou `memory`).
- Inclusão da dependência `prometheus_client`.
- Teste unitário básico para o endpoint de métricas.
- Atualização do README com instruções e métricas disponíveis.

---

#### Onde a revisão poderia começar?
Comece por:
- [analytics/monitoring.py](https://github.com/scieloorg/analytics/blob/qa/analytics/monitoring.py)

Depois siga nesta ordem:
- [analytics/__init__.py](https://github.com/scieloorg/analytics/blob/qa/analytics/__init__.py)
- [analytics/request_utils.py](https://github.com/scieloorg/analytics/blob/qa/analytics/request_utils.py)
- [analytics/views_ajax.py](https://github.com/scieloorg/analytics/blob/qa/analytics/views_ajax.py)
- [tests/test_monitoring.py](https://github.com/scieloorg/analytics/blob/qa/tests/test_monitoring.py)
- [README.md](https://github.com/scieloorg/analytics/blob/qa/README.md)

---

#### Como este poderia ser testado manualmente?
1. Subir a aplicação:
```bash
docker compose up -d --build webapp
```

2. Validar que o container está `Up`:
```bash
docker compose ps
```

3. Consultar métricas de dentro do container:
```bash
docker compose exec -T webapp sh -lc "python - <<'PY'
import urllib.request
print(urllib.request.urlopen('http://127.0.0.1:8000/metrics', timeout=5).read(2000).decode())
PY"
```

4. Confirmar presença de métricas `analytics_*`, por exemplo:
- `analytics_http_requests_total`
- `analytics_backend_calls_total`
- `analytics_circuit_breaker_state`

5. Rodar teste unitário adicionado:
```bash
docker compose exec -T webapp sh -lc "cd /app && python -m unittest discover -s tests -p 'test_monitoring.py' -v"
```

---

#### Algum cenário de contexto que queira dar?
Esse PR é necessário para dar visibilidade operacional após as mudanças de resiliência já aplicadas (cache, timeout/fallback, inflight guard e circuit breaker).  
Sem essas métricas, fica difícil comprovar em produção/hml:
- quando há saturação de fila/inflight,
- quando há timeout recorrente por backend,
- quando o circuit breaker abre,
- e o impacto real das otimizações de primeira carga.

---

### Screenshots
Não aplicável neste PR (mudança backend/observabilidade, sem alteração visual de UI).

---

#### Quais são tickets relevantes?
Não foi informado ticket/issue no contexto atual.  
Sugestão: vincular ao ticket de observabilidade/performance da home (ex.: “monitoramento Prometheus do analytics”).

---

### Referências
- Prometheus Python Client: [github.com/prometheus/client_python](https://github.com/prometheus/client_python)
- Prometheus exposition format: [prometheus.io/docs/instrumenting/exposition_formats](https://prometheus.io/docs/instrumenting/exposition_formats/)
- Código da branch `qa`:
  - [analytics/monitoring.py](https://github.com/scieloorg/analytics/blob/qa/analytics/monitoring.py)
  - [analytics/__init__.py](https://github.com/scieloorg/analytics/blob/qa/analytics/__init__.py)
  - [analytics/request_utils.py](https://github.com/scieloorg/analytics/blob/qa/analytics/request_utils.py)
  - [analytics/views_ajax.py](https://github.com/scieloorg/analytics/blob/qa/analytics/views_ajax.py)